### PR TITLE
Fix mul simp

### DIFF
--- a/miasm2/expression/simplifications_common.py
+++ b/miasm2/expression/simplifications_common.py
@@ -447,9 +447,8 @@ def simp_slice(e_s, e):
         e = ExprCond(e.arg.cond, src1, src2)
 
     # (a * int)[0:y] => (a[0:y] * int[0:y])
-    elif (isinstance(e.arg, ExprOp) and
-        e.arg.op == "*" and
-        isinstance(e.arg.args[-1], ExprInt)):
+    elif (e.start == 0 and isinstance(e.arg, ExprOp) and
+        e.arg.op == "*" and isinstance(e.arg.args[-1], ExprInt)):
         args = [e_s.expr_simp_wrapper(a[e.start:e.stop]) for a in e.arg.args]
         e = ExprOp(e.arg.op, *args)
 

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -197,6 +197,9 @@ to_test = [(ExprInt32(1) - ExprInt32(1), ExprInt32(0)),
      ExprCompose([(a, 0, 32), (d, 32, 64)])),
     (ExprCompose([(f[:32], 0, 32), (ExprInt32(0), 32, 64)]) | ExprCompose([(ExprInt32(0), 0, 32), (f[32:], 32, 64)]),
      f),
+    ((ExprCompose([(a, 0, 32), (ExprInt32(0), 32, 64)]) * ExprInt64(0x123))[32:64],
+     (ExprCompose([(a, 0, 32), (ExprInt32(0), 32, 64)]) * ExprInt64(0x123))[32:64])
+
 
 ]
 

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -36,7 +36,7 @@ x = ExprMem(a + b + ExprInt32(0x42))
 # Define tests: (expression to simplify, expected value)
 to_test = [(ExprInt32(1) - ExprInt32(1), ExprInt32(0)),
            ((ExprInt32(5) + c + a + b - a + ExprInt32(1) - ExprInt32(5)),
-            b + c + ExprInt32(1)),
+            ExprOp('+', b, c, ExprInt32(1))),
            (a + b + c - a - b - c + a, a),
            (a + a + b + c - (a + (b + c)), a),
            (c ^ b ^ a ^ c ^ b, a),
@@ -52,13 +52,13 @@ to_test = [(ExprInt32(1) - ExprInt32(1), ExprInt32(0)),
            (ExprOp('<<<', a, ExprOp('<<<', b, c)),
             ExprOp('<<<', a, ExprOp('<<<', b, c))),
            (ExprOp('<<<', ExprOp('<<<', a, b), c),
-            ExprOp('<<<', ExprOp('<<<', a, b), c)),
+            ExprOp('<<<', a, (b+c))),
            (ExprOp('<<<', ExprOp('>>>', a, b), c),
-            ExprOp('<<<', ExprOp('>>>', a, b), c)),
+            ExprOp('>>>', a, (b-c))),
            (ExprOp('>>>', ExprOp('<<<', a, b), c),
-            ExprOp('>>>', ExprOp('<<<', a, b), c)),
+            ExprOp('<<<', a, (b-c))),
            (ExprOp('>>>', ExprOp('<<<', a, b), b),
-            ExprOp('>>>', ExprOp('<<<', a, b), b)),
+            a),
 
 
            (ExprOp('>>>', ExprOp('<<<', a, ExprInt32(10)), ExprInt32(2)),
@@ -137,7 +137,7 @@ to_test = [(ExprInt32(1) - ExprInt32(1), ExprInt32(0)),
     (ExprOp('*', -a, -b, c, ExprInt32(0x12)),
      ExprOp('*', a, b, c, ExprInt32(0x12))),
     (ExprOp('*', -a, -b, -c, ExprInt32(0x12)),
-     ExprOp('*', -a, b, c, ExprInt32(0x12))),
+     - ExprOp('*', a, b, c, ExprInt32(0x12))),
     (a | ExprInt32(0xffffffff),
      ExprInt32(0xffffffff)),
     (ExprCond(a, ExprInt32(1), ExprInt32(2)) * ExprInt32(4),
@@ -203,7 +203,6 @@ to_test = [(ExprInt32(1) - ExprInt32(1), ExprInt32(0)),
 for e, e_check in to_test[:]:
     #
     print "#" * 80
-    e_check = expr_simp(e_check)
     # print str(e), str(e_check)
     e_new = expr_simp(e)
     print "original: ", str(e), "new: ", str(e_new)


### PR DESCRIPTION
Fix simplification for multiplication:
Fix needed for issur #128 

```
    # (a * int)[0:y] => (a[0:y] * int[0:y])
    elif (isinstance(e.arg, ExprOp) and
        e.arg.op == "*" and
        isinstance(e.arg.args[-1], ExprInt)):
        args = [e_s.expr_simp_wrapper(a[e.start:e.stop]) for a in e.arg.args]
        e = ExprOp(e.arg.op, *args)
```

The comment is correct, but the code doesn't do what's in the comment. The code which checks the slice begins with a 0 (in the [0:y]) is not present.