### PR TITLE
Fixes for the tcc jitter

### DIFF
--- a/miasm2/jitter/Jittcc.c
+++ b/miasm2/jitter/Jittcc.c
@@ -47,7 +47,11 @@ TCCState * tcc_init_state(void)
 
 	//tcc_add_file(tcc_state, libcodenat_path);
 	for (i=0;i<lib_array_count; i++){
+#ifdef TCC_FILETYPE_BINARY
+		tcc_add_file(tcc_state, lib_array[i], TCC_FILETYPE_BINARY);
+#else
 		tcc_add_file(tcc_state, lib_array[i]);
+#endif
 	}
 
 	for (i=0;i<include_array_count; i++){

--- a/miasm2/jitter/jitcore_tcc.py
+++ b/miasm2/jitter/jitcore_tcc.py
@@ -2,11 +2,11 @@
 #-*- coding:utf-8 -*-
 
 import os
-from miasm2.ir.ir2C import irblocs2C
-from subprocess import Popen, PIPE
-import miasm2.jitter.jitcore as jitcore
 from distutils.sysconfig import get_python_inc
-import Jittcc
+from subprocess import Popen, PIPE
+from miasm2.ir.ir2C import irblocs2C
+from miasm2.jitter import jitcore
+from miasm2.jitter import Jittcc
 
 
 def jit_tcc_compil(func_name, func_code):

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,8 @@ def buil_all():
                   ["miasm2/jitter/Jitllvm.c"]),
         Extension("miasm2.jitter.Jittcc",
                   ["miasm2/jitter/Jittcc.c"],
-                  libraries=["tcc"])
+                  libraries=["tcc"],
+                  library_dirs=["/usr/local/lib", "/usr/local/lib64"])
         ]
 
     print 'building'


### PR DESCRIPTION
The first two commits are required for me to use the tcc jitter on my Linux box.
The third one is more of a cosmetic nature but should prevent picking a wrong Jittcc module.

Each commit comes with a description so I'll keep the pull request message short.
