### PR TITLE
Test "do not suppr" option

### DIFF
--- a/test/test_all.py
+++ b/test/test_all.py
@@ -138,8 +138,9 @@ testset += RegressionTest(["depgraph.py"], base_dir="analysis",
                                     "graph_test_09_00.dot",
                                     "graph_test_09_01.dot",
                                     "graph_test_10_00.dot",
+                                    "graph_test_11_00.dot",
                                     ] + ["graph_%02d.dot" % test_nb
-                                         for test_nb in xrange(1, 11)])
+                                         for test_nb in xrange(1, 12)])
 
 # Examples
 class Example(Test):

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -371,6 +371,8 @@ if __name__ == "__main__":
     parser.add_argument("-t", "--ommit-tags", help="Ommit tests based on tags \
 (tag1,tag2). Available tags are %s. \
 By default, no tag is ommited." % ", ".join(TAGS.keys()), default="")
+    parser.add_argument("-n", "--do-not-clean",
+                        help="Do not clean tests products", action="store_true")
     args = parser.parse_args()
 
     ## Parse multiproc argument
@@ -470,6 +472,9 @@ By default, no tag is ommited." % ", ".join(TAGS.keys()), default="")
 
     # Run tests
     testset.run()
+
+    # Finalize
+    testset.end(clean=not args.do_not_clean)
 
     # Exit with an error if at least a test failed
     exit(testset.tests_passed())

--- a/test/utils/testset.py
+++ b/test/utils/testset.py
@@ -208,7 +208,7 @@ class TestSet(object):
         "Launch tests"
 
         # Go in the right directory
-        current_directory = os.getcwd()
+        self.current_directory = os.getcwd()
         os.chdir(self.base_dir)
 
         # Launch workers
@@ -237,11 +237,17 @@ class TestSet(object):
         for p in processes:
             p.join()
 
+    def end(self, clean=True):
+        """End a testset run
+        @clean: (optional) if set, remove tests products
+        PRE: run()
+        """
         # Clean
-        self._clean()
+        if clean:
+            self._clean()
 
         # Restore directory
-        os.chdir(current_directory)
+        os.chdir(self.current_directory)
 
     def tests_passed(self):
         "Return a non zero value if at least one test failed"

--- a/test/utils/testset.py
+++ b/test/utils/testset.py
@@ -10,20 +10,20 @@ class Message(object):
     pass
 
 
-class MessageTaskNew(object):
+class MessageTaskNew(Message):
     "Stand for a new task"
     def __init__(self, task):
         self.task = task
 
 
-class MessageTaskDone(object):
+class MessageTaskDone(Message):
     "Stand for a task done"
     def __init__(self, task, error):
         self.task = task
         self.error = error
 
 
-class MessageClose(object):
+class MessageClose(Message):
     "Close the channel"
     pass
 

--- a/test/utils/testset.py
+++ b/test/utils/testset.py
@@ -76,7 +76,7 @@ class TestSet(object):
         if task_new:
             self.task_new_cb = task_new
 
-    def add_tasks(self):
+    def _add_tasks(self):
         "Add tests to do, regarding to dependencies"
         for test in self.tests:
             # Check dependencies
@@ -100,7 +100,7 @@ class TestSet(object):
         if len(self.tests_done) == self.init_tests_number:
             self.message_queue.put(MessageClose())
 
-    def messages_handler(self):
+    def _messages_handler(self):
         "Manage message between Master and Workers"
 
         # Main loop
@@ -115,7 +115,7 @@ class TestSet(object):
             elif isinstance(message, MessageTaskDone):
                 # A task has been done
                 self.tests_done.append(message.task)
-                self.add_tasks()
+                self._add_tasks()
                 self.task_done_cb(message.task, message.error)
                 if message.error is not None:
                     self.errorcode = -1
@@ -179,7 +179,7 @@ class TestSet(object):
             result.append(item)
         return result
 
-    def clean(self):
+    def _clean(self):
         "Remove produced files"
 
         # Build the list of products
@@ -224,10 +224,10 @@ class TestSet(object):
         # Add initial tasks
         self.init_tests_number = len(self.tests)
         # Initial tasks
-        self.add_tasks()
+        self._add_tasks()
 
         # Handle messages
-        self.messages_handler()
+        self._messages_handler()
 
         # Close queue and join processes
         self.todo_queue.close()
@@ -238,7 +238,7 @@ class TestSet(object):
             p.join()
 
         # Clean
-        self.clean()
+        self._clean()
 
         # Restore directory
         os.chdir(current_directory)


### PR DESCRIPTION
Add an option `--do-not-clean` in `test_all.py` to avoid cleaning tests products (use case: debugging sessions).