### PR TITLE
Resource leak in VmMngr implementation

### DIFF
--- a/miasm2/jitter/Jittcc.c
+++ b/miasm2/jitter/Jittcc.c
@@ -73,17 +73,13 @@ PyObject* tcc_set_emul_lib_path(PyObject* self, PyObject* args)
 	char* include_arg;
 	char* lib_arg;
 
-	char* str1, * str2;
+	char* str1, * str2, * init_ptr;
 	if (!PyArg_ParseTuple(args, "ss",
 			      &include_arg,
 			      &lib_arg))
 		return NULL;
-	/*
-	if (include_array)
-		free(include_array);
-	*/
 
-	str2 = strdup(include_arg);
+	init_ptr = str2 = strdup(include_arg);
 	while (str2){
 		str1 = strsep(&str2, ";");
 		if (str1){
@@ -94,9 +90,10 @@ PyObject* tcc_set_emul_lib_path(PyObject* self, PyObject* args)
 			// fprintf(stderr, "adding include file: %s\n", str1);
 		}
 	}
+	if (init_ptr != NULL)
+		free(init_ptr);
 
-
-	str2 = strdup(lib_arg);
+	init_ptr = str2 = strdup(lib_arg);
 	while (str2){
 		str1 = strsep(&str2, ";");
 		if (str1){
@@ -107,6 +104,9 @@ PyObject* tcc_set_emul_lib_path(PyObject* self, PyObject* args)
 			// fprintf(stderr, "adding lib file: %s\n", str1);
 		}
 	}
+	if (init_ptr != NULL)
+		free(init_ptr);
+
 
 	/*
 	libcodenat_path = (char*)malloc(strlen(libcodenat_path_arg)+1);

--- a/miasm2/jitter/vm_mngr.c
+++ b/miasm2/jitter/vm_mngr.c
@@ -1296,6 +1296,7 @@ struct memory_page_node * create_memory_page_node(uint64_t ad, unsigned int size
 	}
 	p = malloc(size);
 	if (!p){
+		free(mpn);
 		fprintf(stderr, "cannot alloc %d\n", size);
 		return NULL;
 	}

--- a/miasm2/jitter/vm_mngr_py.c
+++ b/miasm2/jitter/vm_mngr_py.c
@@ -157,8 +157,11 @@ PyObject* vm_add_memory_page(VmMngr* self, PyObject* args)
 	mpn = create_memory_page_node(page_addr, buf_size, page_access);
 	if (mpn == NULL)
 		RAISE(PyExc_TypeError,"cannot create page");
-	if (is_mpn_in_tab(&self->vm_mngr, mpn))
+	if (is_mpn_in_tab(&self->vm_mngr, mpn)) {
+		free(mpn->ad_hp);
+		free(mpn);
 		RAISE(PyExc_TypeError,"known page in memory");
+	}
 
 	memcpy(mpn->ad_hp, buf_data, buf_size);
 	add_memory_page(&self->vm_mngr, mpn);


### PR DESCRIPTION
This PR fixes 2 resources leak in the implementation of  `VmMngr` regarding `mpn` management.

It also frees pointers returned by `strdup` in `tcc_set_emul_lib_path`.