### PR TITLE
TestAll: Never launch tests from `miasm2` root (files are used before mo...

### DIFF
--- a/test/test_all.py
+++ b/test/test_all.py
@@ -48,13 +48,12 @@ for script in ["x86/sem.py",
 class SemanticTestAsm(RegressionTest):
     """Assemble an asm file"""
 
-    shellcode_script = os.path.join("example", "asm", "shellcode.py")
+    shellcode_script = os.path.join("..", "example", "asm", "shellcode.py")
     container_dct = {"PE": "--PE"}
 
     def __init__(self, arch, container, *args, **kwargs):
         super(SemanticTestAsm, self).__init__(*args, **kwargs)
-        self.base_dir = os.path.join(self.base_dir, "..")
-        sample_dir = os.path.join("test", "samples", arch)
+        sample_dir = os.path.join("samples", arch)
         base_filename = os.path.join(sample_dir, self.command_line[0])
         input_filename = base_filename + ".S"
         output_filename = base_filename + ".bin"
@@ -70,12 +69,11 @@ class SemanticTestExec(RegressionTest):
     """Execute a binary file"""
 
     launcher_dct = {("PE", "x86_64"): "sandbox_pe_x86_64.py"}
-    launcher_base = os.path.join("example", "jitter")
+    launcher_base = os.path.join("..", "example", "jitter")
 
     def __init__(self, arch, container, address, *args, **kwargs):
         super(SemanticTestExec, self).__init__(*args, **kwargs)
-        self.base_dir = os.path.join(self.base_dir, "..")
-        sample_dir = os.path.join("test", "samples", arch)
+        sample_dir = os.path.join("samples", arch)
         base_filename = os.path.join(sample_dir, self.command_line[0])
         input_filename = base_filename + ".bin"
         launcher = os.path.join(self.launcher_base,


### PR DESCRIPTION
The commit ef6c6b0b855800375758058863861f28657b5ba7 introduces a bug while launching tests:
```Python
FAIL:example/jitter/sandbox_pe_x86_64.py test/samples/x86_64/mul_div.bin -a 0x401000
Traceback (most recent call last):
  File "example/jitter/sandbox_pe_x86_64.py", line 18, in <module>
    sb = Sandbox_Win_x86_64(options.filename, options, globals())
  File "miasm2/miasm2/analysis/sandbox.py", line 347, in __init__
    Sandbox.__init__(self, *args, **kwargs)
  File "miasm2/miasm2/analysis/sandbox.py", line 51, in __init__
    cls.__init__(self)
  File "miasm2/miasm2/analysis/sandbox.py", line 269, in __init__
    super(Arch_x86, self).__init__()
  File "miasm2/miasm2/analysis/sandbox.py", line 145, in __init__
    self.jitter = self.machine.jitter(self.options.jitter)
  File "miasm2/miasm2/arch/x86/jit.py", line 118, in __init__
    jitter.__init__(self, ir_x86_64(sp), *args, **kwargs)
  File "miasm2/miasm2/jitter/jitload.py", line 146, in __init__
    from arch import JitCore_x86 as jcore
ImportError: cannot import name JitCore_x86
```
Indeed, the `sandbox_pe_x86_64.py` script was launched with the root dir as base directory. That way, `miasm2/` is used instead of the module comming from `PYTHONPATH`.
As `JitCore*` are not compiled in the source dir, the `import` statement fails.