### PR TITLE
Fix expr hash

### DIFF
--- a/test/expression/expression.py
+++ b/test/expression/expression.py
@@ -1,0 +1,7 @@
+#
+# Expression regression tests  #
+#
+from pdb import pm
+from miasm2.expression.expression import *
+
+assert(ExprInt64(-1) != ExprInt64(-2))

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -105,6 +105,7 @@ for script in ["interval.py",
     testset += RegressionTest([script], base_dir="core")
 ## Expression
 for script in ["modint.py",
+               "expression.py",
                "stp.py",
                "simplifications.py",
                "expression_helper.py",


### PR DESCRIPTION
The expressions are compared using only hash, which is prone to collisions.
The PR keeps the use of the hash, but equality is done on the expression's representation. This is a bit weird but it seems there are no obvious solutions to this problem, including singleton pattern.