### PR TITLE
README: add a workaround for Windows & IDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Reverse engineering framework in Python
 - [Obtaining Miasm](#user-content-obtaining-miasm)
 	- [Software requirements](#user-content-software-requirements)
 	- [Configuration](#user-content-configuration)
+	- [Windows & IDA](#user-content-windows--ida)
 - [Testing](#user-content-testing)
 - [They already use Miasm](#user-content-they-already-use-miasm)
 - [Misc](#user-content-misc)
@@ -474,6 +475,16 @@ $ sudo python setup.py install
 If something goes wrong during one of the jitter modules compilation, Miasm will
 skip the error and disable the corresponding module (see the compilation
 output).
+
+Windows & IDA
+-------------
+
+Most of Miasm's IDA plugins use a subset of Miasm functionnality.
+A quick way to have them working is to add:
+* `elfesteem` directory and `pyparsing.py` to `C:\...\IDA\python\` or `pip install pyparsing elfesteem`
+* `miasm2/miasm2` directory to `C:\...\IDA\python\` 
+
+All features excepting JITter related ones will be available. For a more complete installation, please refer to above paragraphs.
 
 Testing
 =======


### PR DESCRIPTION
It seems that most of reversers use the Windows version of IDA, particularly for available plugins.

This PR add some quick steps to describe how to have a part of Miasm (actually, everything except the jitter part) working on Windows through IDA.
These steps have been tested with an IDA 6.6 on a Windows 7, with the following plugins:
* `symbol_exec.py`
* `graph_ir.py` (if nodes are blank, just wait a few seconds for the IDA refresh)
* `depgraph.py`