### PR TITLE
Faster depgraph

### DIFF
--- a/miasm2/analysis/depgraph.py
+++ b/miasm2/analysis/depgraph.py
@@ -504,6 +504,9 @@ class DependencyGraph(object):
             # Update the dependencydict until fixed point is reached
             self._updateDependencyDict(depdict)
 
+            # Clean irrelevant path
+            depdict.filter_used_nodes(depnodes)
+
             # Avoid infinite loops
             label = depdict.label
             if depdict in done.get(label, []):

--- a/miasm2/analysis/depgraph.py
+++ b/miasm2/analysis/depgraph.py
@@ -495,7 +495,7 @@ class DependencyGraph(object):
         current_depdict.pending.update(depnodes)
 
         # Init the work list
-        done = []
+        done = {}
         todo = [current_depdict]
 
         while todo:
@@ -505,9 +505,10 @@ class DependencyGraph(object):
             self._updateDependencyDict(depdict)
 
             # Avoid infinite loops
-            if depdict in done:
+            label = depdict.label
+            if depdict in done.get(label, []):
                 continue
-            done.append(depdict)
+            done.setdefault(label, []).append(depdict)
 
             # No more dependencies
             if len(depdict.pending) == 0:

--- a/miasm2/analysis/depgraph.py
+++ b/miasm2/analysis/depgraph.py
@@ -1,5 +1,6 @@
 """Provide dependency graph"""
 import itertools
+
 import miasm2.expression.expression as m2_expr
 from miasm2.core.graph import DiGraph
 from miasm2.core.asmbloc import asm_label
@@ -274,6 +275,8 @@ class DependencyDict(object):
         # Map
         while todo:
             node = todo.pop()
+            if node in used_nodes:
+                continue
             used_nodes.add(node)
             if not node in self._cache:
                 continue


### PR DESCRIPTION
Ridiculously increase `DepGraph` performance.

In some corner cases, the complexity go from factorial to polynomial. Indeed, irrelevant path were conserved and used during comparison. That is to say, to be equal, two depnodes must have visited the same basic blocks with same elements. It's a good thing when one of these element is relevant (ie. is a `modifier`), but not when none of them are relevant.
In addition, some pure data-structures improvement have been done.

An naive hash on `DepDict` has not been used because there are a lot of collisions. Indexing `DepDict` by `label` seems to be a more efficient patch.