### PR TITLE
x86 semantic fix for Bit Scan instructions (BSR, BSF)

### DIFF
--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -2504,7 +2504,7 @@ def bsf(ir, instr, a, b):
                                               m2_expr.ExprInt_from(zf, 1)))]
 
     e_do = []
-    e_do.append(m2_expr.ExprAff(a, m2_expr.ExprOp('bsf', b)))
+    e_do.append(m2_expr.ExprAff(a, m2_expr.ExprOp('bsf', a, b)))
     e_do.append(m2_expr.ExprAff(ir.IRDst, lbl_skip))
     e.append(m2_expr.ExprAff(ir.IRDst, m2_expr.ExprCond(b, lbl_do, lbl_skip)))
     return e, [irbloc(lbl_do.name, [e_do])]
@@ -2518,9 +2518,10 @@ def bsr(ir, instr, a, b):
                                               m2_expr.ExprInt_from(zf, 1)))]
 
     e_do = []
-    e_do.append(m2_expr.ExprAff(a, m2_expr.ExprOp('bsr', b)))
+    e_do.append(m2_expr.ExprAff(a, m2_expr.ExprOp('bsr', a, b)))
     e_do.append(m2_expr.ExprAff(ir.IRDst, lbl_skip))
     e.append(m2_expr.ExprAff(ir.IRDst, m2_expr.ExprCond(b, lbl_do, lbl_skip)))
+
     return e, [irbloc(lbl_do.name, [e_do])]
 
 

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -2521,7 +2521,6 @@ def bsr(ir, instr, a, b):
     e_do.append(m2_expr.ExprAff(a, m2_expr.ExprOp('bsr', a, b)))
     e_do.append(m2_expr.ExprAff(ir.IRDst, lbl_skip))
     e.append(m2_expr.ExprAff(ir.IRDst, m2_expr.ExprCond(b, lbl_do, lbl_skip)))
-
     return e, [irbloc(lbl_do.name, [e_do])]
 
 


### PR DESCRIPTION
Hi,

By using the miasm jitter on a piece of x86 code containing BSR and BSF instructions, one can see an exception [here] (https://github.com/cea-sec/miasm/blob/master/miasm2/ir/translators/C.py#L76).

By looking at the code around, one can see:
```python
@classmethod
def from_ExprOp(cls, expr):
    if len(expr.args) == 1:
        # [...]
        raise NotImplementedError('Unknown op: %r' % expr.op)

    elif len(expr.args) == 2:
        if expr.op == "==":
        # [...]
        elif expr.op in ['bsr', 'bsf']:
            # Here we call jitter 'my_bsr or my_bsf' functions.
```

So now we know, to JiT BSR or BSF, we need to have 2 elements in expr.args, but the exception tells us there is just one. By looking at the semantic of BSR/BSF [here](https://github.com/cea-sec/miasm/blob/master/miasm2/arch/x86/sem.py#L2499-L2524), we can see the ExprOp take only one parameter:

```python
# [...]
e_do.append(m2_expr.ExprAff(a, m2_expr.ExprOp('bsf', b)))
# [...]
e_do.append(m2_expr.ExprAff(a, m2_expr.ExprOp('bsr', b)))
# [...]
```

But, the BSR/BSF semantic needs to know the source and destination registers, because if no bit is found during the scan, the destination is left unchanged, as we can see in the miasm jitter [implementation](https://github.com/cea-sec/miasm/blob/master/miasm2/jitter/vm_mngr.c#L918-L938):
```c
unsigned int my_bsr(unsigned int a, unsigned int b)
{
    int i;
    for (i=31; i>=0; i--)
    {
        if (b & (1<<i))
        return i;
    }
    return a;
}
```

The pull request suggest a fix to resolve the problem (tested/working)

