### PR TITLE
Inits: Add docstring for main modules

### DIFF
--- a/miasm2/__init__.py
+++ b/miasm2/__init__.py
@@ -1,0 +1,1 @@
+"Reverse engineering framework in Python"

--- a/miasm2/analysis/__init__.py
+++ b/miasm2/analysis/__init__.py
@@ -1,0 +1,1 @@
+"High-level tools for binary analysis"

--- a/miasm2/arch/__init__.py
+++ b/miasm2/arch/__init__.py
@@ -1,0 +1,1 @@
+"Architecture implementations"

--- a/miasm2/core/__init__.py
+++ b/miasm2/core/__init__.py
@@ -1,0 +1,1 @@
+"Core components"

--- a/miasm2/expression/__init__.py
+++ b/miasm2/expression/__init__.py
@@ -16,3 +16,4 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+"Intermediate language implementation"

--- a/miasm2/ir/__init__.py
+++ b/miasm2/ir/__init__.py
@@ -1,0 +1,1 @@
+"Intermediate representation methods"

--- a/miasm2/jitter/__init__.py
+++ b/miasm2/jitter/__init__.py
@@ -1,0 +1,1 @@
+"JustInTime compilation feature"

--- a/miasm2/os_dep/__init__.py
+++ b/miasm2/os_dep/__init__.py
@@ -1,0 +1,1 @@
+"Operating System specific methods"


### PR DESCRIPTION
This PR adds a quick hint on modules behavior.

* `miasm2`: Reverse engineering framework in Python
* `miasm2.analysis`: High-level tools for binary analysis
* `miasm2.arch`: Architectures implementation
* `miasm2.core`: Miasm's core elements
* `miasm2.expression`: Intermediate language implementation
* `miasm2.ir`: Intermediate reprensentation methods
* `miasm2.jitter`: JIT feature
* `miasm2.os_dep`: Operating System dependent methods

May you have better definitions ?