### PR TITLE
SandboxLinux: entry_point was inexistant, options.address was ignored

### DIFF
--- a/miasm2/analysis/sandbox.py
+++ b/miasm2/analysis/sandbox.py
@@ -232,6 +232,8 @@ class OS_Linux(OS):
         self.elf = elf
         preload_elf(self.jitter.vm, elf, libs)
 
+        self.entry_point = elf.Ehdr.entry
+
         # Library calls handler
         self.jitter.add_lib_handler(libs, custom_methods)
 
@@ -348,7 +350,7 @@ class Sandbox_Linux_x86_32(Sandbox, Arch_x86_32, OS_Linux):
         """
         If addr is not set, use entrypoint
         """
-        if addr is None:
+        if addr is None and self.options.address is None:
             addr = self.entry_point
         super(Sandbox_Linux_x86_32, self).run(addr)
 


### PR DESCRIPTION
`Sandbox_Linux` was broken due to an uninitialized attribute `entry_point`.

In addition, the option `--address` was ignored.
