### PR TITLE
VmMngrPY: Null Deref in `set_mem_access`

### DIFF
--- a/miasm2/jitter/vm_mngr_py.c
+++ b/miasm2/jitter/vm_mngr_py.c
@@ -232,6 +232,11 @@ PyObject* vm_set_mem_access(VmMngr* self, PyObject* args)
 	PyGetInt(access, page_access);
 
 	mpn = get_memory_page_from_address(&self->vm_mngr, page_addr);
+	if (!mpn){
+		PyErr_SetString(PyExc_RuntimeError, "cannot find address");
+		return 0;
+	}
+
 	mpn->access = page_access;
 	return PyLong_FromUnsignedLongLong((uint64_t)ret);
 }


### PR DESCRIPTION
There was a NULL deref in `vm_set_mem_access`.
The value returned by `get_memory_page_from_address` is checked everytime but not in this function. Others check:
* vm_mngr.c:169
* vm_mngr.c:220
* vm_mngr.c:257
* vm_mngr_py.c:276
* vm_mngr_py.c:205

Before the PR:
```Python
sb.jitter.vm.set_mem_access(0x1555, 2)
WARNING: address 0x1555 is not mapped in virtual memory:

Segmentation fault (core dumped)
```

After:
```Python
sb.jitter.vm.set_mem_access(0x1550, 2)
WARNING: address 0x1550 is not mapped in virtual memory:
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: cannot find address
```