### PR TITLE
IR/Translators: No more usage of wild import

### DIFF
--- a/miasm2/ir/translators/__init__.py
+++ b/miasm2/ir/translators/__init__.py
@@ -1,6 +1,7 @@
 """IR Translators"""
-from miasm2.ir.translators.C import *
-from miasm2.ir.translators.python import *
-from miasm2.ir.translators.miasm import *
+from miasm2.ir.translators.translator import Translator
+import miasm2.ir.translators.C
+import miasm2.ir.translators.python
+import miasm2.ir.translators.miasm
 
 __all__ = ["Translator"]


### PR DESCRIPTION
The submodule `miasm2.ir.translators` was using wild import instead of using `import` statement to reduce the local scope footprint.