### PR TITLE
Depgraph z3

### DIFF
--- a/example/symbol_exec/depgraph.py
+++ b/example/symbol_exec/depgraph.py
@@ -4,6 +4,7 @@ from pdb import pm
 from miasm2.analysis.machine import Machine
 from miasm2.analysis.binary import Container
 from miasm2.analysis.depgraph import DependencyGraph
+from miasm2.expression.expression import ExprMem, ExprId, ExprInt32
 
 parser = ArgumentParser("Dependency grapher")
 parser.add_argument("filename", help="Binary to analyse")
@@ -19,6 +20,9 @@ parser.add_argument("--unfollow-mem", help="Stop on memory statements",
 parser.add_argument("--unfollow-call", help="Stop on call statements",
 		    action="store_true")
 parser.add_argument("--do-not-simplify", help="Do not simplify expressions",
+		    action="store_true")
+parser.add_argument("--rename-args",
+                    help="Rename common arguments (@32[ESP_init] -> Arg1)",
 		    action="store_true")
 args = parser.parse_args()
 
@@ -40,6 +44,15 @@ for element in args.element:
 
 mdis = machine.dis_engine(cont.bin_stream, dont_dis_nulstart_bloc=True)
 ir_arch = machine.ira(mdis.symbol_pool)
+
+# Common argument forms
+init_ctx = {}
+if args.rename_args:
+    if arch == "x86_32":
+        # StdCall example
+        for i in xrange(4):
+            e_mem = ExprMem(ExprId("ESP_init") + ExprInt32(4 * (i + 1)), 32)
+            init_ctx[e_mem] = ExprId("arg%d" % i)
 
 # Disassemble the targeted function
 blocks = mdis.dis_multibloc(int(args.func_addr, 16))
@@ -71,7 +84,7 @@ for sol_nb, sol in enumerate(dg.get(current_block.label, elements, line_nb, set(
 	with open(fname, "w") as fdesc:
 		fdesc.write(sol.graph.dot())
 	result = ", ".join("%s: %s" % (k, v)
-			   for k, v in sol.emul().iteritems())
+			   for k, v in sol.emul(ctx=init_ctx).iteritems())
 	print "Solution %d: %s -> %s" % (sol_nb,
 					 result,
 					 fname)
@@ -81,5 +94,5 @@ for sol_nb, sol in enumerate(dg.get(current_block.label, elements, line_nb, set(
             if sat:
                 constraints = {}
                 for element in sol.constraints:
-                    constraints[element] = sol.constraints[element]
+                    constraints[element] = hex(sol.constraints[element].as_long())
             print "\tSatisfiability: %s %s" % (sat, constraints)

--- a/example/symbol_exec/depgraph.py
+++ b/example/symbol_exec/depgraph.py
@@ -75,3 +75,11 @@ for sol_nb, sol in enumerate(dg.get(current_block.label, elements, line_nb, set(
 	print "Solution %d: %s -> %s" % (sol_nb,
 					 result,
 					 fname)
+        if args.implicit:
+            sat = sol.is_satisfiable
+            constraints = ""
+            if sat:
+                constraints = {}
+                for element in sol.constraints:
+                    constraints[element] = sol.constraints[element]
+            print "\tSatisfiability: %s %s" % (sat, constraints)

--- a/miasm2/analysis/depgraph.py
+++ b/miasm2/analysis/depgraph.py
@@ -346,13 +346,18 @@ class DependencyResult(object):
     def input(self):
         return self._input_depnodes
 
-    def emul(self, step=False):
+    def emul(self, ctx=None, step=False):
         """Symbolic execution of relevant nodes according to the history
         Return the values of input nodes' elements
+        @ctx: (optional) Initial context as dictionnary
+        @step: (optional) Verbose execution
 
         /!\ The emulation is not safe if there is a loop in the relevant labels
         """
         # Init
+        ctx_init = self._ira.arch.regs.regs_init
+        if ctx is not None:
+            ctx_init.update(ctx)
         depnodes = self.relevant_nodes
         affects = []
 
@@ -366,7 +371,7 @@ class DependencyResult(object):
 
         # Eval the block
         temp_label = asm_label("Temp")
-        sb = symbexec(self._ira, self._ira.arch.regs.regs_init)
+        sb = symbexec(self._ira, ctx_init)
         sb.emulbloc(irbloc(temp_label, affects), step=step)
 
         # Return only inputs values (others could be wrongs)

--- a/miasm2/analysis/depgraph.py
+++ b/miasm2/analysis/depgraph.py
@@ -2,7 +2,10 @@
 import itertools
 from collections import namedtuple
 
-import z3
+try:
+    import z3
+except ImportError:
+    pass
 
 import miasm2.expression.expression as m2_expr
 from miasm2.core.graph import DiGraph

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -322,7 +322,7 @@ class ExampleSymbolExec(Example):
 
 testset += ExampleSymbolExec(["single_instr.py"])
 for options, nb_sol in [([], 8),
-                        (["-i"], 12)]:
+                        (["-i", "--rename-args"], 12)]:
     testset += ExampleSymbolExec(["depgraph.py",
                                   Example.get_sample("simple_test.bin"),
                                   "-m", "x86_32", "0x0", "0x8b",

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -321,15 +321,15 @@ class ExampleSymbolExec(Example):
 
 
 testset += ExampleSymbolExec(["single_instr.py"])
-for options, nb_sol in [([], 8),
-                        (["-i", "--rename-args"], 12)]:
+for options, nb_sol, tag in [([], 8, []),
+                             (["-i", "--rename-args"], 12, [TAGS["z3"]])]:
     testset += ExampleSymbolExec(["depgraph.py",
                                   Example.get_sample("simple_test.bin"),
                                   "-m", "x86_32", "0x0", "0x8b",
                                   "eax"] + options,
                                  products=["sol_%d.dot" % nb
-                                           for nb in xrange(nb_sol)])
-
+                                           for nb in xrange(nb_sol)],
+                                 tags=tag)
 
 ## Jitter
 class ExampleJitter(Example):


### PR DESCRIPTION
Finalize the PR #148. Add a binding with z3 to retrieve constraints on solutions paths and try to solve them.

For instance, giving `samples/simple_test.c`:
```
$ python symbol_exec/depgraph.py samples/simple_test.bin -i --rename-args -m x86_32 0x0 0x8B eax

Solution 0: EAX: 0x1005 -> sol_0.dot
	Satisfiability: True {arg0: '0x7', EBP_init: '0x88'}
Solution 1: EAX: 0x1005 -> sol_1.dot
	Satisfiability: False 
Solution 2: EAX: 0x1001 -> sol_2.dot
	Satisfiability: True {arg0: '0x0', EBP_init: '0x88'}
Solution 3: EAX: 0x1007 -> sol_3.dot
	Satisfiability: False 
Solution 4: EAX: 0x1007 -> sol_4.dot
	Satisfiability: True {arg0: '0x42', EBP_init: '0x88'}
Solution 5: EAX: 0x1008 -> sol_5.dot
	Satisfiability: False 
Solution 6: EAX: 0x1008 -> sol_6.dot
	Satisfiability: True {EBP_init: '0x88', arg0: '0x40000005'}
Solution 7: EAX: 0x1004 -> sol_7.dot
	Satisfiability: True {arg0: '0x80000007', EBP_init: '0x88'}
Solution 8: EAX: 0x1006 -> sol_8.dot
	Satisfiability: False 
Solution 9: EAX: 0x1006 -> sol_9.dot
	Satisfiability: True {EBP_init: '0x88', arg0: '0x25'}
Solution 10: EAX: 0x1002 -> sol_10.dot
	Satisfiability: True {EBP_init: '0x88', arg0: '0x1'}
Solution 11: EAX: 0x1003 -> sol_11.dot
	Satisfiability: True {EBP_init: '0x88', arg0: '0x5'}
```

In addition, the `DepGraph` implicit part has been rewritten to be easier to implement / understand (creds @serpilliere).