### PR TITLE
Extend ExprOp and Z3 translation with If-Then-Else

### DIFF
--- a/miasm2/expression/expression.py
+++ b/miasm2/expression/expression.py
@@ -735,10 +735,19 @@ class ExprOp(Expr):
 
         if len(sizes) != 1:
             # Special cases : operande sizes can differ
-            if op not in ["segm"]:
+            if op not in ["segm", "ite"]:
                 raise ValueError(
                     "sanitycheck: ExprOp args must have same size! %s" %
                                  ([(str(arg), arg.size) for arg in args]))
+
+        if op in ["ite"]:
+            if len(args) != 3:
+                raise ValueError("sanitycheck: ExprOp 'ite' must have three args!")
+
+            elif args[1].size != args[2].size:
+                raise ValueError(
+                    "sanitycheck: ExprOp 'ite' args must have same size! %s" %
+                                 ([(str(arg), arg.size) for arg in args[1:]]))
 
         if not isinstance(op, str):
             raise ValueError("ExprOp: 'op' argument must be a string")
@@ -771,7 +780,7 @@ class ExprOp(Expr):
             sz = 64
         elif self._op in ['double_to_mem_80', 'double_to_int_80', 'double_trunc_to_int_80']:
             sz = 80
-        elif self._op in ['segm']:
+        elif self._op in ['segm', 'ite']:
             sz = self._args[1].size
         else:
             if None in sizes:

--- a/miasm2/ir/translators/z3_ir.py
+++ b/miasm2/ir/translators/z3_ir.py
@@ -169,6 +169,9 @@ class TranslatorZ3(Translator):
                     res = res << arg
                 elif expr.op == "idiv":
                     res = res / arg
+                elif expr.op == "ite":
+                    res = z3.If(args[0], args[1], args[2])
+                    break
                 else:
                     raise NotImplementedError("Unsupported OP yet: %s" % expr.op)
         elif expr.op == 'parity':


### PR DESCRIPTION
The idea behind this PR is to introduce a conditional expression in another context then ExprCond. The ExprOp ```ite``` intends to receive a condition and two expressions of the same size. The condition itself doesn't depend on the other expressions' size.

That allows it to make assignments as
```
x = ite(a + b = 7, y, z ) # x = (a + b == 7) ? y : z
```
or nested assignments as 
```
x  = (a == 1) ? b : ((a == 2) ? b : c)
```
and add them as contraints/implications to Z3.  

