### PR TITLE
Bin stream no len

### DIFF
--- a/miasm2/core/bin_stream.py
+++ b/miasm2/core/bin_stream.py
@@ -126,7 +126,7 @@ class bin_stream_file(bin_stream):
 
 class bin_stream_container(bin_stream):
 
-    def __init__(self, virt_view="", offset=0L):
+    def __init__(self, virt_view, offset=0L):
         bin_stream.__init__(self)
         self.bin = virt_view
         self.l = virt_view.max_addr()
@@ -154,8 +154,11 @@ class bin_stream_container(bin_stream):
     def setoffset(self, val):
         self.offset = val
 
+
 class bin_stream_pe(bin_stream_container):
     pass
+
+
 class bin_stream_elf(bin_stream_container):
     pass
 

--- a/miasm2/core/bin_stream_ida.py
+++ b/miasm2/core/bin_stream_ida.py
@@ -1,4 +1,4 @@
-from idc import Byte
+from idc import Byte, SegEnd
 
 from miasm2.core.bin_stream import bin_stream_str
 
@@ -6,8 +6,6 @@ from miasm2.core.bin_stream import bin_stream_str
 class bin_stream_ida(bin_stream_str):
     """
     bin_stream implementation for IDA
-
-    IDA should provide Byte function
 
     Don't generate xrange using address computation:
     It can raise error on overflow 7FFFFFFF with 32 bit python
@@ -20,13 +18,10 @@ class bin_stream_ida(bin_stream_str):
 
     def readbs(self, l=1):
         if self.offset + l > self.l:
-            raise IOError
+            raise IOError("not enough bytes")
         o = self.getbytes(self.offset)
         self.offset += l
         return p
-
-    def writebs(self, l=1):
-        raise ValueError('writebs unsupported')
 
     def __str__(self):
         raise NotImplementedError('Not fully functional')
@@ -34,8 +29,5 @@ class bin_stream_ida(bin_stream_str):
     def setoffset(self, val):
         self.offset = val
 
-    def __len__(self):
-        return 0x7FFFFFFF
-
     def getlen(self):
-        return 0x7FFFFFFF - self.offset - self.shift
+        return SegEnd(0) - (self.offset + self.shift)

--- a/miasm2/core/cpu.py
+++ b/miasm2/core/cpu.py
@@ -1044,10 +1044,12 @@ class cls_mn(object):
             # print 'len', fname, l
             if l is not None:
                 # print fname, hex(bs_l), l
-                if bs_l * 8 - offset_b < l:
-                    continue
                 # print hex(offset_b)
-                v = cls.getbits(bs, attrib, offset_b, l)
+                try:
+                    v = cls.getbits(bs, attrib, offset_b, l)
+                except IOError:
+                    # Raised if offset is out of bound
+                    continue
                 # print 'TEST', bval, fname, offset_b, cpt, (l, fmask, fbits),
                 # hex(v), hex(v & fmask), hex(fbits), v & fmask == fbits
                 offset_b += l


### PR DESCRIPTION
The `__len__` cannot be used any more in `bin_stream`: Python returns an int object, which will cap values to `0x7FFFFFFF` on 32 bit systems. A binary can have a base address higher than this, making it impossible to handle such programs.

The `__len__` is replaced by a call to `getlen`.

:warning: Elfesteem has been updated to support `max_addr` API in order to retrieve the elf/pe max virtual address. See revision `772380e060e8` on [elfesteem](https://code.google.com/p/elfesteem/source/detail?r=772380e060e856c98b65ba327ab5f7edb2a2bac4).