### PR TITLE
Arch/X86: fix fsntenv in 64bit

### DIFF
--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -2003,6 +2003,9 @@ def fnstenv(ir, instr, a):
                                ])
 
     s = instr.mode
+    # The behaviour in 64bit is identical to 64 bit
+    # This will truncate addresses
+    s = min(32, s)
     ad = ExprMem(a.arg, size=16)
     e.append(ExprAff(ad, float_control))
     ad = ExprMem(a.arg + ExprInt_from(a.arg, s / 8 * 1), size=16)


### PR DESCRIPTION
Fix the fstenv/fnstenv semantic according to intel doc: same behaviour in 32/64 bit.