### PR TITLE
Fix xorps semantic

### DIFF
--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -2884,7 +2884,7 @@ def xorps(ir, instr, a, b):
     e = []
     if isinstance(b, ExprMem):
         b = ExprMem(b.arg, a.size)
-    e.append(ExprAff(a, ExprOp('xorps', a, b)))
+    e.append(ExprAff(a, ExprOp('^', a, b)))
     return e, []
 
 ### MMX/SSE/AVX operations


### PR DESCRIPTION
Use classic `^` operator for xorps
