### PR TITLE
Expression: move is_func_call to expr scr

### DIFF
--- a/miasm2/expression/expression.py
+++ b/miasm2/expression/expression.py
@@ -517,9 +517,6 @@ class ExprAff(Expr):
         else:
             return self._dst.get_w()
 
-    def is_function_call(self):
-        return isinstance(self.src, ExprOp) and self.src.op.startswith('call')
-
     def _exprhash(self):
         return hash((EXPRAFF, hash(self._dst), hash(self._src)))
 
@@ -820,6 +817,9 @@ class ExprOp(Expr):
             if arg.__contains__(e):
                 return True
         return False
+
+    def is_function_call(self):
+        return self._op.startswith('call')
 
     def is_associative(self):
         "Return True iff current operation is associative"

--- a/miasm2/ir/analysis.py
+++ b/miasm2/ir/analysis.py
@@ -167,7 +167,7 @@ class ira:
             # Function call, memory write or IRDst affectation
             for k, ir in enumerate(block.irs):
                 for i_cur in ir:
-                    if i_cur.is_function_call():
+                    if i_cur.src.is_function_call():
                         # /!\ never remove ir calls
                         useful.add((block.label, k, i_cur))
                     if isinstance(i_cur.dst, ExprMem):


### PR DESCRIPTION
:warning: API change: `is_func_call` is now linked to an `ExprOp` instead of an `ExprAff`
`Depgraph.py` is not changed because it *already* relies on this new behaviour.