### PR TITLE
Kernel32: GetModuleFileName: Give a hint on warning (hcurmodule)

### DIFF
--- a/miasm2/os_dep/win_api_x86_32.py
+++ b/miasm2/os_dep/win_api_x86_32.py
@@ -805,7 +805,8 @@ def kernel32_GetModuleFileName(jitter, funcname, set_str):
                         for x in winobjs.runtime_dll.name2off.items()])
         p = name_inv[hmodule]
     else:
-        log.warning('unknown module %x' % hmodule)
+        log.warning('Unknown module 0x%x.' + \
+                        'Set winobjs.hcurmodule and retry' % hmodule)
         p = None
 
     if p is None:


### PR DESCRIPTION
By default, `winobjs.hcurmodule` is not set. That way, kernel32_GetModuleFileName will warn the user
