### PR TITLE
Example/IDA: Reorganize imports

### DIFF
--- a/example/ida/graph_ir.py
+++ b/example/ida/graph_ir.py
@@ -11,7 +11,6 @@ from miasm2.core.bin_stream_ida import bin_stream_ida
 from miasm2.core.asmbloc import *
 from miasm2.expression.simplifications import expr_simp
 from miasm2.expression.expression import *
-from miasm2.analysis.machine import Machine
 
 from miasm2.analysis.data_analysis import intra_bloc_flow_raw, inter_bloc_flow
 from miasm2.analysis.data_analysis import intra_bloc_flow_symbexec
@@ -97,8 +96,6 @@ class GraphMiasmIR(GraphViewer):
             print "Failed to add popup menu item!"
         return True
 
-
-from miasm2.analysis.disasm_cb import guess_funcs, guess_multi_cb
 
 machine = guess_machine()
 mn, dis_engine, ira = machine.mn, machine.dis_engine, machine.ira

--- a/example/ida/symbol_exec.py
+++ b/example/ida/symbol_exec.py
@@ -75,7 +75,6 @@ class symbolicexec_t(idaapi.simplecustviewer_t):
 
 
 def symbolic_exec():
-    from miasm2.analysis.machine import Machine
     from miasm2.ir.symbexec import symbexec
     from miasm2.core.bin_stream_ida import bin_stream_ida
 

--- a/example/ida/utils.py
+++ b/example/ida/utils.py
@@ -40,6 +40,7 @@ def guess_machine():
             else:
                 machine = Machine("arml")
 
+        from miasm2.analysis.disasm_cb import guess_funcs, guess_multi_cb
         from miasm2.analysis.disasm_cb import arm_guess_subcall, arm_guess_jump_table
         guess_funcs.append(arm_guess_subcall)
         guess_funcs.append(arm_guess_jump_table)


### PR DESCRIPTION
In the commit 704af54e5518038eb9ab52f078dd9357ed81bf23, an `import` move was missing. Thus, the ARM support was broken.

Additionally, `Machine` is no more used in both `graph_ir.py` and `symbol_exec.py`.