### PR TITLE
Expression: Fix ExprCompose:get_w (wrong copy/paste ?)

### DIFF
--- a/miasm2/expression/expression.py
+++ b/miasm2/expression/expression.py
@@ -866,7 +866,7 @@ class ExprCompose(Expr):
 
     def get_w(self):
         return reduce(lambda x, y:
-            x.union(y[0].get_r(mem_read, cst_read)), self.args, set())
+            x.union(y[0].get_w()), self.args, set())
 
     def __contains__(self, e):
         if self == e:


### PR DESCRIPTION
In the `ExprCompose` definition, the `get_w` definition was the same than `get_r`. Thus, `mem_*` arguments were left unitialized.
