### PR TITLE
README: fixed elfesteem documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,8 +456,8 @@ Configuration
 
 * Install elfesteem
 ```
-hg clone https://code.google.com/p/elfesteem/
-cd elfesteem_directory
+git clone https://github.com/serpilliere/elfesteem.git elfesteem
+cd elfesteem
 python setup.py build
 sudo python setup.py install
 ```

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ Miasm uses:
 * or LLVM v3.2 with python-llvm, see below
 * python-pyparsing
 * python-dev
-* elfesteem from [Elfesteem](http://code.google.com/p/elfesteem/)
+* elfesteem from [Elfesteem](https://github.com/serpilliere/elfesteem.git)
 
 Configuration
 -------------


### PR DESCRIPTION
elfesteem from google code doesn't work any longer with the new aarch64 support. So, I updated the README.md with the contents of the travis file.