### PR TITLE
Fix x86 prefix bin

### DIFF
--- a/miasm2/core/cpu.py
+++ b/miasm2/core/cpu.py
@@ -1164,7 +1164,7 @@ class cls_mn(object):
                 a.expr = expr_simp(a.expr)
 
             c.l = prefix_len + total_l / 8
-            c.b = cls.getbytes(bs, offset, total_l / 8)
+            c.b = cls.getbytes(bs, offset_o, c.l)
             c.offset = offset_o
             c = c.post_dis()
             if c is None:
@@ -1173,7 +1173,7 @@ class cls_mn(object):
             instr = cls.instruction(c.name, mode, c_args,
                                     additional_info=c.additional_info())
             instr.l = prefix_len + total_l / 8
-            instr.b = cls.getbytes(bs, offset, total_l / 8)
+            instr.b = cls.getbytes(bs, offset_o, instr.l)
             instr.offset = offset_o
             instr.get_info(c)
             if c.alias:

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -1938,3 +1938,8 @@ import cProfile
 # cProfile.run(r'mn_x86.dis("\x81\x54\x18\xfe\x44\x33\x22\x11", m32)')
 cProfile.run('profile_dis(o)')
 # profile_dis(o)
+
+# Test instruction representation with prefix
+instr_bytes = '\x65\xc7\x00\x09\x00\x00\x00'
+inst = mn_x86.dis(instr_bytes, 32, 0)
+assert(inst.b == instr_bytes)


### PR DESCRIPTION
The `b` attribute of an instruction represents its binary encoding.
The prefix was missing in this representation.

This fixes the issue #95.

A regression test is added.