### PR TITLE
added z3 translation for call_func_ret

### DIFF
--- a/miasm2/ir/translators/z3_ir.py
+++ b/miasm2/ir/translators/z3_ir.py
@@ -170,6 +170,8 @@ class TranslatorZ3(Translator):
                     res = res << arg
                 elif expr.op == "idiv":
                     res = res / arg
+                elif expr.op == "call_func_ret":
+                    res = arg
                 else:
                     raise NotImplementedError("Unsupported OP yet: %s" % expr.op)
         elif expr.op == 'parity':


### PR DESCRIPTION
This allows reasoning about return values of function calls within a function.

For instance, foo(a) will return 1 if bar(a) returns 1335.
```
int foo(int a)
{
    if (bar(a) + 2 == 1337)
        return 1;
    return 0;
}
```