### PR TITLE
Fix gdbserver

### DIFF
--- a/example/jitter/unpack_upx.py
+++ b/example/jitter/unpack_upx.py
@@ -81,6 +81,9 @@ def update_binary(jitter):
         sdata = sb.jitter.vm.get_mem(sb.pe.rva2virt(s.addr), s.rawsize)
         sb.pe.virt[sb.pe.rva2virt(s.addr)] = sdata
 
+    # Stop execution
+    jitter.run = False
+    return False
 
 # Set callbacks
 sb.jitter.add_breakpoint(end_label, update_binary)

--- a/miasm2/analysis/debugging.py
+++ b/miasm2/analysis/debugging.py
@@ -22,6 +22,16 @@ class DebugBreakpointSoft(DebugBreakpoint):
         return "Soft BP @0x%08x" % self.addr
 
 
+class DebugBreakpointTerminate(DebugBreakpoint):
+    "Stand for an execution termination"
+
+    def __init__(self, status):
+        self.status = status
+
+    def __str__(self):
+        return "Terminate with %s" % self.status
+
+
 class DebugBreakpointMemory(DebugBreakpoint):
 
     "Stand for memory breakpoint"
@@ -131,8 +141,9 @@ class Debugguer(object):
             self.myjit.jit.log_newbloc = newbloc
 
     def handle_exception(self, res):
-        if res is None:
-            return
+        if not res:
+            # A breakpoint has stopped the execution
+            return DebugBreakpointTerminate(res)
 
         if isinstance(res, DebugBreakpointSoft):
             print "Breakpoint reached @0x%08x" % res.addr

--- a/miasm2/analysis/debugging.py
+++ b/miasm2/analysis/debugging.py
@@ -149,6 +149,9 @@ class Debugguer(object):
         else:
             raise NotImplementedError("type res")
 
+        # Repropagate res
+        return res
+
     def step(self):
         "Step in jit"
 
@@ -165,9 +168,8 @@ class Debugguer(object):
         return res
 
     def run(self):
-        res = self.myjit.continue_run()
-        self.handle_exception(res)
-        return res
+        status = self.myjit.continue_run()
+        return self.handle_exception(status)
 
     def get_mem(self, addr, size=0xF):
         "hexdump @addr, size"

--- a/miasm2/analysis/gdbserver.py
+++ b/miasm2/analysis/gdbserver.py
@@ -245,6 +245,12 @@ class GdbServer(object):
                         self.send_queue.append("S05")
                     else:
                         raise NotImplementedError("Unknown Except")
+                elif isinstance(ret, debugging.DebugBreakpointTerminate):
+                    # Connexion should close, but keep it running as a TRAP
+                    # The connexion will be close on instance destruction
+                    print ret
+                    self.status = "S05"
+                    self.send_queue.append("S05")
                 else:
                     raise NotImplementedError()
 

--- a/miasm2/analysis/gdbserver.py
+++ b/miasm2/analysis/gdbserver.py
@@ -134,7 +134,8 @@ class GdbServer(object):
             elif msg_type == "k":
                 # Kill
                 self.sock.close()
-                exit(1)
+                self.send_queue = []
+                self.sock = None
 
             elif msg_type == "!":
                 # Extending debugging will be used


### PR DESCRIPTION
With this PR, `unpack_upx` with GDBServer will properly finish the binary rebuilt (instead of crashing on `sb.run`) on connexion closing (client side).

In addition, if one set a script breakpoint thanks to `sb.add_breakpoint` which doesn't return `True` - ie execution should stop - a sig TRAP is raised and script execution can continue after connexion closing.
That way, one can easily set a breakpoint to get back control on GDBserver client when getting the OEP in UPX.