### PR TITLE
TranslatorZ3: now uses its cache (forgotten lines...)

### DIFF
--- a/miasm2/ir/translators/z3_ir.py
+++ b/miasm2/ir/translators/z3_ir.py
@@ -190,7 +190,9 @@ class TranslatorZ3(Translator):
             if expr in cls._cache:
                 return cls._cache[expr]
             else:
-                return super(TranslatorZ3, cls).from_expr(expr)
+                ret = super(TranslatorZ3, cls).from_expr(expr)
+                cls._cache[expr] = ret
+                return ret
         finally:
             # Clean cache and Z3Mem if this call is the root call
             if del_cache:


### PR DESCRIPTION
This PR makes TranslatorZ3 actually use its cache. I "just" forgot to put values in it in the previous PR...