### PR TITLE
Refactor asmbloc

### DIFF
--- a/example/asm/simple.py
+++ b/example/asm/simple.py
@@ -30,7 +30,7 @@ symbol_pool.set_offset(symbol_pool.getby_name("main"), 0x0)
 resolved_b, patches = asmbloc.asm_resolve_final(mn_x86, blocs[0], symbol_pool)
 
 # Show resolved blocs
-for bloc, dummy in resolved_b:
+for bloc in resolved_b:
     print bloc
 
 # Print offset -> bytes

--- a/miasm2/core/asmbloc.py
+++ b/miasm2/core/asmbloc.py
@@ -368,8 +368,7 @@ class asm_symbol_pool:
 
 def dis_bloc(mnemo, pool_bin, cur_bloc, offset, job_done, symbol_pool,
              dont_dis=[], split_dis=[
-             ], follow_call=False, patch_instr_symb=True,
-             dontdis_retcall=False, lines_wd=None,
+             ], follow_call=False, dontdis_retcall=False, lines_wd=None,
              dis_bloc_callback=None, dont_dis_nulstart_bloc=False,
              attrib={}):
     # pool_bin.offset = offset
@@ -515,8 +514,7 @@ def split_bloc(mnemo, attrib, pool_bin, blocs,
 
 
 def dis_bloc_all(mnemo, pool_bin, offset, job_done, symbol_pool, dont_dis=[],
-                 split_dis=[], follow_call=False, patch_instr_symb=True,
-                 dontdis_retcall=False,
+                 split_dis=[], follow_call=False, dontdis_retcall=False,
                  blocs_wd=None, lines_wd=None, blocs=None,
                  dis_bloc_callback=None, dont_dis_nulstart_bloc=False,
                  attrib={}):
@@ -553,8 +551,7 @@ def dis_bloc_all(mnemo, pool_bin, offset, job_done, symbol_pool, dont_dis=[],
         l = symbol_pool.getby_offset_create(n)
         cur_bloc = asm_bloc(l)
         todo += dis_bloc(mnemo, pool_bin, cur_bloc, n, job_done, symbol_pool,
-                         dont_dis, split_dis, follow_call, patch_instr_symb,
-                         dontdis_retcall,
+                         dont_dis, split_dis, follow_call, dontdis_retcall,
                          dis_bloc_callback=dis_bloc_callback,
                          lines_wd=lines_wd,
                          dont_dis_nulstart_bloc=dont_dis_nulstart_bloc,
@@ -1358,7 +1355,6 @@ class disasmEngine(object):
         self.dont_dis = []
         self.split_dis = []
         self.follow_call = False
-        self.patch_instr_symb = True
         self.dontdis_retcall = False
         self.lines_wd = None
         self.blocs_wd = None
@@ -1374,7 +1370,6 @@ class disasmEngine(object):
                  self.symbol_pool,
                  dont_dis=self.dont_dis, split_dis=self.split_dis,
                  follow_call=self.follow_call,
-                 patch_instr_symb=self.patch_instr_symb,
                  dontdis_retcall=self.dontdis_retcall,
                  lines_wd=self.lines_wd,
                  dis_bloc_callback=self.dis_bloc_callback,
@@ -1387,7 +1382,6 @@ class disasmEngine(object):
                              self.symbol_pool,
                              dont_dis=self.dont_dis, split_dis=self.split_dis,
                              follow_call=self.follow_call,
-                             patch_instr_symb=self.patch_instr_symb,
                              dontdis_retcall=self.dontdis_retcall,
                              blocs_wd=self.blocs_wd,
                              lines_wd=self.lines_wd,

--- a/miasm2/core/asmbloc.py
+++ b/miasm2/core/asmbloc.py
@@ -1029,8 +1029,7 @@ def asmbloc_final(mnemo, blocs, symbol_pool, symb_reloc_off=None, conservative =
 
 
 def asm_resolve_final(mnemo, blocs, symbol_pool, dont_erase=[],
-                      max_offset=0xFFFFFFFF,
-                      symb_reloc_off=None, constrain_pos=False):
+                      max_offset=0xFFFFFFFF, symb_reloc_off=None):
     if symb_reloc_off is None:
         symb_reloc_off = {}
     guess_blocs_size(mnemo, blocs)

--- a/miasm2/core/asmbloc.py
+++ b/miasm2/core/asmbloc.py
@@ -632,7 +632,7 @@ def fix_expr_val(e, symbols):
     return e
 
 
-def guess_blocs_size(mnemo, blocs, symbols):
+def guess_blocs_size(mnemo, blocs):
     """
     Asm and compute max bloc length
     """
@@ -1033,7 +1033,7 @@ def asm_resolve_final(mnemo, blocs, symbol_pool, dont_erase=[],
                       symb_reloc_off=None, constrain_pos=False):
     if symb_reloc_off is None:
         symb_reloc_off = {}
-    guess_blocs_size(mnemo, blocs, symbol_pool)
+    guess_blocs_size(mnemo, blocs)
     bloc_g = group_blocs(blocs)
 
     resolved_b = resolve_symbol(bloc_g, symbol_pool, dont_erase=dont_erase,

--- a/miasm2/core/asmbloc.py
+++ b/miasm2/core/asmbloc.py
@@ -1206,87 +1206,13 @@ def bloc_find_path_next(blocs, blocby_label, a, b, path=None):
     return all_path
 
 
-def bloc_merge(blocs, symbol_pool, dont_merge=[]):
-    i = -1
-    """
-    # TODO XXXX implement find all path for digraph
-
-    g = blist2graph(blocs)
-    g.lbl2node = dict([(b.label, b) for b in blocs])
-
-    while i<len(blocs)-1:
-        i+=1
-        b = blocs[i]
-        if b.label in dont_merge:
-            continue
-
-        successors = [x for x in g.successors(b.label)]
-        predecessors = [x for x in g.predecessors(b.label)]
-        # if bloc doesn't self ref
-        if b.label in successors:
-            continue
-        # and bloc has only one parent
-        if len(predecessors) != 1:
-            continue
-        # may merge
-        bpl = predecessors[0]
-
-        # and parent has only one son
-        p_s = [x for x in g.successors(bpl)]
-        if len(p_s)!=1:
-            continue
-
-        bp = g.lbl2node[bpl]
-        # and parent has not a next constraint yet
-        found = False
-        for gpl in g.predecessors(bpl):
-            gp = g.lbl2node[gpl]
-            for x in gp.bto:
-                if x.c_t != asm_constraint.c_next:
-                    continue
-                if x.label == bpl:
-                    found = True
-                    break
-            if found:
-                break
-        if found:
-            continue
-        if bp.lines:
-            l = bp.lines[-1]
-            #jmp opt; jcc opt
-            if l.is_subcall():
-                continue
-            if l.breakflow() and l.dstflow():
-                bp.lines.pop()
-        #merge
-        #sons = b.bto[:]
-
-        # update parents
-        for s in b.bto:
-            if not isinstance(s.label, asm_label): continue
-            if s.label.name == None:
-                continue
-            if not s.label in g.lbl2node:
-                print "unknown parent XXX"
-                continue
-            bs = g.lbl2node[s.label]
-            for p in g.predecessors(bs.label):
-                if p == b.label:
-                    bs.parents.discard(p)
-                    bs.parents.add(bp.label)
-        bp.lines+=b.lines
-        bp.bto = b.bto
-        #symbol_pool.remove(b.label)
-        del(blocs[i])
-        i = -1
-
-    return
-    """
+def bloc_merge(blocs, dont_merge=[]):
     blocby_label = {}
     for b in blocs:
         blocby_label[b.label] = b
         b.parents = find_parents(blocs, b.label)
 
+    i = -1
     while i < len(blocs) - 1:
         i += 1
         b = blocs[i]
@@ -1339,7 +1265,7 @@ def bloc_merge(blocs, symbol_pool, dont_merge=[]):
                     bs.parents.add(bp.label)
         bp.lines += b.lines
         bp.bto = b.bto
-        # symbol_pool.remove(b.label)
+
         del(blocs[i])
         i = -1
 

--- a/miasm2/jitter/jitcore.py
+++ b/miasm2/jitter/jitcore.py
@@ -116,8 +116,7 @@ class JitCore(object):
         try:
             asmbloc.dis_bloc(self.ir_arch.arch, self.bs, cur_bloc, addr,
                              set(), self.ir_arch.symbol_pool, [],
-                             follow_call=False, patch_instr_symb=True,
-                             dontdis_retcall=False,
+                             follow_call=False, dontdis_retcall=False,
                              lines_wd=self.options["jit_maxline"],
                              # max 10 asm lines
                              attrib=self.ir_arch.attrib,

--- a/test/arch/x86/sem.py
+++ b/test/arch/x86/sem.py
@@ -51,7 +51,7 @@ def compute_txt(ir, mode, txt, inputstate={}, debug=False):
         mn, blocs[0], symbol_pool)
     interm = ir(symbol_pool)
     for bbl in resolved_b:
-        interm.add_bloc(bbl[0])
+        interm.add_bloc(bbl)
     return symb_exec(interm, inputstate, debug)
 
 op_add = lambda a, b: a+b


### PR DESCRIPTION
This PR applies a lint pass on `miasm2/core/asmbloc.py`. For instance, some unused arguments have been removed from the API.
In addition, the `resolve_symbol` method will no longer return a list of tuple `(BLOCK, 0)`, but a list of `BLOCK` instead (the `0` seems to be an artefact of the past).