### PR TITLE
Remove lazy logging pattern

### DIFF
--- a/miasm2/analysis/binary.py
+++ b/miasm2/analysis/binary.py
@@ -46,7 +46,7 @@ class Container(object):
             addr = 0
         else:
             # Force fallback mode
-            log.warning('Fallback to string input (offset=%s)' % hex(addr))
+            log.warning('Fallback to string input (offset=%s)', hex(addr))
             return cls.fallback_container(data, vm, addr)
 
         # Try each available format
@@ -59,7 +59,7 @@ class Container(object):
                 log.error(error)
 
         # Fallback mode
-        log.warning('Fallback to string input (offset=%s)' % hex(addr))
+        log.warning('Fallback to string input (offset=%s)', hex(addr))
         return cls.fallback_container(data, vm, addr)
 
     @classmethod

--- a/miasm2/analysis/gdbserver.py
+++ b/miasm2/analysis/gdbserver.py
@@ -43,7 +43,7 @@ class GdbServer(object):
             data = self.sock.recv(4096)
             all_data += data
 
-        logging.debug("<- %r" % all_data)
+        logging.debug("<- %r", all_data)
         self.recv_queue += self.parse_messages(all_data)
 
     def parse_messages(self, data):
@@ -258,7 +258,7 @@ class GdbServer(object):
                 data = "+"
             else:
                 data = "$%s#%s" % (msg, self.compute_checksum(msg))
-            logging.debug("-> %r" % data)
+            logging.debug("-> %r", data)
             self.sock.send(data)
         self.send_queue = []
 

--- a/miasm2/arch/arm/arch.py
+++ b/miasm2/arch/arm/arch.py
@@ -403,7 +403,7 @@ class instruction_arm(instruction):
         if self.offset is None:
             raise ValueError('symbol not resolved %s' % l)
         if not isinstance(e, ExprInt):
-            log.debug('dyn dst %r' % e)
+            log.debug('dyn dst %r', e)
             return
         # Can't find the +4 reason in doc
         off = e.arg - (self.offset + 4 + self.l)
@@ -474,7 +474,7 @@ class instruction_armt(instruction_arm):
         if self.offset is None:
             raise ValueError('symbol not resolved %s' % l)
         if not isinstance(e, ExprInt):
-            log.debug('dyn dst %r' % e)
+            log.debug('dyn dst %r', e)
             return
         # The first +2 is to compensate instruction len, but strangely, 32 bits
         # thumb2 instructions len is 2... For the second +2, didn't find it in
@@ -846,7 +846,7 @@ class arm_imm8_12(m_arg):
             return True
         e = e.args[1]
         if not isinstance(e, ExprInt):
-            log.debug('should be int %r' % e)
+            log.debug('should be int %r', e)
             return False
         v = int(e.arg)
         if v < 0 or v & (1 << 31):
@@ -1080,7 +1080,7 @@ class arm_op2imm(arm_imm8_12):
             return True
         # rot reg
         if not isinstance(e.args[1], ExprOp):
-            log.debug('bad reg rot2 %r' % e)
+            log.debug('bad reg rot2 %r', e)
             return False
         e = e.args[1]
         rm = gpregs.expr.index(e.args[0])
@@ -1571,10 +1571,10 @@ class arm_offreg(m_arg):
     def encode(self):
         e = self.expr
         if not (isinstance(e, ExprOp) and e.op == "preinc"):
-            log.debug('cannot encode %r' % e)
+            log.debug('cannot encode %r', e)
             return False
         if e.args[0] != self.off_reg:
-            log.debug('cannot encode reg %r' % e.args[0])
+            log.debug('cannot encode reg %r', e.args[0])
             return False
         v = int(e.args[1].arg)
         v = self.encodeval(v)
@@ -1605,10 +1605,10 @@ class arm_offpc(arm_offreg):
             return False
         e = e.arg
         if not (isinstance(e, ExprOp) and e.op == "preinc"):
-            log.debug('cannot encode %r' % e)
+            log.debug('cannot encode %r', e)
             return False
         if e.args[0] != self.off_reg:
-            log.debug('cannot encode reg %r' % e.args[0])
+            log.debug('cannot encode reg %r', e.args[0])
             return False
         v = int(e.args[1].arg)
         v >>= 2
@@ -1684,7 +1684,7 @@ class arm_deref(m_arg):
             return False
         e = e.arg
         if not (isinstance(e, ExprOp) and e.op == 'preinc'):
-            log.debug('cannot encode %r' % e)
+            log.debug('cannot encode %r', e)
             return False
         off = e.args[1]
         if isinstance(off, ExprId):
@@ -1692,11 +1692,11 @@ class arm_deref(m_arg):
         elif isinstance(off, ExprInt):
             self.parent.off.expr = off
         else:
-            log.debug('cannot encode off %r' % off)
+            log.debug('cannot encode off %r', off)
             return False
         self.value = gpregs.expr.index(e.args[0])
         if self.value >= 1 << self.l:
-            log.debug('cannot encode reg %r' % off)
+            log.debug('cannot encode reg %r', off)
             return False
         return True
 
@@ -1716,7 +1716,7 @@ class arm_offbw(imm_noarg):
         v = int(self.expr.arg)
         if self.parent.trb.value == 0:
             if v & 3:
-                log.debug('off must be aligned %r' % v)
+                log.debug('off must be aligned %r', v)
                 return False
             v >>= 2
         self.value = v
@@ -1736,7 +1736,7 @@ class arm_offh(imm_noarg):
             return False
         v = int(self.expr.arg)
         if v & 1:
-            log.debug('off must be aligned %r' % v)
+            log.debug('off must be aligned %r', v)
             return False
         v >>= 1
         self.value = v

--- a/miasm2/arch/msp430/arch.py
+++ b/miasm2/arch/msp430/arch.py
@@ -185,7 +185,7 @@ class instruction_msp430(instruction):
             raise ValueError('symbol not resolved %s' % l)
         if not isinstance(e, ExprInt):
             # raise ValueError('dst must be int or label')
-            log.warning('dynamic dst %r' % e)
+            log.warning('dynamic dst %r', e)
             return
         # return ExprInt32(e.arg - (self.offset + self.l))
         self.args[0] = ExprInt_fromsize(16, e.arg - (self.offset + self.l))

--- a/miasm2/arch/sh4/arch.py
+++ b/miasm2/arch/sh4/arch.py
@@ -449,7 +449,7 @@ class instruction_sh4(instruction):
         if self.offset is None:
             raise ValueError('symbol not resolved %s' % l)
         if not isinstance(e, ExprInt):
-            log.debug('dyn dst %r' % e)
+            log.debug('dyn dst %r', e)
             return
         off = e.arg - (self.offset + 4 + self.l)
         print hex(off)

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -554,7 +554,7 @@ class instruction_x86(instruction):
             raise ValueError('symbol not resolved %s' % l)
         if not isinstance(e, ExprInt):
             # raise ValueError('dst must be int or label')
-            log.warning('dynamic dst %r' % e)
+            log.warning('dynamic dst %r', e)
             return
         # return ExprInt32(e.arg - (self.offset + self.l))
         self.args[0] = ExprInt_fromsize(
@@ -2445,7 +2445,7 @@ class x86_rm_reg_noarg(object):
             i = gpregs08_64.expr.index(self.expr)
             self.parent.rex_p.value = 1
         else:
-            log.debug("cannot encode reg %r" % self.expr)
+            log.debug("cannot encode reg %r", self.expr)
             return False
         # print "zzz", opmode, self.expr, i, self.parent.mode
         if self.parent.v_opmode() == 64:
@@ -2462,8 +2462,8 @@ class x86_rm_reg_noarg(object):
                 i -= 8
         self.value = i
         if self.value > self.lmask:
-            log.debug("cannot encode field value %x %x" %
-                      (self.value, self.lmask))
+            log.debug("cannot encode field value %x %x",
+                      self.value, self.lmask)
             return False
         # print 'RR ok'
         return True
@@ -2671,7 +2671,7 @@ class bs_cond_imm(bs_cond_scale, m_arg):
             self.expr = e
 
         if self.expr is None:
-            log.debug('cannot fromstring int %r' % s)
+            log.debug('cannot fromstring int %r', s)
             return None, None
         return start, stop
 
@@ -2936,7 +2936,7 @@ class bs_movoff(m_arg):
             return None, None
         e = v[0]
         if e is None:
-            log.debug('cannot fromstring int %r' % s)
+            log.debug('cannot fromstring int %r', s)
             return None, None
         self.expr = e
         return start, stop
@@ -3004,7 +3004,7 @@ class bs_msegoff(m_arg):
         e = v[0]
         print "XXX", e
         if e is None:
-            log.debug('cannot fromstring int %r' % s)
+            log.debug('cannot fromstring int %r', s)
             return None, None
         self.expr = e
         return start, stop

--- a/miasm2/core/asmbloc.py
+++ b/miasm2/core/asmbloc.py
@@ -158,7 +158,7 @@ class asm_bloc:
         self.bto.add(c)
 
     def split(self, offset, l):
-        log_asmbloc.debug('split at %x' % offset)
+        log_asmbloc.debug('split at %x', offset)
         i = -1
         offsets = [x.offset for x in self.lines]
         if not l.offset in offsets:
@@ -172,13 +172,13 @@ class asm_bloc:
 
         self.lines, new_bloc.lines = self.lines[:i], self.lines[i:]
         flow_mod_instr = self.get_flow_instr()
-        log_asmbloc.debug('flow mod %r' % flow_mod_instr)
+        log_asmbloc.debug('flow mod %r', flow_mod_instr)
         c = asm_constraint(l, asm_constraint.c_next)
         # move dst if flowgraph modifier was in original bloc
         # (usecase: split delayslot bloc)
         if flow_mod_instr:
             for xx in self.bto:
-                log_asmbloc.debug('lbl %s' % xx)
+                log_asmbloc.debug('lbl %s', xx)
             c_next = set(
                 [x for x in self.bto if x.c_t == asm_constraint.c_next])
             c_to = [x for x in self.bto if x.c_t != asm_constraint.c_next]
@@ -367,7 +367,7 @@ def dis_bloc(mnemo, pool_bin, cur_bloc, offset, job_done, symbol_pool,
     delayslot_count = mnemo.delayslot
     offsets_to_dis = set()
     add_next_offset = False
-    log_asmbloc.debug("dis at %X" % int(offset))
+    log_asmbloc.debug("dis at %X", int(offset))
     while not in_delayslot or delayslot_count > 0:
         if in_delayslot:
             delayslot_count -= 1
@@ -395,13 +395,13 @@ def dis_bloc(mnemo, pool_bin, cur_bloc, offset, job_done, symbol_pool,
             instr = None
 
         if instr is None:
-            log_asmbloc.warning("cannot disasm at %X" % int(off_i))
+            log_asmbloc.warning("cannot disasm at %X", int(off_i))
             cur_bloc.add_cst(off_i, asm_constraint.c_bad, symbol_pool)
             break
 
         # XXX TODO nul start block option
         if dont_dis_nulstart_bloc and instr.b.count('\x00') == instr.l:
-            log_asmbloc.warning("reach nul instr at %X" % int(off_i))
+            log_asmbloc.warning("reach nul instr at %X", int(off_i))
             cur_bloc.add_cst(off_i, asm_constraint.c_bad, symbol_pool)
             break
 
@@ -411,7 +411,7 @@ def dis_bloc(mnemo, pool_bin, cur_bloc, offset, job_done, symbol_pool,
             break
 
         job_done.add(offset)
-        log_asmbloc.debug("dis at %X" % int(offset))
+        log_asmbloc.debug("dis at %X", int(offset))
 
         offset += instr.l
         log_asmbloc.debug(instr)
@@ -487,9 +487,9 @@ def split_bloc(mnemo, attrib, pool_bin, blocs,
                 continue
             l = symbol_pool.getby_offset_create(off)
             new_b = cb.split(off, l)
-            log_asmbloc.debug("split bloc %x" % off)
+            log_asmbloc.debug("split bloc %x", off)
             if new_b is None:
-                log_asmbloc.error("cannot split %x!!" % off)
+                log_asmbloc.error("cannot split %x!!", off)
                 break
             if dis_bloc_callback:
                 offsets_to_dis = set(
@@ -518,7 +518,7 @@ def dis_bloc_all(mnemo, pool_bin, offset, job_done, symbol_pool, dont_dis=[],
     while len(todo):
         bloc_cpt += 1
         if blocs_wd is not None and bloc_cpt > blocs_wd:
-            log_asmbloc.debug("blocs watchdog reached at %X" % int(offset))
+            log_asmbloc.debug("blocs watchdog reached at %X", int(offset))
             break
 
         n = int(todo.pop(0))
@@ -655,7 +655,7 @@ def guess_blocs_size(mnemo, blocs):
         b.blen = blen
         # bloc with max rel values encoded
         b.blen_max = blen + blen_max
-        log_asmbloc.info("blen: %d max: %d" % (b.blen, b.blen_max))
+        log_asmbloc.info("blen: %d max: %d", b.blen, b.blen_max)
 
 
 def group_blocs(blocs):
@@ -839,7 +839,7 @@ def resolve_symbol(group_bloc, symbol_pool, dont_erase=[],
                     if c.label == g:
                         tmp = free_interval[x] - g.total_max_l
                         log_asmbloc.debug(
-                            "consumed %d rest: %d" % (g.total_max_l, int(tmp)))
+                            "consumed %d rest: %d", g.total_max_l, int(tmp))
                         free_interval[g] = tmp
                         del free_interval[x]
                         symbol_pool.set_offset(
@@ -868,7 +868,7 @@ def resolve_symbol(group_bloc, symbol_pool, dont_erase=[],
                 g, AsmBlockLinkNext(group_bloc[k][-1].label))
             tmp = free_interval[k] - g.total_max_l
             log_asmbloc.debug(
-                "consumed %d rest: %d" % (g.total_max_l, int(tmp)))
+                "consumed %d rest: %d", g.total_max_l, int(tmp))
             free_interval[g] = tmp
             del free_interval[k]
 
@@ -884,7 +884,7 @@ def resolve_symbol(group_bloc, symbol_pool, dont_erase=[],
                 i += 1
                 continue
             resolving = True
-            log_asmbloc.info("bloc %s resolved" % unr_bloc[i].label)
+            log_asmbloc.info("bloc %s resolved", unr_bloc[i].label)
             bloc_list.append(unr_bloc[i])
             g_found = None
             for g in g_tab:

--- a/miasm2/core/cpu.py
+++ b/miasm2/core/cpu.py
@@ -654,12 +654,12 @@ class reg_noarg(object):
 
     def encode(self):
         if not self.expr in self.reg_info.expr:
-            log.debug("cannot encode reg %r" % self.expr)
+            log.debug("cannot encode reg %r", self.expr)
             return False
         self.value = self.reg_info.expr.index(self.expr)
         if self.value > self.lmask:
-            log.debug("cannot encode field value %x %x" %
-                      (self.value, self.lmask))
+            log.debug("cannot encode field value %x %x",
+                      self.value, self.lmask)
             return False
         return True
 
@@ -1132,9 +1132,8 @@ class cls_mn(object):
                     total_l += l
                     f.l = l
                     f.is_present = True
-                    log.debug("FIELD %s %s %s %s" % (f.__class__,
-                                                     f.fname,
-                                                     offset_b, l))
+                    log.debug("FIELD %s %s %s %s", f.__class__, f.fname,
+                              offset_b, l)
                     if bs_l * 8 - offset_b < l:
                         getok = False
                         break
@@ -1155,7 +1154,7 @@ class cls_mn(object):
                 if f.is_present:
                     ret = f.decode(todo[i])
                     if not ret:
-                        log.debug("cannot decode %r" % (f))
+                        log.debug("cannot decode %r", f)
                         break
 
             if not ret:
@@ -1237,7 +1236,7 @@ class cls_mn(object):
 
                     start, stop = f.fromstring(args_str, parsers[(i, start_i)])
                     if start != 0:
-                        log.debug("cannot fromstring %r" % (args_str))
+                        log.debug("cannot fromstring %r", args_str)
                         cannot_parse = True
                         break
                     if f.expr is None:
@@ -1310,7 +1309,7 @@ class cls_mn(object):
 
                 v = c.value(instr.mode)
                 if not v:
-                    log.debug("cannot encode %r" % (c))
+                    log.debug("cannot encode %r", c)
                     cannot_parse = True
                 if cannot_parse:
                     continue
@@ -1354,7 +1353,7 @@ class cls_mn(object):
             for i, f in to_decode[index:]:
                 ret = f.encode()
                 if not ret:
-                    log.debug('cannot encode %r' % f)
+                    log.debug('cannot encode %r', f)
                     can_encode = False
                     break
                 index += 1
@@ -1494,7 +1493,7 @@ class imm_noarg(object):
         else:
             raise TypeError('zarb expr')
         if self.expr is None:
-            log.debug('cannot fromstring int %r' % s)
+            log.debug('cannot fromstring int %r', s)
             return None, None
         return start, stop
 

--- a/miasm2/jitter/jitload.py
+++ b/miasm2/jitter/jitload.py
@@ -55,19 +55,19 @@ def named_arguments(func):
             ret_ad, arg_vals = func(self, len(args))
             arg_vals = namedtuple("args", args)(*arg_vals)
             # func_name(arguments) return address
-            log_func.info('%s(%s) ret addr: %s' % (
+            log_func.info('%s(%s) ret addr: %s',
                 whoami(),
                 ', '.join("%s=0x%x" % (field, value)
                           for field, value in arg_vals._asdict().iteritems()),
-                hex(ret_ad)))
+                hex(ret_ad))
             return ret_ad, namedtuple("args", args)(*arg_vals)
         else:
             ret_ad, arg_vals = func(self, args)
             # func_name(arguments) return address
-            log_func.info('%s(%s) ret addr: %s' % (
+            log_func.info('%s(%s) ret addr: %s',
                 whoami(),
                 ', '.join(hex(arg) for arg in arg_vals),
-                hex(ret_ad)))
+                hex(ret_ad))
             return ret_ad, arg_vals
     return newfunc
 
@@ -404,7 +404,7 @@ class jitter:
         if fname in jitter.user_globals:
             func = jitter.user_globals[fname]
         else:
-            log.debug('%s' % repr(fname))
+            log.debug('%r', fname)
             raise ValueError('unknown api', hex(jitter.pc), repr(fname))
         func(jitter)
         jitter.pc = getattr(jitter.cpu, jitter.ir_arch.pc.name)

--- a/miasm2/jitter/loader/elf.py
+++ b/miasm2/jitter/loader/elf.py
@@ -40,8 +40,7 @@ def preload_elf(vm, e, runtime_lib, patch_vm_imp=True):
             libname_s = canon_libname_libfunc(libname, libfunc)
             dyn_funcs[libname_s] = ad_libfunc
             if patch_vm_imp:
-                log.debug('patch %s %s %s' %
-                          (hex(ad), hex(ad_libfunc), libfunc))
+                log.debug('patch 0x%x 0x%x %s', ad, ad_libfunc, libfunc)
                 vm.set_mem(
                     ad, struct.pack(cstruct.size2type[e.size], ad_libfunc))
     return runtime_lib, dyn_funcs
@@ -60,8 +59,8 @@ def vm_load_elf(vm, fdata, **kargs):
     for p in e.ph.phlist:
         if p.ph.type != 1:
             continue
-        log.debug('%s %s %s %s' %
-                  (hex(p.ph.vaddr), hex(p.ph.memsz), hex(p.ph.offset), hex(p.ph.filesz)))
+        log.debug('0x%x 0x%x 0x%x 0x%x', p.ph.vaddr, p.ph.memsz, p.ph.offset,
+                  p.ph.filesz)
         data_o = e._content[p.ph.offset:p.ph.offset + p.ph.filesz]
         addr_o = p.ph.vaddr
         a_addr = addr_o & ~0xFFF

--- a/miasm2/jitter/loader/pe.py
+++ b/miasm2/jitter/loader/pe.py
@@ -170,8 +170,8 @@ def vm_load_pe(vm, fdata, align_s=True, load_hdr=True, **kargs):
 
     min_addr = pe.rva2virt(min_addr)
     max_addr = pe.rva2virt(max_addr)
-    log.debug('Min: 0x%x, Max: 0x%x, Size: 0x%x' % (min_addr, max_addr,
-                                                    (max_addr - min_addr)))
+    log.debug('Min: 0x%x, Max: 0x%x, Size: 0x%x', min_addr, max_addr,
+              (max_addr - min_addr))
 
     # Create only one big section containing the whole PE
     vm.add_memory_page(min_addr,
@@ -180,7 +180,8 @@ def vm_load_pe(vm, fdata, align_s=True, load_hdr=True, **kargs):
 
     # Copy each sections content in memory
     for section in pe.SHList:
-        log.debug('Map 0x%x bytes to 0x%x' % (len(section.data), pe.rva2virt(section.addr)))
+        log.debug('Map 0x%x bytes to 0x%x', len(section.data),
+                  pe.rva2virt(section.addr))
         vm.set_mem(pe.rva2virt(section.addr), str(section.data))
 
     return pe
@@ -245,7 +246,7 @@ def vm2pe(myjit, fname, libs=None, e_orig=None,
     for ad in addrs:
         if not min_addr <= ad < max_addr:
             continue
-        log.debug('%s' % hex(ad))
+        log.debug("0x%x", ad)
         if first:
             mye.SHList.add_section(
                 "%.8X" % ad,
@@ -270,18 +271,18 @@ def vm2pe(myjit, fname, libs=None, e_orig=None,
     else:
         new_dll = {}
 
-    log.debug('%s' % new_dll)
+    log.debug('%s', new_dll)
 
     mye.DirImport.add_dlldesc(new_dll)
     s_imp = mye.SHList.add_section("import", rawsize=len(mye.DirImport))
     mye.DirImport.set_rva(s_imp.addr)
-    log.debug('%s' % repr(mye.SHList))
+    log.debug('%r', mye.SHList)
     if e_orig:
         # resource
         xx = str(mye)
         mye.content = xx
         ad = e_orig.NThdr.optentries[pe.DIRECTORY_ENTRY_RESOURCE].rva
-        log.debug('dirres %s' % hex(ad))
+        log.debug('dirres 0x%x', ad)
         if ad != 0:
             mye.NThdr.optentries[pe.DIRECTORY_ENTRY_RESOURCE].rva = ad
             mye.DirRes = pe.DirRes.unpack(xx, ad, mye)
@@ -289,7 +290,7 @@ def vm2pe(myjit, fname, libs=None, e_orig=None,
             s_res = mye.SHList.add_section(
                 name="myres", rawsize=len(mye.DirRes))
             mye.DirRes.set_rva(s_res.addr)
-            log.debug('%s' % repr(mye.DirRes))
+            log.debug('%r', mye.DirRes)
     # generation
     open(fname, 'w').write(str(mye))
     return mye
@@ -303,7 +304,7 @@ class libimp_pe(libimp):
         if name in self.name2off:
             ad = self.name2off[name]
         else:
-            log.debug('new lib %s' % name)
+            log.debug('new lib %s', name)
             ad = e.NThdr.ImageBase
             libad = ad
             self.name2off[name] = ad
@@ -371,7 +372,7 @@ class libimp_pe(libimp):
 
             # Filter available addresses according to @flt
             all_ads = [addr for addr in out_ads.keys() if flt(addr)]
-            log.debug('ads: %s' % map(hex, all_ads))
+            log.debug('ads: %s', map(hex, all_ads))
             if not all_ads:
                 continue
 

--- a/miasm2/jitter/loader/utils.py
+++ b/miasm2/jitter/loader/utils.py
@@ -32,13 +32,13 @@ class libimp:
         if not "." in name:
             log.debug('warning adding .dll to modulename')
             name += '.dll'
-            log.debug('%s' % name)
+            log.debug(name)
 
         if name in self.name2off:
             ad = self.name2off[name]
         else:
             ad = self.libbase_ad
-            log.debug('new lib %s %s' % (name, hex(ad)))
+            log.debug('new lib %s 0x%x', name, ad)
             self.name2off[name] = ad
             self.libbase2lastad[ad] = ad + 0x1
             self.lib_imp2ad[ad] = {}

--- a/miasm2/os_dep/win_api_x86_32.py
+++ b/miasm2/os_dep/win_api_x86_32.py
@@ -403,7 +403,7 @@ def advapi32_CryptAcquireContext(jitter, funcname, get_str):
                                              "pszprovider", "dwprovtype",
                                              "dwflags"])
     prov = get_str(jitter, args.pszprovider) if args.pszprovider else "NONE"
-    log.debug('prov: %r' % prov)
+    log.debug('prov: %r', prov)
     jitter.vm.set_mem(args.phprov, pck32(winobjs.cryptcontext_hwnd))
     jitter.func_ret_stdcall(ret_ad, 1)
 
@@ -455,7 +455,7 @@ def advapi32_CryptHashData(jitter):
         raise ValueError("unknown crypt context")
 
     data = jitter.vm.get_mem(args.pbdata, args.dwdatalen)
-    log.debug('will hash %X' % args.dwdatalen)
+    log.debug('will hash %X', args.dwdatalen)
     log.debug(repr(data[:10]) + "...")
     winobjs.cryptcontext[args.hhash].h.update(data)
     jitter.func_ret_stdcall(ret_ad, 1)
@@ -493,7 +493,7 @@ def advapi32_CryptDeriveKey(jitter):
     else:
         raise ValueError('un impl algo2')
     h = winobjs.cryptcontext[args.hbasedata].h.digest()
-    log.debug('hash %r'% h)
+    log.debug('hash %r', h)
     winobjs.cryptcontext[args.hbasedata].h_result = h
     jitter.vm.set_mem(args.phkey, pck32(args.hbasedata))
     jitter.func_ret_stdcall(ret_ad, 1)
@@ -520,7 +520,7 @@ def kernel32_CreateFile(jitter, funcname, get_str):
                                              "dwflagsandattr",
                                              "htemplatefile"])
     fname = get_str(jitter, args.lpfilename)
-    log.debug('fname %s' % fname)
+    log.debug('fname %s', fname)
     fname_o = fname[:]
     ret = 0xffffffff
 
@@ -532,7 +532,7 @@ def kernel32_CreateFile(jitter, funcname, get_str):
     else:
         f = fname_o
     """
-    log.debug("%r %r"%(f.lower(), winobjs.module_path.lower()))
+    log.debug("%r %r", f.lower(), winobjs.module_path.lower())
     is_original_file = f.lower() == winobjs.module_path.lower()
 
     if fname.upper() in [r"\\.\SICE", r"\\.\NTICE", r"\\.\SIWVID"]:
@@ -564,7 +564,7 @@ def kernel32_CreateFile(jitter, funcname, get_str):
                         h = open(f, 'r+b')
                         ret = winobjs.handle_pool.add(f, h)
                 else:
-                    log.warning("FILE %r DOES NOT EXIST!" % fname)
+                    log.warning("FILE %r DOES NOT EXIST!", fname)
             elif args.dwcreationdisposition == 1:
                 # create new
                 if os.access(f, os.R_OK):
@@ -620,7 +620,7 @@ def kernel32_CreateFile(jitter, funcname, get_str):
 
         # h = open(f, 'rb+')
         # ret = winobjs.handle_pool.add(f, h)
-    log.debug('ret %x' % ret)
+    log.debug('ret %x', ret)
     jitter.func_ret_stdcall(ret_ad, ret)
 
 
@@ -752,7 +752,7 @@ def kernel32_VirtualAlloc(jitter):
             jitter.vm.add_memory_page(
                 alloc_addr, access_dict[args.flprotect], "\x00" * args.dwsize)
 
-    log.debug('Memory addr: %x' %alloc_addr)
+    log.debug('Memory addr: %x', alloc_addr)
     jitter.func_ret_stdcall(ret_ad, alloc_addr)
 
 
@@ -783,7 +783,7 @@ def kernel32_GetModuleFileName(jitter, funcname, set_str):
         p = name_inv[args.hmodule]
     else:
         log.warning(('Unknown module 0x%x.' + \
-                        'Set winobjs.hcurmodule and retry') % args.hmodule)
+                        'Set winobjs.hcurmodule and retry'), args.hmodule)
         p = None
 
     if p is None:
@@ -893,7 +893,7 @@ def kernel32_LoadLibraryA(jitter):
     log.info(libname)
 
     ret = winobjs.runtime_dll.lib_get_add_base(libname)
-    log.info("ret %x" %ret)
+    log.info("ret %x", ret)
     jitter.func_ret_stdcall(ret_ad, ret)
 
 
@@ -906,7 +906,7 @@ def kernel32_LoadLibraryExA(jitter):
     log.info(libname)
 
     ret = winobjs.runtime_dll.lib_get_add_base(libname)
-    log.info("ret %x" % ret)
+    log.info("ret %x", ret)
     jitter.func_ret_stdcall(ret_ad, ret)
 
 
@@ -1525,11 +1525,11 @@ def my_GetEnvironmentVariable(jitter, funcname, get_str, set_str, mylen):
     s = get_str(jitter, args.lpname)
     if get_str == get_str_unic:
         s = s
-    log.debug('variable %r' % s)
+    log.debug('variable %r', s)
     if s in winobjs.env_variables:
         v = set_str(winobjs.env_variables[s])
     else:
-        log.warning('WARNING unknown env variable %r' % s)
+        log.warning('WARNING unknown env variable %r', s)
         v = ""
     jitter.vm.set_mem(args.lpbuffer, v)
     jitter.func_ret_stdcall(ret_ad, mylen(v))
@@ -1946,7 +1946,7 @@ def user32_IsCharAlpha(jitter, funcname, get_str):
     try:
         c = chr(args.c)
     except:
-        log.error('bad char %r' % args.c)
+        log.error('bad char %r', args.c)
         c = "\x00"
     if c.isalpha(jitter):
         ret = 1
@@ -2214,7 +2214,7 @@ def kernel32_MapViewOfFile(jitter):
     data = fd.read(args.length) if args.length else args.read()
     length = len(data)
 
-    log.debug('mapp total: %x' %len(data))
+    log.debug('mapp total: %x', len(data))
     access_dict = {0x0: 0,
                    0x1: 0,
                    0x2: PAGE_READ,
@@ -2541,7 +2541,7 @@ def user32_MessageBoxA(jitter):
     text = get_str_ansi(jitter, args.lptext)
     caption = get_str_ansi(jitter, args.lpcaption)
 
-    log.info('Caption: %r Text: %r' % (caption, text))
+    log.info('Caption: %r Text: %r', caption, text)
 
     jitter.func_ret_stdcall(ret_ad, 0)
 

--- a/miasm2/os_dep/win_api_x86_32_seh.py
+++ b/miasm2/os_dep/win_api_x86_32_seh.py
@@ -861,13 +861,13 @@ def return_from_seh(myjit):
 
     # Get current context
     myjit.cpu.ESP = upck32(myjit.vm.get_mem(context_address + 0xc4, 4))
-    logging.info('-> new esp: %x' % myjit.cpu.ESP)
+    logging.info('-> new esp: %x', myjit.cpu.ESP)
 
     # Rebuild SEH
     old_seh = upck32(myjit.vm.get_mem(tib_address, 4))
     new_seh = upck32(myjit.vm.get_mem(old_seh, 4))
-    logging.info('-> old seh: %x' % old_seh)
-    logging.info('-> new seh: %x' % new_seh)
+    logging.info('-> old seh: %x', old_seh)
+    logging.info('-> new seh: %x', new_seh)
     myjit.vm.set_mem(tib_address, pck32(new_seh))
 
     dump_seh(myjit)
@@ -888,7 +888,7 @@ def return_from_seh(myjit):
         for reg_name, reg_value in regs.items():
             setattr(myjit.cpu, reg_name, reg_value)
 
-        logging.info('-> context::Eip: %x' % myjit.pc)
+        logging.info('-> context::Eip: %x', myjit.pc)
 
     elif myjit.cpu.EAX == -1:
         raise NotImplementedError("-> seh try to go to the next handler")


### PR DESCRIPTION
In Python, the pattern:
```Python
log.info("my %s format %x string" % ("little", 4))
```
Can be re-written (avoiding an unnecessary pre-computing of format string):
```Python
log.info("my %s format %x string", "little", 4)
```

See [PyLint logging-not-lazy](http://docs.pylint.org/features.html) and [PEP 0282](https://www.python.org/dev/peps/pep-0282/) for more information.