### PR TITLE
Handling IOError Interrupted System Call when launching tests.

### DIFF
--- a/test/utils/testset.py
+++ b/test/utils/testset.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import subprocess
 import sys
@@ -105,7 +106,13 @@ class TestSet(object):
 
         # Main loop
         while True:
-            message = self.message_queue.get()
+            message = None
+            while message is None:
+                try:
+                    message = self.message_queue.get()
+                except IOError as e:
+                    if e.errno != errno.EINTR:
+                        raise
             if isinstance(message, MessageClose):
                 # Poison pill
                 break


### PR DESCRIPTION
On Fedora 20 (kernel 3.17.3-200) with python 2.7.5 I had the following exception when running the tests:

```python
Traceback (most recent call last):
  File "test_all.py", line 297, in <module>
    testset.run()
  File "/home/lawki/opt/miasm/test/utils/testset.py", line 230, in run
    self.messages_handler()
  File "/home/lawki/opt/miasm/test/utils/testset.py", line 108, in messages_handler
    message = self.message_queue.get()
  File "/usr/lib64/python2.7/multiprocessing/queues.py", line 117, in get
    res = self._recv()
IOError: [Errno 4] Interrupted system call
```

As a consequence, the test script would block indefinitely. The tests were still running fine with '-m' option though.

I fixed that problem by ignoring that precise error (based on this [stackoverflow thread](http://stackoverflow.com/questions/4952247/interrupted-system-call-with-processing-queue), itself based on this [comp.lang.python thread](https://groups.google.com/forum/#!topic/comp.lang.python/rjz11HXE8bo), it should be safe to ignore this error). Now the tests are running fine on my machine.

I hope this will fix tests on other machines too!
