### PR TITLE
TestAll: Coverage mode was broken

### DIFF
--- a/test/test_all.py
+++ b/test/test_all.py
@@ -1,6 +1,7 @@
 import argparse
 import time
 import os
+import tempfile
 
 from utils.test import Test
 from utils.testset import TestSet

--- a/test/utils/testset.py
+++ b/test/utils/testset.py
@@ -202,7 +202,7 @@ class TestSet(object):
         """Add arguments to used on the test command line
         @args: list of str
         """
-        self.add_additionnal_args += args
+        self.additional_args += args
 
     def run(self):
         "Launch tests"


### PR DESCRIPTION
Fix the `--coverage` option of `test_all.py`.

For information, with the current test set, I obtain:

statements | missing | excluded | coverage
----|---|---|---
29330 | 8509 | 0 | 71%
