### PR TITLE
Example/IDA: Replace /tmp/ by tempfile.gettempdir (credits @OwariDa)

### DIFF
--- a/example/ida/depgraph.py
+++ b/example/ida/depgraph.py
@@ -1,4 +1,6 @@
 import sys
+import os
+import tempfile
 
 from idaapi import GraphViewer
 from miasm2.core.bin_stream_ida import bin_stream_ida
@@ -175,7 +177,7 @@ def treat_element():
 
     sol_nb += 1
     print "Get graph number %02d" % sol_nb
-    filename = "/tmp/solution_0x%08x_%02d.dot" % (addr, sol_nb)
+    filename = os.path.join(tempfile.gettempdir(), "solution_0x%08x_%02d.dot" % (addr, sol_nb))
     print "Dump the graph to %s" % filename
     open(filename, "w").write(graph.graph.dot())
 

--- a/example/ida/graph_ir.py
+++ b/example/ida/graph_ir.py
@@ -1,4 +1,6 @@
 import sys
+import os
+import tempfile
 
 # Set your path first!
 sys.path.append("/home/serpilliere/tools/pyparsing/pyparsing-2.0.1/build/lib.linux-x86_64-2.7")
@@ -144,7 +146,7 @@ for irb in ir_arch.blocs.values():
 
 ir_arch.gen_graph()
 out = ir_arch.graph()
-open('/tmp/graph.txt', 'w').write(out)
+open(os.path.join(tempfile.gettempdir(), 'graph.txt'), 'wb').write(out)
 
 
 # ir_arch.dead_simp()


### PR DESCRIPTION
Replace mentions to `/tmp/` by `tempfile.gettempdir()` to be more platform-independent (thks to Joel Eriksson <je@clevcode.org>).