### PR TITLE
TravisCI: Configuration file for the Travis continuous integration framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+- "2.7"
+addons:
+apt_packages:
+- make
+- gcc
+- libpython2.7-dev
+- unzip
+before_install:
+- "git clone http://repo.or.cz/tinycc.git tinycc && cd tinycc && git checkout d5e22108a0dc48899e44a158f91d5b3215eb7fe6 && ./configure --disable-static && make && sudo make install && cd .. && hg clone https://code.google.com/p/elfesteem/ elfesteem && cd elfesteem && python setup.py install && cd .. && pip install pyparsing && python setup.py install && sudo ldconfig"
+script: "cd test && python test_all.py -m"


### PR DESCRIPTION
Add the `.travis.yml` configuration file according to the current `DockerFile`.
This configuration file is used by the [Travis CI](https://travis-ci.org/) service.