### PR TITLE
Machine ir

### DIFF
--- a/example/disasm/full.py
+++ b/example/disasm/full.py
@@ -57,7 +57,8 @@ if args.verbose:
 
 log.info("import machine...")
 machine = Machine(args.architecture)
-mn, dis_engine, ira = machine.mn, machine.dis_engine, machine.ira
+mn, dis_engine = machine.mn, machine.dis_engine
+ira, ir = machine.ira, machine.ir
 log.info('ok')
 
 log.info('Load binary')
@@ -163,21 +164,31 @@ log.info('total lines %s' % total_l)
 
 # Bonus, generate IR graph
 if args.gen_ir:
-    log.info("generating IR")
+    log.info("generating IR and IR analysis")
 
-    ir_arch = ira(mdis.symbol_pool)
+    ir_arch = ir(mdis.symbol_pool)
+    ir_arch_a = ira(mdis.symbol_pool)
     ir_arch.blocs = {}
+    ir_arch_a.blocs = {}
     for ad, all_bloc in all_funcs_blocs.items():
         log.info("generating IR... %x" % ad)
         for b in all_bloc:
+            ir_arch_a.add_bloc(b)
             ir_arch.add_bloc(b)
+
+    log.info("Print blocs (without analyse)")
+    for label, bloc in ir_arch.blocs.iteritems():
+        print bloc
 
     log.info("Gen Graph... %x" % ad)
 
-    ir_arch.gen_graph()
+    log.info("Print blocs (with analyse)")
+    for label, bloc in ir_arch_a.blocs.iteritems():
+        print bloc
+    ir_arch_a.gen_graph()
 
     if args.simplify:
-        ir_arch.dead_simp()
+        ir_arch_a.dead_simp()
 
-    out = ir_arch.graph()
+    out = ir_arch_a.graph()
     open('graph_irflow.txt', 'w').write(out)

--- a/miasm2/analysis/machine.py
+++ b/miasm2/analysis/machine.py
@@ -20,6 +20,7 @@ class Machine(object):
         dis_engine = None
         mn = None
         ira = None
+        ir = None
         jitter = None
         gdbserver = None
         jit = None
@@ -34,22 +35,26 @@ class Machine(object):
             mn = arch.mn_arm
             jitter = jit.jitter_arml
             from miasm2.arch.arm.ira import ir_a_arml as ira
+            from miasm2.arch.arm.sem import ir_arml as ir
         elif machine_name == "armb":
             from miasm2.arch.arm.disasm import dis_armb as dis_engine
             from miasm2.arch.arm import arch, jit
             mn = arch.mn_arm
             jitter = jit.jitter_armb
             from miasm2.arch.arm.ira import ir_a_armb as ira
+            from miasm2.arch.arm.sem import ir_armb as ir
         elif machine_name == "armtl":
             from miasm2.arch.arm.disasm import dis_armtl as dis_engine
             from miasm2.arch.arm import arch
             mn = arch.mn_armt
             from miasm2.arch.arm.ira import ir_a_armtl as ira
+            from miasm2.arch.arm.sem import ir_armtl as ir
         elif machine_name == "armtb":
             from miasm2.arch.arm.disasm import dis_armtb as dis_engine
             from miasm2.arch.arm import arch
             mn = arch.mn_armt
             from miasm2.arch.arm.ira import ir_a_armtb as ira
+            from miasm2.arch.arm.sem import ir_armtb as ir
         elif machine_name == "sh4":
             from miasm2.arch.sh4 import arch
             mn = arch.mn_sh4
@@ -59,12 +64,14 @@ class Machine(object):
             mn = arch.mn_x86
             jitter = jit.jitter_x86_16
             from miasm2.arch.x86.ira import ir_a_x86_16 as ira
+            from miasm2.arch.x86.sem import ir_x86_16 as ir
         elif machine_name == "x86_32":
             from miasm2.arch.x86.disasm import dis_x86_32 as dis_engine
             from miasm2.arch.x86 import arch, jit
             mn = arch.mn_x86
             jitter = jit.jitter_x86_32
             from miasm2.arch.x86.ira import ir_a_x86_32 as ira
+            from miasm2.arch.x86.sem import ir_x86_32 as ir
             from miasm2.analysis.gdbserver import GdbServer_x86_32 as gdbserver
         elif machine_name == "x86_64":
             from miasm2.arch.x86.disasm import dis_x86_64 as dis_engine
@@ -72,12 +79,14 @@ class Machine(object):
             mn = arch.mn_x86
             jitter = jit.jitter_x86_64
             from miasm2.arch.x86.ira import ir_a_x86_64 as ira
+            from miasm2.arch.x86.sem import ir_x86_64 as ir
         elif machine_name == "msp430":
             from miasm2.arch.msp430.disasm import dis_msp430 as dis_engine
             from miasm2.arch.msp430 import arch, jit
             mn = arch.mn_msp430
             jitter = jit.jitter_msp430
             from miasm2.arch.msp430.ira import ir_a_msp430 as ira
+            from miasm2.arch.msp430.sem import ir_msp430 as ir
             from miasm2.analysis.gdbserver import GdbServer_msp430 as gdbserver
         elif machine_name == "mips32b":
             from miasm2.arch.mips32.disasm import dis_mips32b as dis_engine
@@ -85,12 +94,14 @@ class Machine(object):
             mn = arch.mn_mips32
             jitter = jit.jitter_mips32b
             from miasm2.arch.mips32.ira import ir_a_mips32b as ira
+            from miasm2.arch.mips32.sem import ir_mips32b as ir
         elif machine_name == "mips32l":
             from miasm2.arch.mips32.disasm import dis_mips32l as dis_engine
             from miasm2.arch.mips32 import arch, jit
             mn = arch.mn_mips32
             jitter = jit.jitter_mips32l
             from miasm2.arch.mips32.ira import ir_a_mips32l as ira
+            from miasm2.arch.mips32.sem import ir_mips32l as ir
         else:
             raise ValueError('Unknown machine: %s' % machine_name)
 
@@ -107,6 +118,7 @@ class Machine(object):
         self.__log_jit = log_jit
         self.__log_arch = log_arch
         self.__base_expr = arch.base_expr
+        self.__ir = ir
 
     @property
     def dis_engine(self):
@@ -119,6 +131,10 @@ class Machine(object):
     @property
     def ira(self):
         return self.__ira
+
+    @property
+    def ir(self):
+        return self.__ir
 
     @property
     def jitter(self):


### PR DESCRIPTION
Export an `ir` attribute from `Machine`.

In addition, the example `disasm/full.py` uses now both `ir` and `ira`.
For instance, the following assembly lines:
```
00000000 e841414141                     call        41414146
00000005 0a                             db          0a   
```

Output (with `-g`):
```
INFO : Print blocs (without analyse)
loc_0000000000000000:0x00000000
        ESP = {(ESP[0:32]+0xFFFFFFFC),0,32}
        @32[(ESP[0:32]+0xFFFFFFFC)] = loc_0000000000000005:0x00000005
        EIP = loc_0000000041414146:0x41414146
        IRDst = loc_0000000041414146:0x41414146

INFO : Gen Graph... 0
INFO : Print blocs (with analyse)
lbl_gen_00000000:None
        EAX = (loc_0000000041414146:0x41414146 call_func_ret ESP)
        ESP = (loc_0000000041414146:0x41414146 call_func_stack ESP)

        IRDst = loc_0000000000000005:0x00000005

loc_0000000000000000:0x00000000
        ESP = {(ESP[0:32]+0xFFFFFFFC),0,32}
        @32[(ESP[0:32]+0xFFFFFFFC)] = loc_0000000000000005:0x00000005
        EIP = loc_0000000041414146:0x41414146
        IRDst = lbl_gen_00000000:None

```