### PR TITLE
Add couple of macros for OS X

### DIFF
--- a/miasm2/jitter/vm_mngr.h
+++ b/miasm2/jitter/vm_mngr.h
@@ -20,6 +20,8 @@
 
 #ifdef __APPLE__
 #define __BYTE_ORDER __BYTE_ORDER__
+#define __BIG_ENDIAN __DARWIN_BIG_ENDIAN
+#define __LITTLE_ENDIAN __DARWIN_LITTLE_ENDIAN
 #elif defined(__NetBSD__)
 #define __BYTE_ORDER _BYTE_ORDER
 #define __BIG_ENDIAN _BIG_ENDIAN


### PR DESCRIPTION
Those macros where required for miasm to compile on Yosemite using
Apple XCode LLVM 6.0.