### PR TITLE
Vm repr

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ RIP 0000000040000013
 Interacting with the jitter:
 
 ```
->>> jitter.vm.dump_memory_page_pool()
+>>> jitter.vm
 ad 1230000 size 10000 RW_ hpad 0x2854b40
 ad 40000000 size 16 RW_ hpad 0x25e0ed0
 

--- a/example/jitter/arm.py
+++ b/example/jitter/arm.py
@@ -22,7 +22,7 @@ else:
     logging.basicConfig(level=logging.WARNING)
 
 if options.verbose is True:
-    sb.jitter.vm.dump_memory_page_pool()
+    print sb.jitter.vm
 
 if options.address is None:
     raise ValueError('Invalid address')

--- a/example/jitter/unpack_upx.py
+++ b/example/jitter/unpack_upx.py
@@ -44,7 +44,7 @@ else:
     logging.basicConfig(level=logging.WARNING)
 
 if options.verbose is True:
-    sb.jitter.vm.dump_memory_page_pool()
+    print sb.jitter.vm
 
 
 ep = sb.entry_point
@@ -71,7 +71,7 @@ if options.graph is True:
 
 
 if options.verbose is True:
-    sb.jitter.vm.dump_memory_page_pool()
+    print sb.jitter.vm
 
 
 def update_binary(jitter):

--- a/miasm2/jitter/loader/elf.py
+++ b/miasm2/jitter/loader/elf.py
@@ -73,7 +73,6 @@ def vm_load_elf(vm, fdata, **kargs):
         #print hex(a), hex(b)
         vm.add_memory_page(a, PAGE_READ | PAGE_WRITE, "\x00"*(b+2-a))
 
-    #vm.dump_memory_page_pool()
 
     for r_vaddr, data in all_data.items():
         vm.set_mem(r_vaddr, data)

--- a/miasm2/jitter/vm_mngr.c
+++ b/miasm2/jitter/vm_mngr.c
@@ -132,7 +132,6 @@ struct memory_page_node * get_memory_page_from_address(vm_mngr_t* vm_mngr, uint6
 		return mpn;
 
 	fprintf(stderr, "WARNING: address 0x%"PRIX64" is not mapped in virtual memory:\n", ad);
-	//dump_memory_page_pool();
 	//dump_gpregs();
 	//exit(-1);
 	vm_mngr->exception_flags |= EXCEPT_ACCESS_VIOL;
@@ -146,7 +145,6 @@ struct memory_page_node * get_memory_page_from_address(vm_mngr_t* vm_mngr, uint6
 			return mpn;
 	}
 	fprintf(stderr, "WARNING: address 0x%"PRIX64" is not mapped in virtual memory:\n", ad);
-	//dump_memory_page_pool();
 	//dump_gpregs();
 	//exit(-1);
 	vm_mngr->exception_flags |= EXCEPT_ACCESS_VIOL;
@@ -214,7 +212,6 @@ static uint64_t memory_page_read(vm_mngr_t* vm_mngr, unsigned int my_size, uint6
 		unsigned int new_size = my_size;
 		int index = 0;
 		//fprintf(stderr, "read multiple page! %"PRIX64" %d\n", ad, new_size);
-		//dump_memory_page_pool(vm_mngr);
 		while (new_size){
 			mpn = get_memory_page_from_address(vm_mngr, ad);
 			if (!mpn)
@@ -299,7 +296,6 @@ static void memory_page_write(vm_mngr_t* vm_mngr, unsigned int my_size,
 	/* write is multiple page wide */
 	else{
 		//fprintf(stderr, "write multiple page! %"PRIX64" %d\n", ad, my_size);
-		//dump_memory_page_pool(vm_mngr);
 		switch(my_size){
 
 		case 8:
@@ -1488,20 +1484,43 @@ void add_memory_page(vm_mngr_t* vm_mngr, struct memory_page_node* mpn_a)
 
 }
 
-void dump_memory_page_pool(vm_mngr_t* vm_mngr)
+/*
+   Return a char* representing the repr of vm_mngr_t object
+*/
+char* dump(vm_mngr_t* vm_mngr)
 {
+	char buf[100];
+	int length;
+	int total_len = 0;
+	char *buf_final;
 	struct memory_page_node * mpn;
 
-	LIST_FOREACH(mpn, &vm_mngr->memory_page_pool, next){
-		printf("ad %"PRIX64" size %"PRIX64" %c%c%c hpad %p\n",
-		       mpn->ad,
-		       mpn->size,
-		       mpn->access & PAGE_READ? 'R':'_',
-		       mpn->access & PAGE_WRITE? 'W':'_',
-		       mpn->access & PAGE_EXEC? 'X':'_',
-		       mpn->ad_hp
-		       );
+	buf_final = malloc(1);
+	if (buf_final == NULL) {
+		printf("cannot alloc\n");
+		exit(0);
 	}
+	buf_final[0] = '\x00';
+	LIST_FOREACH(mpn, &vm_mngr->memory_page_pool, next){
+
+		length = snprintf(buf, sizeof(buf),
+				  "ad 0x%"PRIX64" size 0x%"PRIX64" %c%c%c\n",
+				  (uint64_t)mpn->ad,
+				  (uint64_t)mpn->size,
+				  mpn->access & PAGE_READ? 'R':'_',
+				  mpn->access & PAGE_WRITE? 'W':'_',
+				  mpn->access & PAGE_EXEC? 'X':'_'
+				  );
+		total_len += length+1;
+		buf_final = realloc(buf_final, total_len);
+		if (buf_final == NULL) {
+			printf("cannot alloc\n");
+			exit(0);
+		}
+		strcat(buf_final, buf);
+	}
+
+	return buf_final;
 }
 
 void dump_memory_breakpoint_pool(vm_mngr_t* vm_mngr)

--- a/miasm2/jitter/vm_mngr.h
+++ b/miasm2/jitter/vm_mngr.h
@@ -248,7 +248,7 @@ void add_memory_page(vm_mngr_t* vm_mngr, struct memory_page_node* mpn);
 void check_write_code_bloc(vm_mngr_t* vm_mngr, uint64_t my_size, uint64_t addr);
 
 
-void dump_memory_page_pool(vm_mngr_t* vm_mngr);
+char* dump(vm_mngr_t* vm_mngr);
 void dump_memory_breakpoint_pool(vm_mngr_t* vm_mngr);
 //PyObject* _vm_get_all_memory(void);
 PyObject* addr2BlocObj(vm_mngr_t* vm_mngr, uint64_t addr);

--- a/miasm2/jitter/vm_mngr_py.c
+++ b/miasm2/jitter/vm_mngr_py.c
@@ -353,16 +353,15 @@ PyObject* vm_reset_memory_breakpoint(VmMngr* self, PyObject* args)
 
 }
 
-
-
-
-
-
-PyObject* vm_dump_memory_page_pool(VmMngr* self, PyObject* args)
+PyObject *vm_dump(PyObject* self)
 {
-	dump_memory_page_pool(&self->vm_mngr);
-	Py_INCREF(Py_None);
-	return Py_None;
+	char* buf_final;
+	PyObject* ret_obj;
+
+	buf_final = dump(&((VmMngr* )self)->vm_mngr);
+	ret_obj = PyString_FromString(buf_final);
+	free(buf_final);
+	return ret_obj;
 }
 
 PyObject* vm_dump_memory_breakpoint(VmMngr* self, PyObject* args)
@@ -571,8 +570,6 @@ static PyMethodDef VmMngr_methods[] = {
 	 "X"},
 	{"set_exception", (PyCFunction)vm_set_exception, METH_VARARGS,
 	 "X"},
-	{"dump_memory_page_pool", (PyCFunction)vm_dump_memory_page_pool, METH_VARARGS,
-	 "X"},
 	{"dump_memory_breakpoint", (PyCFunction)vm_dump_memory_breakpoint, METH_VARARGS,
 	 "X"},
 	{"get_all_memory",(PyCFunction)vm_get_all_memory, METH_VARARGS,
@@ -613,7 +610,6 @@ static PyGetSetDef VmMngr_getseters[] = {
     {NULL}  /* Sentinel */
 };
 
-
 static PyTypeObject VmMngrType = {
     PyObject_HEAD_INIT(NULL)
     0,                         /*ob_size*/
@@ -625,7 +621,7 @@ static PyTypeObject VmMngrType = {
     0,                         /*tp_getattr*/
     0,                         /*tp_setattr*/
     0,                         /*tp_compare*/
-    0,                         /*tp_repr*/
+    vm_dump,                   /*tp_repr*/
     0,                         /*tp_as_number*/
     0,                         /*tp_as_sequence*/
     0,                         /*tp_as_mapping*/

--- a/miasm2/os_dep/win_api_x86_32.py
+++ b/miasm2/os_dep/win_api_x86_32.py
@@ -1675,7 +1675,6 @@ def ntdll_ZwProtectVirtualMemory(jitter):
     # XXX todo real old protect
     jitter.vm.set_mem(args.lpfloldprotect, pck32(0x40))
 
-    # dump_memory_page_pool_py()
     jitter.func_ret_stdcall(ret_ad, 1)
 
 
@@ -1709,7 +1708,6 @@ def ntdll_ZwAllocateVirtualMemory(jitter):
         alloc_addr, access_dict[args.flprotect], "\x00" * dwsize)
     jitter.vm.set_mem(args.lppvoid, pck32(alloc_addr))
 
-    # dump_memory_page_pool_py()
     jitter.func_ret_stdcall(ret_ad, 0)
 
 


### PR DESCRIPTION
The `vm_mngr` object has now a `repr` function, which replaces a call to `dump_memory_page_pool()`

:warning: This commit breaks `dump_memory_page_pool` API.

For instance: 
```
sb.jitter.vm.dump_memory_page_pool()
```
must be replaced by:
```
print sb.jitter.vm
```
