### PR TITLE
Add a link to the auto-generated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,10 @@ emulate library functions effects.
 
 Documentation
 =============
+
 TODO
+
+An auto-generated documentation is available [here](http://miasmdoc.ajax.re).
 
 Obtaining Miasm
 ===============


### PR DESCRIPTION
Add a link to http://miasmdoc.ajax.re (see #162).