### PR TITLE
Fix depgraph

### DIFF
--- a/miasm2/analysis/depgraph.py
+++ b/miasm2/analysis/depgraph.py
@@ -511,8 +511,12 @@ class DependencyGraph(object):
                 yield depdict.copy()
                 continue
 
+            # Has a predecessor ?
+            is_final = True
+
             # Propagate the DependencyDict to all parents
             for label, irb_len in self._get_previousblocks(depdict.label):
+                is_final = False
 
                 ## Duplicate the DependencyDict
                 new_depdict = depdict.extend(label)
@@ -529,8 +533,9 @@ class DependencyGraph(object):
                 ## Manage the new element
                 todo.append(new_depdict)
 
-            # Return the node if it's a final one, ie. it's a head
-            if depdict.label in heads:
+            # Return the node if it's a final one, ie. it's a head (in graph
+            # or defined by caller)
+            if is_final or depdict.label in heads:
                 yield depdict.copy()
 
     def get(self, label, elements, line_nb, heads):

--- a/miasm2/analysis/depgraph.py
+++ b/miasm2/analysis/depgraph.py
@@ -508,7 +508,7 @@ class DependencyGraph(object):
 
             # No more dependencies
             if len(depdict.pending) == 0:
-                yield depdict
+                yield depdict.copy()
                 continue
 
             # Propagate the DependencyDict to all parents


### PR DESCRIPTION
This PR ensures that element returned by `DependencyGraph.get*` are always copies of internal elements.

In addition, the heads of the `ira` graph are also used as bound for the algorithm (like user-specified `heads`).
Indeed, with a graph which looks like:
```
+---------+         +---------+
| 1)      |         | 2)      |
|         |         |         |
|  HEAD   |         |         |
|         |         |         |
|         |         |         |
+----+----+         +------+--+
     |                     |   
     |                     |   
     |                     |   
     |     +---------+     |   
     +-----> 3)      +-----+   
           |         |         
           |         |         
           |         |         
           |         |         
           +----+----+         
                |              
           +----v----+         
           | 4)      |         
           | Tracked |         
           | Element |         
           |         |         
           +---------+         
```

Here, just `1` is a user-specified head.
Before the patch, if dependencies are tracked through `2`, the result will be ignored if and only if there is pending dependencies at the beginning of `2`.

After the patch, these results no more conditioned by the pending state of dependencies, and are keep.
The `heads` argument is now a "help" given to the algorithm when graph `heads` are not enough (for instance, a graph beginning with a loop).