### PR TITLE
Ida symbol exec

### DIFF
--- a/example/ida/symbol_exec.py
+++ b/example/ida/symbol_exec.py
@@ -16,7 +16,8 @@ class symbolicexec_t(idaapi.simplecustviewer_t):
 
     def expand(self, linenum):
         element = self.line2eq[linenum]
-        expanded = Variables_Identifier(element[1])
+        expanded = Variables_Identifier(element[1],
+                                        var_prefix="%s_v" % element[0])
         self.line2eq = self.line2eq[0:linenum] + \
             expanded.vars.items() + \
             [(element[0], expanded.equation)] + \

--- a/example/ida/symbol_exec.py
+++ b/example/ida/symbol_exec.py
@@ -1,0 +1,110 @@
+import operator
+
+import idaapi
+import idc
+from miasm2.expression.expression_helper import Variables_Identifier
+
+from utils import expr2colorstr
+
+
+class symbolicexec_t(idaapi.simplecustviewer_t):
+
+    def add(self, key, value):
+        self.AddLine("%s = %s" % (expr2colorstr(self.machine.mn.regs.all_regs_ids, key),
+                                  expr2colorstr(self.machine.mn.regs.all_regs_ids, value)))
+
+    def expand(self, linenum):
+        element = self.line2eq[linenum]
+        expanded = Variables_Identifier(element[1])
+        self.line2eq = self.line2eq[0:linenum] + \
+            expanded.vars.items() + \
+            [(element[0], expanded.equation)] + \
+            self.line2eq[linenum + 1:]
+
+    def print_lines(self):
+        self.ClearLines()
+
+        for element in self.line2eq:
+            self.add(*element)
+
+        self.Refresh()
+
+    def Create(self, equations, machine, *args, **kwargs):
+        if not super(symbolicexec_t, self).Create(*args, **kwargs):
+            return False
+
+        self.machine = machine
+        self.line2eq = sorted(equations.items(), key=operator.itemgetter(0))
+        self.lines_expanded = set()
+
+        self.print_lines()
+
+        self.menu_expand = self.AddPopupMenu("Expand [E]")
+        return True
+
+    def OnPopupMenu(self, menu_id):
+        if menu_id == self.menu_expand:
+            self.expand(self.GetLineNo())
+            self.print_lines()
+        return True
+
+    def OnKeydown(self, vkey, shift):
+        # ESCAPE
+        if vkey == 27:
+            self.Close()
+            return True
+        # E (expand)
+        if vkey == 69:
+            self.OnPopupMenu(self.menu_expand)
+        return False
+
+
+def symbolic_exec():
+    from miasm2.analysis.machine import Machine
+    from miasm2.ir.symbexec import symbexec
+    from miasm2.core.bin_stream_ida import bin_stream_ida
+
+    from utils import guess_machine
+
+    bs = bin_stream_ida()
+    machine = guess_machine()
+
+    mdis = machine.dis_engine(bs)
+    start, end = SelStart(), SelEnd()
+
+    mdis.dont_dis = [end]
+    blocs = mdis.dis_multibloc(start)
+    ira = machine.ira()
+    for bloc in blocs:
+        ira.add_bloc(bloc)
+
+    print "Run symbolic execution..."
+    sb = symbexec(ira, machine.mn.regs.regs_init)
+    sb.emul_ir_blocs(ira, start)
+
+    modified = {}
+    for ident in sb.symbols.symbols_id:
+        if ident in sb.ir_arch.arch.regs.regs_init and \
+                ident in sb.symbols.symbols_id and \
+                sb.symbols.symbols_id[ident] == sb.ir_arch.arch.regs.regs_init[ident]:
+            continue
+        modified[ident] = sb.symbols.symbols_id[ident]
+
+    for ident in sb.symbols.symbols_mem:
+        modified[sb.symbols.symbols_mem[ident][0]] = sb.symbols.symbols_mem[ident][1]
+
+
+    view = symbolicexec_t()
+    if not view.Create(modified, machine,
+                       "Symbolic Execution - 0x%x to 0x%x" % (start, end)):
+        return
+
+    view.Show()
+
+idaapi.CompileLine('static key_F3() { RunPythonStatement("symbolic_exec()"); }')
+idc.AddHotkey("F3", "key_F3")
+
+print "=" * 50
+print """Available commands:
+    symbolic_exec() - F3: Symbolic execution of current selection
+"""

--- a/example/ida/symbol_exec.py
+++ b/example/ida/symbol_exec.py
@@ -4,64 +4,8 @@ import idaapi
 import idc
 from miasm2.expression.expression_helper import Variables_Identifier
 from miasm2.expression.expression import ExprAff
-from miasm2.ir.translators import Translator
 
-from utils import expr2colorstr
-
-
-class translatorForm(Form):
-    """Translator Form.
-
-    Offer a ComboBox with available languages (ie. IR translators) and the
-    corresponding translation."""
-
-    flags = (Form.MultiLineTextControl.TXTF_FIXEDFONT | \
-                 Form.MultiLineTextControl.TXTF_READONLY)
-
-    def __init__(self, expr):
-        "@expr: Expr instance"
-
-        # Init
-        self.languages = list(Translator.available_languages())
-        self.expr = expr
-
-        # Initial translation
-        text = Translator.to_language(self.languages[0]).from_expr(self.expr)
-
-        # Create the Form
-        Form.__init__(self, r"""STARTITEM 0
-Python Expression
-{FormChangeCb}
-<Language:{cbLanguage}>
-<Translation:{result}>
-""", {
-            'result': Form.MultiLineTextControl(text=text,
-                                                flags=translatorForm.flags),
-            'cbLanguage': Form.DropdownListControl(
-                    items=self.languages,
-                    readonly=True,
-                    selval=0),
-            'FormChangeCb': Form.FormChangeCb(self.OnFormChange),
-        })
-
-    def OnFormChange(self, fid):
-        if fid == self.cbLanguage.id:
-            # Display the Field (may be hide)
-            self.ShowField(self.result, True)
-
-            # Translate the expression
-            dest_lang = self.languages[self.GetControlValue(self.cbLanguage)]
-            try:
-                text = Translator.to_language(dest_lang).from_expr(self.expr)
-            except Exception, error:
-                self.ShowField(self.result, False)
-                return -1
-
-            # Update the form
-            self.SetControlValue(self.result,
-                                 textctrl_info_t(text=str(text),
-                                                 flags=translatorForm.flags))
-        return 1
+from utils import expr2colorstr, translatorForm
 
 
 class symbolicexec_t(idaapi.simplecustviewer_t):

--- a/example/ida/utils.py
+++ b/example/ida/utils.py
@@ -1,0 +1,113 @@
+import idaapi
+from idc import *
+
+from miasm2.analysis.machine import Machine
+import miasm2.expression.expression as m2_expr
+
+
+def guess_machine():
+    "Return an instance of Machine corresponding to the IDA guessed processor"
+
+    processor_name = GetLongPrm(INF_PROCNAME)
+
+    if processor_name == "metapc":
+
+        # HACK: check 32/64 using INF_START_SP
+        max_size = GetLongPrm(INF_START_SP)
+        if max_size == 0x80:  # TODO XXX check
+            machine = Machine("x86_16")
+        elif max_size == 0xFFFFFFFF:
+            machine = Machine("x86_32")
+        elif max_size == 0xFFFFFFFFFFFFFFFF:
+            machine = Machine("x86_64")
+        else:
+            raise ValueError('cannot guess 32/64 bit! (%x)' % max_size)
+    elif processor_name == "ARM":
+        # TODO ARM/thumb
+        # hack for thumb: set armt = True in globals :/
+        # set bigendiant = True is bigendian
+        is_armt = globals().get('armt', False)
+        is_bigendian = globals().get('bigendian', False)
+        if is_armt:
+            if is_bigendian:
+                machine = Machine("armtb")
+            else:
+                machine = Machine("armtl")
+        else:
+            if is_bigendian:
+                machine = Machine("armb")
+            else:
+                machine = Machine("arml")
+
+        from miasm2.analysis.disasm_cb import arm_guess_subcall, arm_guess_jump_table
+        guess_funcs.append(arm_guess_subcall)
+        guess_funcs.append(arm_guess_jump_table)
+
+    elif processor_name == "msp430":
+        machine = Machine("msp430")
+    elif processor_name == "mipsl":
+        machine = Machine("mipsl")
+    elif processor_name == "mipsb":
+        machine = Machine("mipsb")
+    else:
+        print repr(processor_name)
+        raise NotImplementedError('not fully functional')
+
+    return machine
+
+
+def expr2colorstr(regs_ids, expr):
+    """Colorize an Expr instance for IDA
+    @regs_ids: list of ExprId corresponding to available registers
+    @expr: Expr instance to colorize
+    """
+
+    if isinstance(expr, m2_expr.ExprId):
+        s = str(expr)
+        if expr in regs_ids:
+            s = idaapi.COLSTR(s, idaapi.SCOLOR_REG)
+    elif isinstance(expr, m2_expr.ExprInt):
+        s = str(expr)
+        s = idaapi.COLSTR(s, idaapi.SCOLOR_NUMBER)
+    elif isinstance(expr, m2_expr.ExprMem):
+        s = '%s[%s]' % (idaapi.COLSTR('@' + str(expr.size),
+                                      idaapi.SCOLOR_RPTCMT),
+                         expr2colorstr(regs_ids, expr.arg))
+    elif isinstance(expr, m2_expr.ExprOp):
+        out = []
+        for a in expr.args:
+            s = expr2colorstr(regs_ids, a)
+            if isinstance(a, m2_expr.ExprOp):
+                s = "(%s)" % s
+            out.append(s)
+        if len(out) == 1:
+            s = "%s %s" % (expr.op, str(out[0]))
+        else:
+            s = (" " + expr.op + " ").join(out)
+    elif isinstance(expr, m2_expr.ExprAff):
+        s = "%s = %s" % (
+            expr2colorstr(regs_ids, expr.dst), expr2colorstr(regs_ids, expr.src))
+    elif isinstance(expr, m2_expr.ExprCond):
+        cond = expr2colorstr(regs_ids, expr.cond)
+        src1 = expr2colorstr(regs_ids, expr.src1)
+        src2 = expr2colorstr(regs_ids, expr.src2)
+        s = "(%s?%s:%s)" % (cond, src1, src2)
+    elif isinstance(expr, m2_expr.ExprSlice):
+        s = "(%s)[%s:%s]" % (expr2colorstr(regs_ids, expr.arg),
+                             idaapi.COLSTR(str(expr.start),
+                                           idaapi.SCOLOR_RPTCMT),
+                             idaapi.COLSTR(str(expr.stop),
+                                           idaapi.SCOLOR_RPTCMT))
+    elif isinstance(expr, m2_expr.ExprCompose):
+        s = "{"
+        s += ", ".join(["%s, %s, %s" % (expr2colorstr(regs_ids, subexpr),
+                                        idaapi.COLSTR(str(start),
+                                                      idaapi.SCOLOR_RPTCMT),
+                                        idaapi.COLSTR(str(stop),
+                                                      idaapi.SCOLOR_RPTCMT))
+                        for subexpr, start, stop in expr.args])
+        s += "}"
+    else:
+        s = str(expr)
+
+    return s

--- a/miasm2/expression/expression_helper.py
+++ b/miasm2/expression/expression_helper.py
@@ -257,9 +257,13 @@ class Variables_Identifier(object):
 
         ## Build initial needs
         for var_id, var_expr in self._vars.iteritems():
+            ### Handle corner cases while using Variable Identifier on an
+            ### already computed equation
             needs[var_id] = [var_name
                              for var_name in var_expr.get_r(mem_read=True)
-                             if self.is_var_identifier(var_name)]
+                             if self.is_var_identifier(var_name) and \
+                                 var_name in todo and \
+                                 var_name != var_id]
 
         ## Build order list
         while todo:
@@ -271,7 +275,6 @@ class Variables_Identifier(object):
                         # A dependency is not met
                         all_met = False
                         break
-
                 if not all_met:
                     continue
 

--- a/test/expression/expression_helper.py
+++ b/test/expression/expression_helper.py
@@ -30,6 +30,7 @@ class TestExpressionExpressionHelper(unittest.TestCase):
 
         # Test the result
         new_expr = vi.equation
+
         ## Force replace in the variable dependency order
         for var_id, var_value in reversed(vi.vars.items()):
             new_expr = new_expr.replace_expr({var_id: var_value})
@@ -38,15 +39,45 @@ class TestExpressionExpressionHelper(unittest.TestCase):
         # Test prefix
         vi = Variables_Identifier(exprf, var_prefix="prefix_v")
 
-        # Use __str__
+        ## Use __str__
         print vi
 
-        # Test the result
+        ## Test the result
         new_expr = vi.equation
-        ## Force replace in the variable dependency order
+        ### Force replace in the variable dependency order
         for var_id, var_value in reversed(vi.vars.items()):
             new_expr = new_expr.replace_expr({var_id: var_value})
         self.assertEqual(exprf, new_expr)
+
+        # Test an identify on an expression already containing identifier
+        vi = Variables_Identifier(exprf)
+        vi2 = Variables_Identifier(vi.equation)
+
+        ## Test the result
+        new_expr = vi2.equation
+        ### Force replace in the variable dependency order
+        for var_id, var_value in reversed(vi2.vars.items()):
+            new_expr = new_expr.replace_expr({var_id: var_value})
+        self.assertEqual(vi.equation, new_expr)
+
+        ## Corner case: each sub var depends on itself
+        mem1 = m2_expr.ExprMem(ebx, size=32)
+        mem2 = m2_expr.ExprMem(mem1, size=32)
+        cst2 = m2_expr.ExprInt32(-1)
+        expr_mini = ((eax ^ mem2 ^ cst2) & (mem2 ^ (eax + mem2)))[31:32]
+
+        ## Build
+        vi = Variables_Identifier(expr_mini)
+        vi2 = Variables_Identifier(vi.equation)
+
+        ## Test the result
+        new_expr = vi2.equation
+        ### Force replace in the variable dependency order
+        for var_id, var_value in reversed(vi2.vars.items()):
+            new_expr = new_expr.replace_expr({var_id: var_value})
+        self.assertEqual(vi.equation, new_expr)
+
+
 
 if __name__ == '__main__':
     testcase = TestExpressionExpressionHelper

--- a/test/expression/expression_helper.py
+++ b/test/expression/expression_helper.py
@@ -35,6 +35,19 @@ class TestExpressionExpressionHelper(unittest.TestCase):
             new_expr = new_expr.replace_expr({var_id: var_value})
         self.assertEqual(exprf, new_expr)
 
+        # Test prefix
+        vi = Variables_Identifier(exprf, var_prefix="prefix_v")
+
+        # Use __str__
+        print vi
+
+        # Test the result
+        new_expr = vi.equation
+        ## Force replace in the variable dependency order
+        for var_id, var_value in reversed(vi.vars.items()):
+            new_expr = new_expr.replace_expr({var_id: var_value})
+        self.assertEqual(exprf, new_expr)
+
 if __name__ == '__main__':
     testcase = TestExpressionExpressionHelper
     testsuite = unittest.TestLoader().loadTestsFromTestCase(testcase)


### PR DESCRIPTION
This PR add a plug-in example for IDA, based on Miasm symbolic execution engine. It also features the `VarExpander` possibility.

For instance, on `samples/sc_connect_back.bin`, one selects the targeted area.
![select](https://cloud.githubusercontent.com/assets/4194483/6110156/399d4acc-b080-11e4-8984-8a162c2788f5.png)

Then, by calling `symbolic_exec()` or pressing `F3`, the new view `Symbolic Execution ...` is created.
![symbolexec](https://cloud.githubusercontent.com/assets/4194483/6110158/39a1de52-b080-11e4-9bd2-78bb945c8543.png)

If a line is too complicated, one can expand it by pressing `E` or `Right click > Expand`.
![varexpanded](https://cloud.githubusercontent.com/assets/4194483/6110157/39a0f2e4-b080-11e4-8109-d64a3651f3e5.png)

The common code between IDA examples has been moved to `samples/ida/utils.py`.