### PR TITLE
Fix uint

### DIFF
--- a/miasm2/expression/modint.py
+++ b/miasm2/expression/modint.py
@@ -4,9 +4,7 @@
 class moduint(object):
 
     def __init__(self, arg):
-        if isinstance(arg, moduint):
-            arg = arg.arg
-        self.arg = arg % self.__class__.limit
+        self.arg = long(arg) % self.__class__.limit
         assert(self.arg >= 0 and self.arg < self.__class__.limit)
 
     def __repr__(self):

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -198,7 +198,10 @@ to_test = [(ExprInt32(1) - ExprInt32(1), ExprInt32(0)),
     (ExprCompose([(f[:32], 0, 32), (ExprInt32(0), 32, 64)]) | ExprCompose([(ExprInt32(0), 0, 32), (f[32:], 32, 64)]),
      f),
     ((ExprCompose([(a, 0, 32), (ExprInt32(0), 32, 64)]) * ExprInt64(0x123))[32:64],
-     (ExprCompose([(a, 0, 32), (ExprInt32(0), 32, 64)]) * ExprInt64(0x123))[32:64])
+     (ExprCompose([(a, 0, 32), (ExprInt32(0), 32, 64)]) * ExprInt64(0x123))[32:64]),
+
+    (ExprInt32(0x12),
+     ExprInt32(0x12L))
 
 
 ]


### PR DESCRIPTION
`ExprInt` uses a `modint`as argument.
This modint can take an int or a long, which change its representation so:
Exprint(0x32) != ExprInt(0x32L)
This fix ensure `modint` argument is always a long

The bug is trigger by the actual regression tests on some 32 bit systems.
Add a dedicated regression tess