### PR TITLE
Jitter: fix cast for 32 bits machines

### DIFF
--- a/miasm2/jitter/arch/JitCore_arm.c
+++ b/miasm2/jitter/arch/JitCore_arm.c
@@ -165,7 +165,7 @@ PyObject* cpu_get_exception(JitCpu* self, PyObject* args)
 
 
 
-void check_automod(JitCpu* jitcpu, uint64_t addr, int size)
+void check_automod(JitCpu* jitcpu, uint64_t addr, uint64_t size)
 {
 	PyObject *result;
 

--- a/miasm2/jitter/arch/JitCore_mips32.c
+++ b/miasm2/jitter/arch/JitCore_mips32.c
@@ -209,7 +209,7 @@ PyObject* cpu_get_exception(JitCpu* self, PyObject* args)
 
 
 
-void check_automod(JitCpu* jitcpu, uint64_t addr, int size)
+void check_automod(JitCpu* jitcpu, uint64_t addr, uint64_t size)
 {
 	PyObject *result;
 

--- a/miasm2/jitter/arch/JitCore_msp430.c
+++ b/miasm2/jitter/arch/JitCore_msp430.c
@@ -182,7 +182,7 @@ PyObject* cpu_get_exception(JitCpu* self, PyObject* args)
 
 
 
-void check_automod(JitCpu* jitcpu, uint64_t addr, int size)
+void check_automod(JitCpu* jitcpu, uint64_t addr, uint64_t size)
 {
 	PyObject *result;
 

--- a/miasm2/jitter/arch/JitCore_x86.c
+++ b/miasm2/jitter/arch/JitCore_x86.c
@@ -307,7 +307,7 @@ IMOD(64)
 
 
 
-void check_automod(JitCpu* jitcpu, uint64_t addr, int size)
+void check_automod(JitCpu* jitcpu, uint64_t addr, uint64_t size)
 {
 	PyObject *result;
 


### PR DESCRIPTION
On 32 bit systems, the high bytes of `size` are not set to 0 to generate random argument to be send to `automod_cb`, so generate a random behaviour in regression tests.

Fix every architectures.