### PR TITLE
Expr immutable

### DIFF
--- a/example/ida/depgraph.py
+++ b/example/ida/depgraph.py
@@ -3,6 +3,8 @@ import sys
 from idaapi import GraphViewer
 from miasm2.core.bin_stream_ida import bin_stream_ida
 from miasm2.core.asmbloc import *
+from miasm2.expression import expression as m2_expr
+
 from miasm2.expression.simplifications import expr_simp
 from miasm2.analysis.machine import Machine
 from miasm2.analysis.depgraph import DependencyGraph, DependencyGraph_NoMemory
@@ -133,8 +135,8 @@ for bloc in blocs:
 # Simplify affectations
 for irb in ir_arch.blocs.values():
     for irs in irb.irs:
-        for i, e in enumerate(irs):
-            e.dst, e.src = expr_simp(e.dst), expr_simp(e.src)
+        for i, expr in enumerate(irs):
+            irs[i] = m2_expr.ExprAff(expr_simp(expr.dst), expr_simp(expr.src))
 
 # Build the IRA Graph
 ir_arch.gen_graph()

--- a/example/ida/graph_ir.py
+++ b/example/ida/graph_ir.py
@@ -139,8 +139,8 @@ print "IR ok... %x" % ad
 
 for irb in ir_arch.blocs.values():
     for irs in irb.irs:
-        for i, e in enumerate(irs):
-            e.dst, e.src = expr_simp(e.dst), expr_simp(e.src)
+        for i, expr in enumerate(irs):
+            irs[i] = ExprAff(expr_simp(expr.dst), expr_simp(expr.src))
 
 ir_arch.gen_graph()
 out = ir_arch.graph()

--- a/miasm2/arch/arm/sem.py
+++ b/miasm2/arch/arm/sem.py
@@ -1191,11 +1191,11 @@ class ir_arml(ir):
             if args[-1].op == 'rrx':
                 args[-1] = ExprCompose(
                     [(args[-1].args[0][1:], 0, 31), (cf, 31, 32)])
-            elif args[-1].op in ['<<', '>>', '<<a', 'a>>', '<<<', '>>>']:
-                if isinstance(args[-1].args[-1], ExprId):
-                    args[-1] = ExprOp(args[-1].op,
-                                      args[-1].args[0],
-                                      args[-1].args[-1][:8].zeroExtend(32))
+            elif (args[-1].op in ['<<', '>>', '<<a', 'a>>', '<<<', '>>>'] and
+                  isinstance(args[-1].args[-1], ExprId)):
+                args[-1] = ExprOp(args[-1].op,
+                                  args[-1].args[0],
+                                  args[-1].args[-1][:8].zeroExtend(32))
         instr_ir, extra_ir = get_mnemo_expr(self, instr, *args)
         # if self.name.startswith('B'):
         #    return instr_ir, extra_ir

--- a/miasm2/arch/arm/sem.py
+++ b/miasm2/arch/arm/sem.py
@@ -1191,10 +1191,11 @@ class ir_arml(ir):
             if args[-1].op == 'rrx':
                 args[-1] = ExprCompose(
                     [(args[-1].args[0][1:], 0, 31), (cf, 31, 32)])
-            elif (args[-1].op in ['<<', '>>', '<<a', 'a>>', '<<<', '>>>'] and
-                  isinstance(args[-1].args[-1], ExprId)):
-                args[-1].args = args[-1].args[:-1] + (
-                    args[-1].args[-1][:8].zeroExtend(32),)
+            elif args[-1].op in ['<<', '>>', '<<a', 'a>>', '<<<', '>>>']:
+                if isinstance(args[-1].args[-1], ExprId):
+                    args[-1] = ExprOp(args[-1].op,
+                                      args[-1].args[0],
+                                      args[-1].args[-1][:8].zeroExtend(32))
         instr_ir, extra_ir = get_mnemo_expr(self, instr, *args)
         # if self.name.startswith('B'):
         #    return instr_ir, extra_ir

--- a/miasm2/arch/msp430/sem.py
+++ b/miasm2/arch/msp430/sem.py
@@ -432,11 +432,12 @@ class ir_msp430(ir):
 
     def mod_sr(self, instr, instr_ir, extra_ir):
         for i, x in enumerate(instr_ir):
-            x.src = x.src.replace_expr({SR: composed_sr})
+            x = ExprAff(x.dst, x.src.replace_expr({SR: composed_sr}))
+            instr_ir[i] = x
             if x.dst != SR:
                 continue
             xx = ComposeExprAff(composed_sr, x.src)
-            instr_ir[i:i + 1] = xx
+            instr_ir[i] = xx
         for i, x in enumerate(instr_ir):
             x = ExprAff(x.dst, x.src.replace_expr(
                 {self.pc: ExprInt16(instr.offset + instr.l)}))

--- a/miasm2/expression/expression.py
+++ b/miasm2/expression/expression.py
@@ -126,7 +126,6 @@ class Expr(object):
         self.arg = arg
 
     size = property(lambda self: self._size)
-    hash = property(lambda self: self._hash)
 
     # Common operations
 
@@ -158,7 +157,7 @@ class Expr(object):
 
     def __eq__(self, a):
         if isinstance(a, Expr):
-            return self.hash == a.hash
+            return hash(self) == hash(a)
         else:
             return False
 
@@ -481,7 +480,7 @@ class ExprAff(Expr):
             return self._dst.get_w()
 
     def _exprhash(self):
-        return hash((EXPRAFF, self._dst.hash, self._src.hash))
+        return hash((EXPRAFF, hash(self._dst), hash(self._src)))
 
     def __contains__(self, e):
         return self == e or self._src.__contains__(e) or self._dst.__contains__(e)
@@ -565,8 +564,8 @@ class ExprCond(Expr):
         return set()
 
     def _exprhash(self):
-        return hash((EXPRCOND, self.cond.hash,
-                     self._src1.hash, self._src2.hash))
+        return hash((EXPRCOND, hash(self.cond),
+                     hash(self._src1), hash(self._src2)))
 
     def __contains__(self, e):
         return (self == e or
@@ -638,7 +637,7 @@ class ExprMem(Expr):
         return set([self])  # [memreg]
 
     def _exprhash(self):
-        return hash((EXPRMEM, self._arg.hash, self._size))
+        return hash((EXPRMEM, hash(self._arg), self._size))
 
     def __contains__(self, e):
         return self == e or self._arg.__contains__(e)
@@ -758,7 +757,7 @@ class ExprOp(Expr):
         raise ValueError('op cannot be written!', self)
 
     def _exprhash(self):
-        h_hargs = [arg.hash for arg in self._args]
+        h_hargs = [hash(arg) for arg in self._args]
         return hash((EXPROP, self._op, tuple(h_hargs)))
 
     def __contains__(self, e):
@@ -823,7 +822,7 @@ class ExprSlice(Expr):
         return self._arg.get_w()
 
     def _exprhash(self):
-        return hash((EXPRSLICE, self._arg.hash, self._start, self._stop))
+        return hash((EXPRSLICE, hash(self._arg), self._start, self._stop))
 
     def __contains__(self, e):
         if self == e:
@@ -923,7 +922,7 @@ class ExprCompose(Expr):
                       elements.union(arg[0].get_w()), self._args, set())
 
     def _exprhash(self):
-        h_args = [EXPRCOMPOSE] + [(arg[0].hash, arg[1], arg[2])
+        h_args = [EXPRCOMPOSE] + [(hash(arg[0]), arg[1], arg[2])
                                   for arg in self._args]
         return hash(tuple(h_args))
 

--- a/miasm2/expression/expression.py
+++ b/miasm2/expression/expression.py
@@ -496,8 +496,8 @@ class ExprAff(Expr):
         modified_s = []
         for x in self.src.args:
             if (not isinstance(x[0], ExprSlice) or
-                x[0].arg != dst or
-                x[1] != x[0].start or
+                    x[0].arg != dst or
+                    x[1] != x[0].start or
                     x[2] != x[0].stop):
                 # If x is not the initial expression
                 modified_s.append(x)

--- a/miasm2/expression/expression.py
+++ b/miasm2/expression/expression.py
@@ -29,6 +29,7 @@
 
 
 import itertools
+from operator import itemgetter
 from miasm2.expression.modint import *
 from miasm2.core.graph import DiGraph
 
@@ -885,11 +886,18 @@ class ExprCompose(Expr):
         @args: tuple(Expr, int, int)
         """
 
+        last_stop = 0
+        args = sorted(args, key=itemgetter(1))
         for e, start, stop in args:
             if e.size != stop - start:
                 raise ValueError(
                     "sanitycheck: ExprCompose args must have correct size!" +
                     " %r %r %r" % (e, e.size, stop - start))
+            if last_stop != start:
+                raise ValueError(
+                    "sanitycheck: ExprCompose args must be contiguous!" +
+                    " %r" % (args))
+            last_stop = stop
 
         # Transform args to lists
         o = []

--- a/miasm2/expression/expression_helper.py
+++ b/miasm2/expression/expression_helper.py
@@ -64,9 +64,11 @@ def merge_sliceto_slice(args):
     final_sources = []
     sorted_s = []
     for x in sources_int.values():
+        x = list(x)
         # mask int
         v = x[0].arg & ((1 << (x[2] - x[1])) - 1)
-        x[0].arg = v
+        x[0] = m2_expr.ExprInt_from(x[0], v)
+        x = tuple(x)
         sorted_s.append((x[1], x))
     sorted_s.sort()
     while sorted_s:
@@ -81,7 +83,7 @@ def merge_sliceto_slice(args):
             a = m2_expr.mod_size2uint[size](
                 (int(out[0].arg) << (out[1] - s_start)) +
                  int(sorted_s[-1][1][0].arg))
-            out[0].arg = a
+            out[0] = m2_expr.ExprInt(a)
             sorted_s.pop()
             out[1] = s_start
         out[0] = m2_expr.ExprInt_fromsize(size, out[0].arg)

--- a/miasm2/expression/simplifications_cond.py
+++ b/miasm2/expression/simplifications_cond.py
@@ -16,16 +16,6 @@
 
 import miasm2.expression.expression as m2_expr
 
-# Define tokens
-TOK_INF = "<"
-TOK_INF_SIGNED = TOK_INF + "s"
-TOK_INF_UNSIGNED = TOK_INF + "u"
-TOK_INF_EQUAL = "<="
-TOK_INF_EQUAL_SIGNED = TOK_INF_EQUAL + "s"
-TOK_INF_EQUAL_UNSIGNED = TOK_INF_EQUAL + "u"
-TOK_EQUAL = "=="
-TOK_POS = "pos"
-TOK_POS_STRICT = "Spos"
 
 # Jokers for expression matching
 
@@ -40,22 +30,21 @@ jok_small = m2_expr.ExprId("jok_small", 1)
 def __ExprOp_cond(op, arg1, arg2):
     "Return an ExprOp standing for arg1 op arg2 with size to 1"
     ec = m2_expr.ExprOp(op, arg1, arg2)
-    ec._size = 1
     return ec
 
 
 def ExprOp_inf_signed(arg1, arg2):
     "Return an ExprOp standing for arg1 <s arg2"
-    return __ExprOp_cond(TOK_INF_SIGNED, arg1, arg2)
+    return __ExprOp_cond(m2_expr.TOK_INF_SIGNED, arg1, arg2)
 
 
 def ExprOp_inf_unsigned(arg1, arg2):
     "Return an ExprOp standing for arg1 <s arg2"
-    return __ExprOp_cond(TOK_INF_UNSIGNED, arg1, arg2)
+    return __ExprOp_cond(m2_expr.TOK_INF_UNSIGNED, arg1, arg2)
 
 def ExprOp_equal(arg1, arg2):
     "Return an ExprOp standing for arg1 == arg2"
-    return __ExprOp_cond(TOK_EQUAL, arg1, arg2)
+    return __ExprOp_cond(m2_expr.TOK_EQUAL, arg1, arg2)
 
 
 # Catching conditions forms
@@ -153,9 +142,9 @@ def expr_simp_inverse(expr_simp, e):
 
         if r is False:
             return e
-        cur_sig = TOK_INF_SIGNED
+        cur_sig = m2_expr.TOK_INF_SIGNED
     else:
-        cur_sig = TOK_INF_UNSIGNED
+        cur_sig = m2_expr.TOK_INF_UNSIGNED
 
 
     arg = __check_msb(r[jok_small])
@@ -172,7 +161,7 @@ def expr_simp_inverse(expr_simp, e):
     if r[jok1] not in op_args or r[jok2] not in op_args:
         return e
 
-    if cur_sig == TOK_INF_UNSIGNED:
+    if cur_sig == m2_expr.TOK_INF_UNSIGNED:
         return ExprOp_inf_signed(r[jok1], r[jok2])
     else:
         return ExprOp_inf_unsigned(r[jok1], r[jok2])
@@ -193,7 +182,7 @@ def expr_simp_equal(expr_simp, e):
 
 def exec_inf_unsigned(expr_simp, e):
     "Compute x <u y"
-    if e.op != TOK_INF_UNSIGNED:
+    if e.op != m2_expr.TOK_INF_UNSIGNED:
         return e
 
     arg1, arg2 = e.args
@@ -221,7 +210,7 @@ def __comp_signed(arg1, arg2):
 def exec_inf_signed(expr_simp, e):
     "Compute x <s y"
 
-    if e.op != TOK_INF_SIGNED:
+    if e.op != m2_expr.TOK_INF_SIGNED:
         return e
 
     arg1, arg2 = e.args
@@ -234,7 +223,7 @@ def exec_inf_signed(expr_simp, e):
 def exec_equal(expr_simp, e):
     "Compute x == y"
 
-    if e.op != TOK_EQUAL:
+    if e.op != m2_expr.TOK_EQUAL:
         return e
 
     arg1, arg2 = e.args

--- a/miasm2/ir/ir.py
+++ b/miasm2/ir/ir.py
@@ -55,12 +55,12 @@ class irbloc(object):
         """Find and replace the IRDst affectation's source by @value"""
         dst = None
         for ir in self.irs:
-            for i in ir:
-                if isinstance(i.dst, m2_expr.ExprId) and i.dst.name == "IRDst":
+            for i, expr in enumerate(ir):
+                if isinstance(expr.dst, m2_expr.ExprId) and expr.dst.name == "IRDst":
                     if dst is not None:
                         raise ValueError('Multiple destinations!')
                     dst = value
-                    i.src = value
+                    ir[i] = m2_expr.ExprAff(expr.dst, value)
         self._dst = value
 
     dst = property(get_dst, set_dst)
@@ -296,8 +296,7 @@ class ir(object):
         for b in self.blocs.values():
             for ir in b.irs:
                 for i, r in enumerate(ir):
-                    ir[i].src = expr_simp(r.src)
-                    ir[i].dst = expr_simp(r.dst)
+                    ir[i] = m2_expr.ExprAff(expr_simp(r.dst), expr_simp(r.src))
 
     def replace_expr_in_ir(self, bloc, rep):
         for irs in bloc.irs:

--- a/miasm2/ir/translators/C.py
+++ b/miasm2/ir/translators/C.py
@@ -50,7 +50,7 @@ class TranslatorC(Translator):
 
     @classmethod
     def from_ExprMem(cls, expr):
-        return "MEM_LOOKUP_%.2d(vm_mngr, %s)" % (expr._size,
+        return "MEM_LOOKUP_%.2d(vm_mngr, %s)" % (expr.size,
                                                  cls.from_expr(expr.arg))
 
     @classmethod


### PR DESCRIPTION
Make expression immutable.
This may avoid bugs on the hash cache computation, and be a start point to correct hash collision.