### PR TITLE
Symbol pool error handling

### DIFF
--- a/miasm2/core/asmbloc.py
+++ b/miasm2/core/asmbloc.py
@@ -292,6 +292,8 @@ class asm_symbol_pool:
         Note that there is a special case when the offset is a list
         it happens when offsets are recomputed in resolve_symbol*
         """
+        if label is None:
+            raise ValueError('label should not be None')
         if not label.name in self._name2label:
             raise ValueError('label %s not in symbol pool' % label)
         if offset is not None and offset in self._offset2label:

--- a/miasm2/core/cpu.py
+++ b/miasm2/core/cpu.py
@@ -958,9 +958,8 @@ class instruction(object):
                 if not name in symbols:
                     continue
                 if symbols[name].offset is None:
-                    default_size = self.get_symbol_size(x, symbols)
-                    # default value
-                    value = m2_expr.ExprInt_fromsize(default_size, 0)
+                    raise ValueError('The offset of label "%s" cannot be '
+                                     'determined' % name)
                 else:
                     size = x.size
                     if size is None:


### PR DESCRIPTION
Hi,

This PR aims at improving error handling in two cases:

* When calling `symbol_pool.set_offset(None, offset)` (this could be extended to catch all cases where the first argument has no 'name' attribute), a more meaningful exception is raised.
* When assembling a block containing undefined labels (labels whose offsets are still equal to `None` when assembling). The previous behavior was to silently replace the labels offset with 0, which seems to be, in most cases, bug-prone. It now raises an exception (and it does not break the tests!).

Cheers,
Florent