### PR TITLE
In interactive use, allow C-like prefixes to choose the base of integers

### DIFF
--- a/example/disasm/file.py
+++ b/example/disasm/file.py
@@ -9,7 +9,7 @@ if len(sys.argv) != 3:
     print "%s samples/box_upx.exe 0x407570" % sys.argv[0]
     sys.exit(0)
 
-addr = int(sys.argv[2], 16)
+addr = int(sys.argv[2], 0)
 cont = Container.from_stream(open(sys.argv[1]))
 mdis = dis_x86_32(cont.bin_stream)
 # Inform the engine to avoid disassembling null instructions

--- a/example/disasm/full.py
+++ b/example/disasm/full.py
@@ -43,7 +43,8 @@ parser.add_argument('-l', "--dontdis-retcall", action="store_true",
                     help="If set, disassemble only call destinations")
 parser.add_argument('-s', "--simplify", action="store_true",
                     help="Use the liveness analysis pass")
-parser.add_argument('-o', "--shiftoffset", default=None, type=int,
+parser.add_argument('-o', "--shiftoffset", default=None,
+                    type=lambda x: int(x, 0),
                     help="Shift input binary by an offset")
 parser.add_argument('-a', "--try-disasm-all", action="store_true",
                     help="Try to disassemble the whole binary")
@@ -85,7 +86,7 @@ mdis.dont_dis_nulstart_bloc = not args.dis_nulstart_block
 mdis.follow_call = args.followcall
 
 todo = []
-addrs = [int(a, 16) for a in args.address]
+addrs = [int(a, 0) for a in args.address]
 
 if len(addrs) == 0 and default_addr is not None:
     addrs.append(default_addr)

--- a/example/jitter/mips32.py
+++ b/example/jitter/mips32.py
@@ -38,7 +38,7 @@ def code_sentinelle(jitter):
     return True
 
 def jit_mips32_binary(args):
-    filepath, entryp = args.binary, int(args.addr, 16)
+    filepath, entryp = args.binary, int(args.addr, 0)
     myjit = machine.jitter(jit_type = args.jitter)
     myjit.init_stack()
 

--- a/example/jitter/msp430.py
+++ b/example/jitter/msp430.py
@@ -31,7 +31,7 @@ parser.add_argument("addr",
 machine = Machine("msp430")
 
 def jit_msp430_binary(args):
-    filepath, entryp = args.binary, int(args.addr, 16)
+    filepath, entryp = args.binary, int(args.addr, 0)
     myjit = machine.jitter(jit_type = args.jitter)
     myjit.init_stack()
 

--- a/example/symbol_exec/depgraph.py
+++ b/example/symbol_exec/depgraph.py
@@ -55,7 +55,7 @@ if args.rename_args:
             init_ctx[e_mem] = ExprId("arg%d" % i)
 
 # Disassemble the targeted function
-blocks = mdis.dis_multibloc(int(args.func_addr, 16))
+blocks = mdis.dis_multibloc(int(args.func_addr, 0))
 
 # Generate IR
 for block in blocks:
@@ -71,7 +71,7 @@ dg = DependencyGraph(ir_arch, implicit=args.implicit,
 		     follow_call=not(args.unfollow_call))
 
 # Build information
-target_addr = int(args.target_addr, 16)
+target_addr = int(args.target_addr, 0)
 current_block = list(ir_arch.getby_offset(target_addr))[0]
 line_nb = 0
 for line_nb, line in enumerate(current_block.lines):

--- a/miasm2/analysis/debugging.py
+++ b/miasm2/analysis/debugging.py
@@ -273,10 +273,7 @@ class DebugCmd(cmd.Cmd, object):
 
     def add_breakpoints(self, bp_addr):
         for addr in bp_addr:
-            if "0x" in addr:
-                addr = int(addr, 16)
-            else:
-                addr = int(addr)
+	    addr = int(addr, 0)
 
             good = True
             for i, dbg_obj in enumerate(self.dbg.bp_list):
@@ -359,17 +356,11 @@ class DebugCmd(cmd.Cmd, object):
 
         args = arg.split(" ")
         if len(args) >= 2:
-            if "0x" in args[1]:
-                size = int(args[1], 16)
-            else:
-                size = int(args[1])
+            size = int(args[1], 0)
         else:
             size = 0xF
 
-        if "0x" in args[0]:
-            addr = int(args[0], 16)
-        else:
-            addr = int(args[0])
+        addr = int(args[0], 0)
 
         self.dbg.watch_mem(addr, size)
 
@@ -445,16 +436,10 @@ class DebugCmd(cmd.Cmd, object):
         else:
             args = arg.split(" ")
             if len(args) >= 2:
-                if "0x" in args[1]:
-                    size = int(args[1], 16)
-                else:
-                    size = int(args[1])
+                size = int(args[1], 0)
             else:
                 size = 0xF
-            if "0x" in args[0]:
-                addr = int(args[0], 16)
-            else:
-                addr = int(args[0])
+            addr = int(args[0], 0)
 
             self.dbg.get_mem(addr, size)
 

--- a/miasm2/analysis/sandbox.py
+++ b/miasm2/analysis/sandbox.py
@@ -97,7 +97,7 @@ class Sandbox(object):
         @addr: (int) start address
         """
         if addr is None and self.options.address is not None:
-            addr = int(self.options.address, 16)
+            addr = int(self.options.address, 0)
 
         if any([self.options.debugging, self.options.gdbserver]):
             dbg = debugging.Debugguer(self.jitter)
@@ -252,7 +252,7 @@ class OS_Linux_str(OS):
         self.libs = libs
 
         data = open(self.fname).read()
-        self.options.load_base_addr = int(self.options.load_base_addr, 16)
+        self.options.load_base_addr = int(self.options.load_base_addr, 0)
         self.jitter.vm.add_memory_page(self.options.load_base_addr, PAGE_READ | PAGE_WRITE, data)
 
         # Library calls handler
@@ -479,7 +479,7 @@ class Sandbox_Linux_armb_str(Sandbox, Arch_armb, OS_Linux_str):
 
     def run(self, addr = None):
         if addr is None and self.options.address is not None:
-            addr = int(self.options.address, 16)
+            addr = int(self.options.address, 0)
         super(Sandbox_Linux_armb_str, self).run(addr)
 
 
@@ -496,7 +496,7 @@ class Sandbox_Linux_arml_str(Sandbox, Arch_arml, OS_Linux_str):
 
     def run(self, addr = None):
         if addr is None and self.options.address is not None:
-            addr = int(self.options.address, 16)
+            addr = int(self.options.address, 0)
         super(Sandbox_Linux_arml_str, self).run(addr)
 
 
@@ -513,5 +513,5 @@ class Sandbox_Linux_aarch64l(Sandbox, Arch_aarch64l, OS_Linux):
 
     def run(self, addr = None):
         if addr is None and self.options.address is not None:
-            addr = int(self.options.address, 16)
+            addr = int(self.options.address, 0)
         super(Sandbox_Linux_aarch64l, self).run(addr)


### PR DESCRIPTION
Use Python's int(s, 0) to allow string "s" to specify its base where
addresses and offsets can be supplied.
This change makes the situation homogeneous among the various examples and
interactive usage.