### PR TITLE
Optimize jitter execution time

### DIFF
--- a/miasm2/core/utils.py
+++ b/miasm2/core/utils.py
@@ -75,7 +75,7 @@ class BoundedDict(UserDict.DictMixin):
         self._max_size = max_size
         self._size = len(self._data)
         # Do not use collections.Counter as it is quite slow
-        self._counter = dict((k, 1) for k in self._data.iterkeys())
+        self._counter = {k: 1 for k in self._data}
         self._delete_cb = delete_cb
 
     def __setitem__(self, asked_key, value):
@@ -99,7 +99,7 @@ class BoundedDict(UserDict.DictMixin):
                 self._size = self._min_size
 
                 # Reset use's counter
-                self._counter = dict((k, 1) for k in self._data.iterkeys())
+                self._counter = {k: 1 for k in self._data}
 
             # Avoid rechecking in dict: set to 1 here, add 1 otherwise
             self._counter[asked_key] = 1

--- a/miasm2/core/utils.py
+++ b/miasm2/core/utils.py
@@ -1,6 +1,7 @@
 import struct
 import inspect
 import UserDict
+from operator import itemgetter
 
 upck8 = lambda x: struct.unpack('B', x)[0]
 upck16 = lambda x: struct.unpack('H', x)[0]
@@ -73,7 +74,8 @@ class BoundedDict(UserDict.DictMixin):
         self._min_size = min_size if min_size else max_size / 3
         self._max_size = max_size
         self._size = len(self._data)
-        self._counter = collections.Counter(self._data.keys())
+        # Do not use collections.Counter as it is quite slow
+        self._counter = dict((k, 1) for k in self._data.iterkeys())
         self._delete_cb = delete_cb
 
     def __setitem__(self, asked_key, value):
@@ -83,31 +85,46 @@ class BoundedDict(UserDict.DictMixin):
 
             # Bound can only be reached on a new element
             if (self._size >= self._max_size):
-                most_commons = [key for key, _ in self._counter.most_common()]
+                most_common = sorted(self._counter.iteritems(),
+                                     key=itemgetter(1), reverse=True)
 
                 # Handle callback
                 if self._delete_cb is not None:
-                    for key in most_commons[self._min_size - 1:]:
+                    for key, _ in most_common[self._min_size - 1:]:
                         self._delete_cb(key)
 
                 # Keep only the most @_min_size used
                 self._data = {key:self._data[key]
-                              for key in most_commons[:self._min_size - 1]}
+                              for key, _ in most_common[:self._min_size - 1]}
                 self._size = self._min_size
 
                 # Reset use's counter
-                self._counter = collections.Counter(self._data.keys())
+                self._counter = dict((k, 1) for k in self._data.iterkeys())
+
+            # Avoid rechecking in dict: set to 1 here, add 1 otherwise
+            self._counter[asked_key] = 1
+        else:
+            self._counter[asked_key] += 1
 
         self._data[asked_key] = value
-        self._counter.update([asked_key])
+
+    def __contains__(self, key):
+        # Do not call has_key to avoid adding function call overhead
+        return key in self._data
+
+    def has_key(self, key):
+        return key in self._data
 
     def keys(self):
         "Return the list of dict's keys"
         return self._data.keys()
 
     def __getitem__(self, key):
-        self._counter.update([key])
-        return self._data[key]
+        # Retrieve data first to raise the proper exception on error
+        data = self._data[key]
+        # Should never raise, since the key is in self._data
+        self._counter[key] += 1
+        return data
 
     def __delitem__(self, key):
         if self._delete_cb is not None:

--- a/miasm2/jitter/jitload.py
+++ b/miasm2/jitter/jitload.py
@@ -139,9 +139,7 @@ class CallbackHandlerBitflag(CallbackHandler):
 
     # Overrides CallbackHandler's implem, but do not serve for optimization
     def has_callbacks(self, bitflag):
-        for b in self.callbacks.iterkeys():
-            if b & bitflag != 0:
-                return True
+        return any(cb_mask & bitflag != 0 for cb_mask in self.callbacks)
 
     def __call__(self, bitflag, *args):
         """Call each callbacks associated with bit set in bitflag. While
@@ -149,7 +147,7 @@ class CallbackHandlerBitflag(CallbackHandler):
         Iterator on other results"""
 
         res = True
-        for b in self.callbacks.iterkeys():
+        for b in self.callbacks:
 
             if b & bitflag != 0:
                 # If the flag matched

--- a/miasm2/jitter/jitload.py
+++ b/miasm2/jitter/jitload.py
@@ -113,6 +113,9 @@ class CallbackHandler(object):
 
         return empty_keys
 
+    def has_callbacks(self, name):
+        return name in self.callbacks
+
     def call_callbacks(self, name, *args):
         """Call callbacks associated to key 'name' with arguments args. While
         callbacks return True, continue with next callback.
@@ -134,13 +137,19 @@ class CallbackHandlerBitflag(CallbackHandler):
 
     "Handle a list of callback with conditions on bitflag"
 
+    # Overrides CallbackHandler's implem, but do not serve for optimization
+    def has_callbacks(self, bitflag):
+        for b in self.callbacks.iterkeys():
+            if b & bitflag != 0:
+                return True
+
     def __call__(self, bitflag, *args):
         """Call each callbacks associated with bit set in bitflag. While
         callbacks return True, continue with next callback.
         Iterator on other results"""
 
         res = True
-        for b in self.callbacks.keys():
+        for b in self.callbacks.iterkeys():
 
             if b & bitflag != 0:
                 # If the flag matched
@@ -301,9 +310,10 @@ class jitter:
 
         # Check breakpoints
         old_pc = self.pc
-        for res in self.breakpoints_handler(self.pc, self):
-            if res is not True:
-                yield res
+        if self.breakpoints_handler.has_callbacks(self.pc):
+            for res in self.breakpoints_handler(self.pc, self):
+                if res is not True:
+                    yield res
 
         # If a callback changed pc, re call every callback
         if old_pc != self.pc:


### PR DESCRIPTION
Hi,

This PR speeds up some of the python code used by the jitter:
- `BoundedDict`'s `Counter` is replaced with a simple `dict` {key -> int}. This makes the run loop twice as fast on programs where compilation time is way inferior to the jitted code execution time (typically programs with intensive loops).
- in `runiter_once`, a preliminary check is made before checking all the callbacks. This brings something like 20% speedup.

Globally, most of the time is wasted by the huge function call overhead of python. As discussed previously with @serpilliere, moving the whole `continue_run`, or at least `runiter_once` loop in C would grant a great speedup (an additional x5 or x10 seems pretty reachable).

Profiling have mainly been performed with cProfile and Runsnakerun.

Here is how it looked like before the PR:
![profile_before](https://cloud.githubusercontent.com/assets/6480082/10413688/b07a3be4-6fb3-11e5-9a22-a74e540e2028.png)

Here is what it looks like now:
![profile_after](https://cloud.githubusercontent.com/assets/6480082/10423952/4dab011a-70cb-11e5-82d8-5ff4c074a4a0.png)


**Note:** `get_exception` can be inlined in `runiter_once` to save some function calls (it is the most called function for this sample), but I think the very slight speedup (non negligeable when benchmarking, but negligeable when running the program without the profiler) is not worth the lack of clarity it brings.