### PR TITLE
Comment mips32

### DIFF
--- a/miasm2/arch/mips32/sem.py
+++ b/miasm2/arch/mips32/sem.py
@@ -1,91 +1,92 @@
-from miasm2.expression.expression import *
+import miasm2.expression.expression as m2_expr
 from miasm2.ir.ir import ir, irbloc
 from miasm2.arch.mips32.arch import mn_mips32
 from miasm2.arch.mips32.regs import R_LO, R_HI, PC, RA
+
 
 def addiu(ir, instr, a, b, c):
     """Adds a register @b and a sign-extended immediate value @c and stores the
     result in a register @a"""
     e = []
-    e.append(ExprAff(a, b+c))
+    e.append(m2_expr.ExprAff(a, b+c))
     return e, []
 
 def lw(ir, instr, a, b):
     "A word is loaded into a register @a from the specified address @b."
     e = []
-    e.append(ExprAff(a, b))
+    e.append(m2_expr.ExprAff(a, b))
     return e, []
 
 def sw(ir, instr, a, b):
     "The contents of @b is stored at the specified address @a."
     e = []
-    e.append(ExprAff(b, a))
+    e.append(m2_expr.ExprAff(b, a))
     return e, []
 
 def jal(ir, instr, a):
     "Jumps to the calculated address @a and stores the return address in $RA"
     e = []
-    n = ExprId(ir.get_next_break_label(instr))
-    e.append(ExprAff(PC, a))
-    e.append(ExprAff(ir.IRDst, a))
-    e.append(ExprAff(RA, n))
+    n = m2_expr.ExprId(ir.get_next_break_label(instr))
+    e.append(m2_expr.ExprAff(PC, a))
+    e.append(m2_expr.ExprAff(ir.IRDst, a))
+    e.append(m2_expr.ExprAff(RA, n))
     return e, []
 
 def jalr(ir, instr, a, b):
     """Jump to an address stored in a register @a, and store the return address
     in another register @b"""
     e = []
-    n = ExprId(ir.get_next_break_label(instr))
-    e.append(ExprAff(PC, a))
-    e.append(ExprAff(ir.IRDst, a))
-    e.append(ExprAff(b, n))
+    n = m2_expr.ExprId(ir.get_next_break_label(instr))
+    e.append(m2_expr.ExprAff(PC, a))
+    e.append(m2_expr.ExprAff(ir.IRDst, a))
+    e.append(m2_expr.ExprAff(b, n))
     return e, []
 
 def bal(ir, instr, a):
     e = []
-    n = ExprId(ir.get_next_break_label(instr))
-    e.append(ExprAff(PC, a))
-    e.append(ExprAff(ir.IRDst, a))
-    e.append(ExprAff(RA, n))
+    n = m2_expr.ExprId(ir.get_next_break_label(instr))
+    e.append(m2_expr.ExprAff(PC, a))
+    e.append(m2_expr.ExprAff(ir.IRDst, a))
+    e.append(m2_expr.ExprAff(RA, n))
     return e, []
 
 def l_b(ir, instr, a):
     e = []
-    e.append(ExprAff(PC, a))
-    e.append(ExprAff(ir.IRDst, a))
+    e.append(m2_expr.ExprAff(PC, a))
+    e.append(m2_expr.ExprAff(ir.IRDst, a))
     return e, []
 
 def lbu(ir, instr, a, b):
     """A byte is loaded (unsigned extended) into a register @a from the
     specified address @b."""
     e = []
-    b = ExprMem(b.arg, 8)
-    e.append(ExprAff(a, b.zeroExtend(32)))
+    b = m2_expr.ExprMem(b.arg, 8)
+    e.append(m2_expr.ExprAff(a, b.zeroExtend(32)))
     return e, []
 
 def lhu(ir, instr, a, b):
     """A word is loaded (unsigned extended) into a register @a from the
     specified address @b."""
     e = []
-    b = ExprMem(b.arg, 16)
-    e.append(ExprAff(a, b.zeroExtend(32)))
+    b = m2_expr.ExprMem(b.arg, 16)
+    e.append(m2_expr.ExprAff(a, b.zeroExtend(32)))
     return e, []
 
 
 def lb(ir, instr, a, b):
     "A byte is loaded into a register @a from the specified address @b."
     e = []
-    b = ExprMem(b.arg, 8)
-    e.append(ExprAff(a, b.signExtend(32)))
+    b = m2_expr.ExprMem(b.arg, 8)
+    e.append(m2_expr.ExprAff(a, b.signExtend(32)))
     return e, []
 
 def beq(ir, instr, a, b, c):
     "Branches on @c if the quantities of two registers @a, @b are equal"
     e = []
-    n = ExprId(ir.get_next_break_label(instr))
-    dst_o = ExprCond(a-b, n, c)
-    e = [ExprAff(PC, dst_o),
-         ExprAff(ir.IRDst, dst_o)
+    n = m2_expr.ExprId(ir.get_next_break_label(instr))
+    dst_o = m2_expr.ExprCond(a-b, n, c)
+    e = [m2_expr.ExprAff(PC, dst_o),
+         m2_expr.ExprAff(ir.IRDst, dst_o)
      ]
     return e, []
 
@@ -93,20 +94,20 @@ def bgez(ir, instr, a, b):
     """Branches on @b if the quantities of register @a is greater than or equal
     to zero"""
     e = []
-    n = ExprId(ir.get_next_break_label(instr))
-    dst_o = ExprCond(a.msb(), n, b)
-    e = [ExprAff(PC, dst_o),
-         ExprAff(ir.IRDst, dst_o)
+    n = m2_expr.ExprId(ir.get_next_break_label(instr))
+    dst_o = m2_expr.ExprCond(a.msb(), n, b)
+    e = [m2_expr.ExprAff(PC, dst_o),
+         m2_expr.ExprAff(ir.IRDst, dst_o)
      ]
     return e, []
 
 def bne(ir, instr, a, b, c):
     "Branches on @c if the quantities of two registers @a, @b are NOT equal"
     e = []
-    n = ExprId(ir.get_next_break_label(instr))
-    dst_o = ExprCond(a-b, c, n)
-    e = [ExprAff(PC, dst_o),
-         ExprAff(ir.IRDst, dst_o)
+    n = m2_expr.ExprId(ir.get_next_break_label(instr))
+    dst_o = m2_expr.ExprCond(a-b, c, n)
+    e = [m2_expr.ExprAff(PC, dst_o),
+         m2_expr.ExprAff(ir.IRDst, dst_o)
     ]
     return e, []
 
@@ -114,8 +115,9 @@ def lui(ir, instr, a, b):
     """The immediate value @b is shifted left 16 bits and stored in the register
     @a. The lower 16 bits are zeroes."""
     e = []
-    e.append(ExprAff(a, ExprCompose([(ExprInt16(0), 0, 16),
-                                     (b[:16], 16, 32)])))
+    e.append(m2_expr.ExprAff(a,
+                             m2_expr.ExprCompose([(m2_expr.ExprInt16(0), 0, 16),
+                                                  (b[:16], 16, 32)])))
     return e, []
 
 def nop(ir, instr):
@@ -125,95 +127,97 @@ def nop(ir, instr):
 def j(ir, instr, a):
     """Jump to an address @a"""
     e = []
-    e.append(ExprAff(PC, a))
-    e.append(ExprAff(ir.IRDst, a))
+    e.append(m2_expr.ExprAff(PC, a))
+    e.append(m2_expr.ExprAff(ir.IRDst, a))
     return e, []
 
 def l_or(ir, instr, a, b, c):
     """Bitwise logical ors two registers @b, @c and stores the result in a
     register @a"""
     e = []
-    e.append(ExprAff(a, b|c))
+    e.append(m2_expr.ExprAff(a, b|c))
     return e, []
 
 def nor(ir, instr, a, b, c):
     """Bitwise logical Nors two registers @b, @c and stores the result in a
     register @a"""
     e = []
-    e.append(ExprAff(a, (b|c)^ExprInt32(0xFFFFFFFF)))
+    e.append(m2_expr.ExprAff(a, (b|c)^m2_expr.ExprInt32(0xFFFFFFFF)))
     return e, []
 
 def l_and(ir, instr, a, b, c):
     """Bitwise logical ands two registers @b, @c and stores the result in a
     register @a"""
     e = []
-    e.append(ExprAff(a, b&c))
+    e.append(m2_expr.ExprAff(a, b&c))
     return e, []
 
 def ext(ir, instr, a, b, c, d):
     e = []
     pos = int(c.arg)
     size = int(d.arg)
-    e.append(ExprAff(a, b[pos:pos+size].zeroExtend(32)))
+    e.append(m2_expr.ExprAff(a, b[pos:pos+size].zeroExtend(32)))
     return e, []
 
 def mul(ir, instr, a, b, c):
     """Multiplies @b by $c and stores the result in @a."""
     e = []
-    e.append(ExprAff(a, ExprOp('imul', b, c)))
+    e.append(m2_expr.ExprAff(a, m2_expr.ExprOp('imul', b, c)))
     return e, []
 
 def sltu(ir, instr, a, x, y):
     """If @y is less than @x (unsigned), @a is set to one. It gets zero
     otherwise."""
     e = []
-    e.append(ExprAff(a, (((x - y) ^ ((x ^ y) & ((x - y) ^ x))) ^ x ^ y).msb().zeroExtend(32)))
+    value = (((x - y) ^ ((x ^ y) & ((x - y) ^ x))) ^ x ^ y).msb().zeroExtend(32)
+    e.append(m2_expr.ExprAff(a, value))
     return e, []
 
 def slt(ir, instr, a, x, y):
     """If @y is less than @x (signed), @a is set to one. It gets zero
     otherwise."""
     e = []
-    e.append(ExprAff(a, ((x - y) ^ ((x ^ y) & ((x - y) ^ x))).zeroExtend(32)))
+    value = ((x - y) ^ ((x ^ y) & ((x - y) ^ x))).zeroExtend(32)
+    e.append(m2_expr.ExprAff(a, value))
     return e, []
 
 def l_sub(ir, instr, a, b, c):
     e = []
-    e.append(ExprAff(a, b-c))
+    e.append(m2_expr.ExprAff(a, b-c))
     return e, []
 
 def sb(ir, instr, a, b):
     "The least significant byte of @a is stored at the specified address @b."
     e = []
-    b = ExprMem(b.arg, 8)
-    e.append(ExprAff(b, a[:8]))
+    b = m2_expr.ExprMem(b.arg, 8)
+    e.append(m2_expr.ExprAff(b, a[:8]))
     return e, []
 
 def sh(ir, instr, a, b):
     e = []
-    b = ExprMem(b.arg, 16)
-    e.append(ExprAff(b, a[:16]))
+    b = m2_expr.ExprMem(b.arg, 16)
+    e.append(m2_expr.ExprAff(b, a[:16]))
     return e, []
 
 def movn(ir, instr, a, b, c):
-    lbl_do = ExprId(ir.gen_label(), 32)
-    lbl_skip = ExprId(ir.get_next_instr(instr), 32)
+    lbl_do = m2_expr.ExprId(ir.gen_label(), 32)
+    lbl_skip = m2_expr.ExprId(ir.get_next_instr(instr), 32)
     e_do = []
-    e_do.append(ExprAff(a, b))
-    e_do.append(ExprAff(ir.IRDst, lbl_skip))
+    e_do.append(m2_expr.ExprAff(a, b))
+    e_do.append(m2_expr.ExprAff(ir.IRDst, lbl_skip))
     e = []
-    e.append(ExprAff(ir.IRDst, ExprCond(c, lbl_do, lbl_skip)))
+    e.append(m2_expr.ExprAff(ir.IRDst, m2_expr.ExprCond(c, lbl_do, lbl_skip)))
 
     return e, [irbloc(lbl_do.name, [e_do], [])]
 
 def movz(ir, instr, a, b, c):
-    lbl_do = ExprId(ir.gen_label(), 32)
-    lbl_skip = ExprId(ir.get_next_instr(instr), 32)
+    lbl_do = m2_expr.ExprId(ir.gen_label(), 32)
+    lbl_skip = m2_expr.ExprId(ir.get_next_instr(instr), 32)
     e_do = []
-    e_do.append(ExprAff(a, b))
-    e_do.append(ExprAff(ir.IRDst, lbl_skip))
+    e_do.append(m2_expr.ExprAff(a, b))
+    e_do.append(m2_expr.ExprAff(ir.IRDst, lbl_skip))
     e = []
-    e.append(ExprAff(ir.IRDst, ExprCond(c, lbl_skip, lbl_do)))
+    e.append(m2_expr.ExprAff(ir.IRDst, m2_expr.ExprCond(c, lbl_skip, lbl_do)))
 
     return e, [irbloc(lbl_do.name, [e_do], [])]
 
@@ -221,149 +225,152 @@ def srl(ir, instr, a, b, c):
     """Shifts a register value @b right by the shift amount @c and places the
     value in the destination register @a. Zeroes are shifted in."""
     e = []
-    e.append(ExprAff(a, b >> c))
+    e.append(m2_expr.ExprAff(a, b >> c))
     return e, []
 
 def sra(ir, instr, a, b, c):
     """Shifts a register value @b right by the shift amount @c and places the
     value in the destination register @a. The sign bit is shifted in."""
     e = []
-    e.append(ExprAff(a, ExprOp('a>>', b, c)))
+    e.append(m2_expr.ExprAff(a, m2_expr.ExprOp('a>>', b, c)))
     return e, []
 
 def srav(ir, instr, a, b, c):
     e = []
-    e.append(ExprAff(a, ExprOp('a>>', b, c&ExprInt32(0x1F))))
+    value = m2_expr.ExprOp('a>>', b, c&m2_expr.ExprInt32(0x1F))
+    e.append(m2_expr.ExprAff(a, value))
     return e, []
 
 def sll(ir, instr, a, b, c):
     e = []
-    e.append(ExprAff(a, b<<c))
+    e.append(m2_expr.ExprAff(a, b<<c))
     return e, []
 
 def srlv(ir, instr, a, b, c):
     """Shifts a register value @b right by the amount specified in @c and places
     the value in the destination register @a. Zeroes are shifted in."""
     e = []
-    e.append(ExprAff(a, b >> (c & ExprInt32(0x1F))))
+    e.append(m2_expr.ExprAff(a, b >> (c & m2_expr.ExprInt32(0x1F))))
     return e, []
 
 def sllv(ir, instr, a, b, c):
     """Shifts a register value @b left by the amount specified in @c and places
     the value in the destination register @a. Zeroes are shifted in."""
     e = []
-    e.append(ExprAff(a, b << (c & ExprInt32(0x1F))))
+    e.append(m2_expr.ExprAff(a, b << (c & m2_expr.ExprInt32(0x1F))))
     return e, []
 
 def l_xor(ir, instr, a, b, c):
     """Exclusive ors two registers @b, @c and stores the result in a register
     @c"""
     e = []
-    e.append(ExprAff(a, b^c))
+    e.append(m2_expr.ExprAff(a, b^c))
     return e, []
 
 def seb(ir, instr, a, b):
     e = []
-    e.append(ExprAff(a, b[:8].signExtend(32)))
+    e.append(m2_expr.ExprAff(a, b[:8].signExtend(32)))
     return e, []
 
 def seh(ir, instr, a, b):
     e = []
-    e.append(ExprAff(a, b[:16].signExtend(32)))
+    e.append(m2_expr.ExprAff(a, b[:16].signExtend(32)))
     return e, []
 
 def bltz(ir, instr, a, b):
     """Branches on @b if the register @a is less than zero"""
     e = []
-    n = ExprId(ir.get_next_break_label(instr))
-    dst_o = ExprCond(a.msb(), b, n)
-    e = [ExprAff(PC, dst_o),
-         ExprAff(ir.IRDst, dst_o)
+    n = m2_expr.ExprId(ir.get_next_break_label(instr))
+    dst_o = m2_expr.ExprCond(a.msb(), b, n)
+    e = [m2_expr.ExprAff(PC, dst_o),
+         m2_expr.ExprAff(ir.IRDst, dst_o)
     ]
     return e, []
 
 def blez(ir, instr, a, b):
     """Branches on @b if the register @a is less than or equal to zero"""
     e = []
-    n = ExprId(ir.get_next_break_label(instr))
-    cond = ExprCond(a, ExprInt1(1), ExprInt1(0)) | a.msb()
-    dst_o = ExprCond(cond, b, n)
-    e = [ExprAff(PC, dst_o),
-         ExprAff(ir.IRDst, dst_o)
+    n = m2_expr.ExprId(ir.get_next_break_label(instr))
+    cond = m2_expr.ExprCond(a, m2_expr.ExprInt1(1),
+                            m2_expr.ExprInt1(0)) | a.msb()
+    dst_o = m2_expr.ExprCond(cond, b, n)
+    e = [m2_expr.ExprAff(PC, dst_o),
+         m2_expr.ExprAff(ir.IRDst, dst_o)
     ]
     return e, []
 
 def bgtz(ir, instr, a, b):
     """Branches on @b if the register @a is greater than zero"""
     e = []
-    n = ExprId(ir.get_next_break_label(instr))
-    cond = ExprCond(a, ExprInt1(1), ExprInt1(0)) | a.msb()
-    dst_o = ExprCond(cond, n, b)
-    e = [ExprAff(PC, dst_o),
-         ExprAff(ir.IRDst, dst_o)
+    n = m2_expr.ExprId(ir.get_next_break_label(instr))
+    cond = m2_expr.ExprCond(a, m2_expr.ExprInt1(1),
+                            m2_expr.ExprInt1(0)) | a.msb()
+    dst_o = m2_expr.ExprCond(cond, n, b)
+    e = [m2_expr.ExprAff(PC, dst_o),
+         m2_expr.ExprAff(ir.IRDst, dst_o)
      ]
     return e, []
 
 def wsbh(ir, instr, a, b):
-    e = [ExprAff(a, ExprCompose([(b[8:16],  0, 8)   ,
-                                 (b[0:8]  , 8, 16)  ,
+    e = [m2_expr.ExprAff(a, m2_expr.ExprCompose([(b[8:16],  0, 8),
+                                 (b[0:8]  , 8, 16),
                                  (b[24:32], 16, 24),
                                  (b[16:24], 24, 32)]))]
     return e, []
 
 def rotr(ir, instr, a, b, c):
     e = []
-    e.append(ExprAff(a, ExprOp('>>>', b, c)))
+    e.append(m2_expr.ExprAff(a, m2_expr.ExprOp('>>>', b, c)))
     return e, []
 
 def add_d(ir, instr, a, b, c):
     # XXX TODO check
     e = []
-    e.append(ExprAff(a, ExprOp('fadd', b, c)))
+    e.append(m2_expr.ExprAff(a, m2_expr.ExprOp('fadd', b, c)))
     return e, []
 
 def sub_d(ir, instr, a, b, c):
     # XXX TODO check
     e = []
-    e.append(ExprAff(a, ExprOp('fsub', b, c)))
+    e.append(m2_expr.ExprAff(a, m2_expr.ExprOp('fsub', b, c)))
     return e, []
 
 def div_d(ir, instr, a, b, c):
     # XXX TODO check
     e = []
-    e.append(ExprAff(a, ExprOp('fdiv', b, c)))
+    e.append(m2_expr.ExprAff(a, m2_expr.ExprOp('fdiv', b, c)))
     return e, []
 
 def mul_d(ir, instr, a, b, c):
     # XXX TODO check
     e = []
-    e.append(ExprAff(a, ExprOp('fmul', b, c)))
+    e.append(m2_expr.ExprAff(a, m2_expr.ExprOp('fmul', b, c)))
     return e, []
 
 def mov_d(ir, instr, a, b):
     # XXX TODO check
     e = []
-    e.append(ExprAff(a, b))
+    e.append(m2_expr.ExprAff(a, b))
     return e, []
 
 def mfc0(ir, instr, a, b):
     e = []
-    e.append(ExprAff(a, b))
+    e.append(m2_expr.ExprAff(a, b))
     return e, []
 
 def mfc1(ir, instr, a, b):
     e = []
-    e.append(ExprAff(a, b))
+    e.append(m2_expr.ExprAff(a, b))
     return e, []
 
 def mtc0(ir, instr, a, b):
     e = []
-    e.append(ExprAff(b, a))
+    e.append(m2_expr.ExprAff(b, a))
     return e, []
 
 def mtc1(ir, instr, a, b):
     e = []
-    e.append(ExprAff(b, a))
+    e.append(m2_expr.ExprAff(b, a))
     return e, []
 
 def tlbwi(ir, instr):
@@ -388,58 +395,58 @@ def ins(ir, instr, a, b, c, d):
         my_slices.append((b[:l], pos, pos+l))
     if pos + l != 32:
         my_slices.append((a[pos+l:], pos+l, 32))
-    r = ExprCompose(my_slices)
-    e.append(ExprAff(a, r))
+    r = m2_expr.ExprCompose(my_slices)
+    e.append(m2_expr.ExprAff(a, r))
     return e, []
 
 
 def lwc1(ir, instr, a, b):
     e = []
-    src = ExprOp('mem_%.2d_to_single' % b.size, b)
-    e.append(ExprAff(a, src))
+    src = m2_expr.ExprOp('mem_%.2d_to_single' % b.size, b)
+    e.append(m2_expr.ExprAff(a, src))
     return e, []
 
 def swc1(ir, instr, a, b):
     e = []
-    src = ExprOp('single_to_mem_%.2d' % a.size, a)
-    e.append(ExprAff(b, src))
+    src = m2_expr.ExprOp('single_to_mem_%.2d' % a.size, a)
+    e.append(m2_expr.ExprAff(b, src))
     return e, []
 
 def c_lt_d(ir, instr, a, b, c):
     e = []
-    e.append(ExprAff(a, ExprOp('fcomp_lt', b, c)))
+    e.append(m2_expr.ExprAff(a, m2_expr.ExprOp('fcomp_lt', b, c)))
     return e, []
 
 def c_eq_d(ir, instr, a, b, c):
     e = []
-    e.append(ExprAff(a, ExprOp('fcomp_eq', b, c)))
+    e.append(m2_expr.ExprAff(a, m2_expr.ExprOp('fcomp_eq', b, c)))
     return e, []
 
 def c_le_d(ir, instr, a, b, c):
     e = []
-    e.append(ExprAff(a, ExprOp('fcomp_le', b, c)))
+    e.append(m2_expr.ExprAff(a, m2_expr.ExprOp('fcomp_le', b, c)))
     return e, []
 
 def bc1t(ir, instr, a, b):
     e = []
-    n = ExprId(ir.get_next_break_label(instr))
-    dst_o = ExprCond(a, b, n)
-    e = [ExprAff(PC, dst_o)]
-    e.append(ExprAff(ir.IRDst, dst_o))
+    n = m2_expr.ExprId(ir.get_next_break_label(instr))
+    dst_o = m2_expr.ExprCond(a, b, n)
+    e = [m2_expr.ExprAff(PC, dst_o)]
+    e.append(m2_expr.ExprAff(ir.IRDst, dst_o))
     return e, []
 
 def bc1f(ir, instr, a, b):
     e = []
-    n = ExprId(ir.get_next_break_label(instr))
-    dst_o = ExprCond(a, n, b)
-    e = [ExprAff(PC, dst_o)]
-    e.append(ExprAff(ir.IRDst, dst_o))
+    n = m2_expr.ExprId(ir.get_next_break_label(instr))
+    dst_o = m2_expr.ExprCond(a, n, b)
+    e = [m2_expr.ExprAff(PC, dst_o)]
+    e.append(m2_expr.ExprAff(ir.IRDst, dst_o))
     return e, []
 
 def cvt_d_w(ir, instr, a, b):
     e = []
     # TODO XXX
-    e.append(ExprAff(a, ExprOp('flt_d_w', b)))
+    e.append(m2_expr.ExprAff(a, m2_expr.ExprOp('flt_d_w', b)))
     return e, []
 
 def mult(ir, instr, a, b):
@@ -448,8 +455,8 @@ def mult(ir, instr, a, b):
     size = a.size
     r = a.signExtend(size * 2) * b.signExtend(size * 2)
 
-    e.append(ExprAff(R_LO, r[:32]))
-    e.append(ExprAff(R_HI, r[32:]))
+    e.append(m2_expr.ExprAff(R_LO, r[:32]))
+    e.append(m2_expr.ExprAff(R_HI, r[32:]))
     return e, []
 
 def multu(ir, instr, a, b):
@@ -458,20 +465,20 @@ def multu(ir, instr, a, b):
     size = a.size
     r = a.zeroExtend(size * 2) * b.zeroExtend(size * 2)
 
-    e.append(ExprAff(R_LO, r[:32]))
-    e.append(ExprAff(R_HI, r[32:]))
+    e.append(m2_expr.ExprAff(R_LO, r[:32]))
+    e.append(m2_expr.ExprAff(R_HI, r[32:]))
     return e, []
 
 def mfhi(ir, instr, a):
     "The contents of register $R_HI are moved to the specified register @a."
     e = []
-    e.append(ExprAff(a, R_HI))
+    e.append(m2_expr.ExprAff(a, R_HI))
     return e, []
 
 def mflo(ir, instr, a):
     "The contents of register R_LO are moved to the specified register @a."
     e = []
-    e.append(ExprAff(a, R_LO))
+    e.append(m2_expr.ExprAff(a, R_LO))
     return e, []
 
 def di(ir, instr, a):
@@ -577,21 +584,21 @@ class ir_mips32l(ir):
         ir.__init__(self, mn_mips32, 'l', symbol_pool)
         self.pc = mn_mips32.getpc()
         self.sp = mn_mips32.getsp()
-        self.IRDst = ExprId('IRDst', 32)
+        self.IRDst = m2_expr.ExprId('IRDst', 32)
 
     def get_ir(self, instr):
         args = instr.args
         instr_ir, extra_ir = get_mnemo_expr(self, instr, *args)
 
         for i, x in enumerate(instr_ir):
-            x = ExprAff(x.dst, x.src.replace_expr(
-                {self.pc: ExprInt32(instr.offset + 4)}))
+            x = m2_expr.ExprAff(x.dst, x.src.replace_expr(
+                {self.pc: m2_expr.ExprInt32(instr.offset + 4)}))
             instr_ir[i] = x
         for b in extra_ir:
             for irs in b.irs:
                 for i, x in enumerate(irs):
-                    x = ExprAff(x.dst, x.src.replace_expr(
-                        {self.pc: ExprInt32(instr.offset + 4)}))
+                    x = m2_expr.ExprAff(x.dst, x.src.replace_expr(
+                        {self.pc: m2_expr.ExprInt32(instr.offset + 4)}))
                     irs[i] = x
         return instr_ir, extra_ir
 
@@ -623,7 +630,7 @@ class ir_mips32l(ir):
             #if bloc_dst is not None:
             #    c.dst = bloc_dst
             if dst is not None:
-                ir_bloc_cur.append(ExprAff(PC_FETCH, dst))
+                ir_bloc_cur.append(m2_expr.ExprAff(PC_FETCH, dst))
                 c.dst = PC_FETCH
             if gen_pc_updt is not False:
                 self.gen_pc_update(c, l)
@@ -645,4 +652,4 @@ class ir_mips32b(ir_mips32l):
         ir.__init__(self, mn_mips32, 'b', symbol_pool)
         self.pc = mn_mips32.getpc()
         self.sp = mn_mips32.getsp()
-        self.IRDst = ExprId('IRDst', 32)
+        self.IRDst = m2_expr.ExprId('IRDst', 32)

--- a/miasm2/arch/mips32/sem.py
+++ b/miasm2/arch/mips32/sem.py
@@ -4,21 +4,26 @@ from miasm2.arch.mips32.arch import mn_mips32
 from miasm2.arch.mips32.regs import *
 
 def addiu(ir, instr, a, b, c):
+    """Adds a register @b and a sign-extended immediate value @c and stores the
+    result in a register @a"""
     e = []
     e.append(ExprAff(a, b+c))
     return e, []
 
 def lw(ir, instr, a, b):
+    "A word is loaded into a register @a from the specified address @b."
     e = []
     e.append(ExprAff(a, b))
     return e, []
 
 def sw(ir, instr, a, b):
+    "The contents of @b is stored at the specified address @a."
     e = []
     e.append(ExprAff(b, a))
     return e, []
 
 def jal(ir, instr, a):
+    "Jumps to the calculated address @a and stores the return address in $RA"
     e = []
     n = ExprId(ir.get_next_break_label(instr))
     e.append(ExprAff(PC, a))
@@ -27,6 +32,8 @@ def jal(ir, instr, a):
     return e, []
 
 def jalr(ir, instr, a, b):
+    """Jump to an address stored in a register @a, and store the return address
+    in another register @b"""
     e = []
     n = ExprId(ir.get_next_break_label(instr))
     e.append(ExprAff(PC, a))
@@ -49,12 +56,16 @@ def l_b(ir, instr, a):
     return e, []
 
 def lbu(ir, instr, a, b):
+    """A byte is loaded (unsigned extended) into a register @a from the
+    specified address @b."""
     e = []
     b = ExprMem(b.arg, 8)
     e.append(ExprAff(a, b.zeroExtend(32)))
     return e, []
 
 def lhu(ir, instr, a, b):
+    """A word is loaded (unsigned extended) into a register @a from the
+    specified address @b."""
     e = []
     b = ExprMem(b.arg, 16)
     e.append(ExprAff(a, b.zeroExtend(32)))
@@ -62,12 +73,14 @@ def lhu(ir, instr, a, b):
 
 
 def lb(ir, instr, a, b):
+    "A byte is loaded into a register @a from the specified address @b."
     e = []
     b = ExprMem(b.arg, 8)
     e.append(ExprAff(a, b.signExtend(32)))
     return e, []
 
 def beq(ir, instr, a, b, c):
+    "Branches on @c if the quantities of two registers @a, @b are equal"
     e = []
     n = ExprId(ir.get_next_break_label(instr))
     dst_o = ExprCond(a-b, n, c)
@@ -77,6 +90,8 @@ def beq(ir, instr, a, b, c):
     return e, []
 
 def bgez(ir, instr, a, b):
+    """Branches on @b if the quantities of register @a is greater than or equal
+    to zero"""
     e = []
     n = ExprId(ir.get_next_break_label(instr))
     dst_o = ExprCond(a.msb(), n, b)
@@ -86,6 +101,7 @@ def bgez(ir, instr, a, b):
     return e, []
 
 def bne(ir, instr, a, b, c):
+    "Branches on @c if the quantities of two registers @a, @b are NOT equal"
     e = []
     n = ExprId(ir.get_next_break_label(instr))
     dst_o = ExprCond(a-b, c, n)
@@ -95,31 +111,41 @@ def bne(ir, instr, a, b, c):
     return e, []
 
 def lui(ir, instr, a, b):
+    """The immediate value @b is shifted left 16 bits and stored in the register
+    @a. The lower 16 bits are zeroes."""
     e = []
     e.append(ExprAff(a, ExprCompose([(ExprInt16(0), 0, 16),
                                      (b[:16], 16, 32)])))
     return e, []
 
 def nop(ir, instr):
+    """Do nothing"""
     return [], []
 
 def j(ir, instr, a):
+    """Jump to an address @a"""
     e = []
     e.append(ExprAff(PC, a))
     e.append(ExprAff(ir.IRDst, a))
     return e, []
 
 def l_or(ir, instr, a, b, c):
+    """Bitwise logical ors two registers @b, @c and stores the result in a
+    register @a"""
     e = []
     e.append(ExprAff(a, b|c))
     return e, []
 
 def nor(ir, instr, a, b, c):
+    """Bitwise logical Nors two registers @b, @c and stores the result in a
+    register @a"""
     e = []
     e.append(ExprAff(a, (b|c)^ExprInt32(0xFFFFFFFF)))
     return e, []
 
 def l_and(ir, instr, a, b, c):
+    """Bitwise logical ands two registers @b, @c and stores the result in a
+    register @a"""
     e = []
     e.append(ExprAff(a, b&c))
     return e, []
@@ -132,16 +158,21 @@ def ext(ir, instr, a, b, c, d):
     return e, []
 
 def mul(ir, instr, a, b, c):
+    """Multiplies @b by $c and stores the result in @a."""
     e = []
     e.append(ExprAff(a, ExprOp('imul', b, c)))
     return e, []
 
 def sltu(ir, instr, a, x, y):
+    """If @y is less than @x (unsigned), @a is set to one. It gets zero
+    otherwise."""
     e = []
     e.append(ExprAff(a, (((x - y) ^ ((x ^ y) & ((x - y) ^ x))) ^ x ^ y).msb().zeroExtend(32)))
     return e, []
 
 def slt(ir, instr, a, x, y):
+    """If @y is less than @x (signed), @a is set to one. It gets zero
+    otherwise."""
     e = []
     e.append(ExprAff(a, ((x - y) ^ ((x ^ y) & ((x - y) ^ x))).zeroExtend(32)))
     return e, []
@@ -152,6 +183,7 @@ def l_sub(ir, instr, a, b, c):
     return e, []
 
 def sb(ir, instr, a, b):
+    "The least significant byte of @a is stored at the specified address @b."
     e = []
     b = ExprMem(b.arg, 8)
     e.append(ExprAff(b, a[:8]))
@@ -186,11 +218,15 @@ def movz(ir, instr, a, b, c):
     return e, [irbloc(lbl_do.name, [e_do], [])]
 
 def srl(ir, instr, a, b, c):
+    """Shifts a register value @b right by the shift amount @c and places the
+    value in the destination register @a. Zeroes are shifted in."""
     e = []
     e.append(ExprAff(a, b >> c))
     return e, []
 
 def sra(ir, instr, a, b, c):
+    """Shifts a register value @b right by the shift amount @c and places the
+    value in the destination register @a. The sign bit is shifted in."""
     e = []
     e.append(ExprAff(a, ExprOp('a>>', b, c)))
     return e, []
@@ -206,16 +242,22 @@ def sll(ir, instr, a, b, c):
     return e, []
 
 def srlv(ir, instr, a, b, c):
+    """Shifts a register value @b right by the amount specified in @c and places
+    the value in the destination register @a. Zeroes are shifted in."""
     e = []
     e.append(ExprAff(a, b >> (c & ExprInt32(0x1F))))
     return e, []
 
 def sllv(ir, instr, a, b, c):
+    """Shifts a register value @b left by the amount specified in @c and places
+    the value in the destination register @a. Zeroes are shifted in."""
     e = []
     e.append(ExprAff(a, b << (c & ExprInt32(0x1F))))
     return e, []
 
 def l_xor(ir, instr, a, b, c):
+    """Exclusive ors two registers @b, @c and stores the result in a register
+    @c"""
     e = []
     e.append(ExprAff(a, b^c))
     return e, []
@@ -231,6 +273,7 @@ def seh(ir, instr, a, b):
     return e, []
 
 def bltz(ir, instr, a, b):
+    """Branches on @b if the register @a is less than zero"""
     e = []
     n = ExprId(ir.get_next_break_label(instr))
     dst_o = ExprCond(a.msb(), b, n)
@@ -240,6 +283,7 @@ def bltz(ir, instr, a, b):
     return e, []
 
 def blez(ir, instr, a, b):
+    """Branches on @b if the register @a is less than or equal to zero"""
     e = []
     n = ExprId(ir.get_next_break_label(instr))
     cond = ExprCond(a, ExprInt1(1), ExprInt1(0)) | a.msb()
@@ -250,6 +294,7 @@ def blez(ir, instr, a, b):
     return e, []
 
 def bgtz(ir, instr, a, b):
+    """Branches on @b if the register @a is greater than zero"""
     e = []
     n = ExprId(ir.get_next_break_label(instr))
     cond = ExprCond(a, ExprInt1(1), ExprInt1(0)) | a.msb()
@@ -398,6 +443,7 @@ def cvt_d_w(ir, instr, a, b):
     return e, []
 
 def mult(ir, instr, a, b):
+    """Multiplies (signed) @a by @b and stores the result in $R_HI:$R_LO"""
     e = []
     size = a.size
     r = a.signExtend(size * 2) * b.signExtend(size * 2)
@@ -407,6 +453,7 @@ def mult(ir, instr, a, b):
     return e, []
 
 def multu(ir, instr, a, b):
+    """Multiplies (unsigned) @a by @b and stores the result in $R_HI:$R_LO"""
     e = []
     size = a.size
     r = a.zeroExtend(size * 2) * b.zeroExtend(size * 2)
@@ -416,11 +463,13 @@ def multu(ir, instr, a, b):
     return e, []
 
 def mfhi(ir, instr, a):
+    "The contents of register $R_HI are moved to the specified register @a."
     e = []
     e.append(ExprAff(a, R_HI))
     return e, []
 
 def mflo(ir, instr, a):
+    "The contents of register R_LO are moved to the specified register @a."
     e = []
     e.append(ExprAff(a, R_LO))
     return e, []

--- a/miasm2/arch/mips32/sem.py
+++ b/miasm2/arch/mips32/sem.py
@@ -1,7 +1,7 @@
 from miasm2.expression.expression import *
 from miasm2.ir.ir import ir, irbloc
 from miasm2.arch.mips32.arch import mn_mips32
-from miasm2.arch.mips32.regs import *
+from miasm2.arch.mips32.regs import R_LO, R_HI, PC, RA
 
 def addiu(ir, instr, a, b, c):
     """Adds a register @b and a sign-extended immediate value @c and stores the


### PR DESCRIPTION
Add docstrings in MIPS32 semantic. The goal is to help to maintain semantic, and to offer a way to retrieve the meaning of an architecture operations.

In addition, the wildcard imports of the module have been removed.