### PR TITLE
Fix depgraph emul

### DIFF
--- a/miasm2/analysis/depgraph.py
+++ b/miasm2/analysis/depgraph.py
@@ -346,7 +346,7 @@ class DependencyResult(object):
     def input(self):
         return self._input_depnodes
 
-    def emul(self):
+    def emul(self, step=False):
         """Symbolic execution of relevant nodes according to the history
         Return the values of input nodes' elements
 
@@ -368,7 +368,7 @@ class DependencyResult(object):
         # Eval the block
         temp_label = asm_label("Temp")
         sb = symbexec(new_ira, new_ira.arch.regs.regs_init)
-        sb.emulbloc(irbloc(temp_label, affects))
+        sb.emulbloc(irbloc(temp_label, affects), step=step)
 
         # Return only inputs values (others could be wrongs)
         return {depnode.element: sb.symbols[depnode.element]

--- a/miasm2/analysis/depgraph.py
+++ b/miasm2/analysis/depgraph.py
@@ -359,8 +359,8 @@ class DependencyResult(object):
 
         # Build a single affectation block according to history
         for label in self.relevant_labels[::-1]:
-            affected_lines = [line.line_nb for line in lines
-                              if line.label == label]
+            affected_lines = set(line.line_nb for line in lines
+                                 if line.label == label)
             irs = self._ira.blocs[label].irs
             for line_nb in sorted(affected_lines):
                 affects.append(irs[line_nb])

--- a/miasm2/analysis/depgraph.py
+++ b/miasm2/analysis/depgraph.py
@@ -354,13 +354,13 @@ class DependencyResult(object):
         """
         # Init
         new_ira = (self._ira.__class__)()
-        lines = self.relevant_nodes
+        depnodes = self.relevant_nodes
         affects = []
 
         # Build a single affectation block according to history
         for label in self.relevant_labels[::-1]:
-            affected_lines = set(line.line_nb for line in lines
-                                 if line.label == label)
+            affected_lines = set(depnode.line_nb for depnode in depnodes
+                                 if depnode.label == label)
             irs = self._ira.blocs[label].irs
             for line_nb in sorted(affected_lines):
                 affects.append(irs[line_nb])

--- a/test/analysis/depgraph.py
+++ b/test/analysis/depgraph.py
@@ -280,6 +280,21 @@ g10_ira.g.add_uniq_edge(g10_irb1.label, g10_irb1.label)
 
 g10_ira.blocs = dict([(irb.label, irb) for irb in [g10_irb1, g10_irb2]])
 
+# graph 11
+
+g11_ira = IRATest()
+g11_ira.g = GraphTest(g11_ira)
+
+g11_irb0 = gen_irbloc(lbl0, [ [ExprAff(a, cst1),
+                               ExprAff(b, cst2)] ])
+g11_irb1 = gen_irbloc(lbl1, [ [ExprAff(a, b),
+                               ExprAff(b, a)] ])
+g11_irb2 = gen_irbloc(lbl2, [ [ExprAff(a, a - b)] ])
+
+g11_ira.g.add_uniq_edge(g11_irb0.label, g11_irb1.label)
+g11_ira.g.add_uniq_edge(g11_irb1.label, g11_irb2.label)
+
+g11_ira.blocs = dict([(irb.label, irb) for irb in [g11_irb0, g11_irb1, g11_irb2]])
 
 # Test graph 1
 
@@ -543,6 +558,32 @@ g10_output1 = {"graph": g10_test1,
                "has_loop": True}
 
 
+# Test 11: no dual bloc emulation
+g11_test1 = DepNodeTest(g11_ira)
+
+g11_test1_dn1 = DependencyNode(g11_irb2.label, a, len(g11_irb2.irs))
+g11_test1_dn2 = DependencyNode(g11_irb2.label, a, 0)
+g11_test1_dn3 = DependencyNode(g11_irb2.label, b, 0)
+g11_test1_dn4 = DependencyNode(g11_irb1.label, a, 0)
+g11_test1_dn5 = DependencyNode(g11_irb1.label, b, 0)
+g11_test1_dn6 = DependencyNode(g11_irb0.label, cst1, 0)
+g11_test1_dn7 = DependencyNode(g11_irb0.label, cst2, 0)
+
+g11_test1.add_uniq_edge(g11_test1_dn7, g11_test1_dn5)
+g11_test1.add_uniq_edge(g11_test1_dn6, g11_test1_dn4)
+g11_test1.add_uniq_edge(g11_test1_dn5, g11_test1_dn2)
+g11_test1.add_uniq_edge(g11_test1_dn4, g11_test1_dn3)
+g11_test1.add_uniq_edge(g11_test1_dn3, g11_test1_dn1)
+g11_test1.add_uniq_edge(g11_test1_dn2, g11_test1_dn1)
+
+g11_input = (set([g11_test1_dn1]), set([g11_irb0.label]))
+
+g11_output1 = {"graph": g11_test1,
+               "emul": {a: ExprInt32(0x1)},
+               "unresolved": set(),
+               "has_loop": False}
+
+
 # Launch tests
 for i, test in enumerate([(g1_ira, g1_input, [g1_output1]),
                           (g2_ira, g2_input, [g2_output1]),
@@ -554,6 +595,7 @@ for i, test in enumerate([(g1_ira, g1_input, [g1_output1]),
                           (g8_ira, g8_input, [g8_output1, g8_output2]),
                           (g8_ira, g9_input, [g9_output1, g9_output2]),
                           (g10_ira, g10_input, [g10_output1]),
+                          (g11_ira, g11_input, [g11_output1]),
                       ]):
     # Extract test elements
     print "[+] Test", i+1


### PR DESCRIPTION
Fix a bug in the generation or the `irbloc`.
When extracting lines of expressions present in the relevant nodes, we can have duplicated lines.
This generated twice emulation of the same expressions.

Add single step support in symbolic execution for easier debugging of `depgraph` emulation.