### PR TITLE
added semantics for x86 pxor

### DIFF
--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -302,6 +302,13 @@ def xor(ir, instr, a, b):
     return e, []
 
 
+def pxor(ir, instr, a, b):
+    e = []
+    c = a ^ b
+    # e += update_flag_logic(c)
+    e.append(m2_expr.ExprAff(a, c))
+    return e, []
+
 def l_or(ir, instr, a, b):
     e = []
     c = a | b
@@ -3138,6 +3145,7 @@ mnemo_func = {'mov': mov,
               'not': l_not,
               'cmp': l_cmp,
               'xor': xor,
+              'pxor': pxor,
               'or': l_or,
               'and': l_and,
               'test': l_test,

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -304,8 +304,11 @@ def xor(ir, instr, a, b):
 
 def pxor(ir, instr, a, b):
     e = []
+    if isinstance(a, m2_expr.ExprMem):
+        a = m2_expr.ExprMem(a.arg, b.size)
+    if isinstance(b, m2_expr.ExprMem):
+        b = m2_expr.ExprMem(b.arg, a.size)
     c = a ^ b
-    # e += update_flag_logic(c)
     e.append(m2_expr.ExprAff(a, c))
     return e, []
 


### PR DESCRIPTION
pxor doesn't change any flags, so I'm not sure if this is needed:

```
e += update_flag_logic(c)
e.append(m2_expr.ExprAff(a, c))
```