### PR TITLE
Keyword disasm cb

### DIFF
--- a/example/disasm/callback.py
+++ b/example/disasm/callback.py
@@ -1,0 +1,60 @@
+from miasm2.core.bin_stream import bin_stream_str
+from miasm2.core.asmbloc import asm_constraint, asm_label
+from miasm2.expression.expression import ExprId
+from miasm2.arch.x86.disasm import dis_x86_32, cb_x86_funcs
+
+
+def cb_x86_callpop(cur_bloc, symbol_pool, *args, **kwargs):
+    """
+    1000: call 1005
+    1005: pop
+
+    Will give:
+
+    1000: push 1005
+    1005: pop
+
+    """
+    if len(cur_bloc.lines) < 1:
+        return
+    l = cur_bloc.lines[-1]
+    if l.name != 'CALL':
+        return
+    dst = l.args[0]
+    if not (isinstance(dst, ExprId) and isinstance(dst.name, asm_label)):
+        return
+    if dst.name.offset != l.offset + l.l:
+        return
+    l.name = 'PUSH'
+    cur_bloc.bto.clear()
+    cur_bloc.add_cst(dst.name.offset, asm_constraint.c_next, symbol_pool)
+
+
+# Prepare a tiny shellcode
+shellcode = ''.join(["\xe8\x00\x00\x00\x00", # CALL $
+                     "X",                    # POP EAX
+                     "\xc3",                 # RET
+                     ])
+bin_stream = bin_stream_str(shellcode)
+mdis = dis_x86_32(bin_stream)
+
+print "Without callback:\n"
+blocks = mdis.dis_multibloc(0)
+print "\n".join(str(block) for block in blocks)
+
+# Enable callback
+cb_x86_funcs.append(cb_x86_callpop)
+## Other method:
+## mdis.dis_bloc_callback = cb_x86_callpop
+
+# Clean disassembly cache
+mdis.job_done.clear()
+
+print "=" * 40
+print "With callback:\n"
+blocks_after = mdis.dis_multibloc(0)
+print "\n".join(str(block) for block in blocks_after)
+
+# Ensure the callback has been called
+assert blocks[0].lines[0].name == "CALL"
+assert blocks_after[0].lines[0].name == "PUSH"

--- a/miasm2/arch/aarch64/disasm.py
+++ b/miasm2/arch/aarch64/disasm.py
@@ -4,9 +4,9 @@ from miasm2.arch.aarch64.arch import mn_aarch64
 cb_aarch64_funcs = []
 
 
-def cb_aarch64_disasm(mn, attrib, pool_bin, cur_bloc, offsets_to_dis, symbol_pool):
+def cb_aarch64_disasm(*args, **kwargs):
     for func in cb_aarch64_funcs:
-        func(mn, attrib, pool_bin, cur_bloc, offsets_to_dis, symbol_pool)
+        func(*args, **kwargs)
 
 
 class dis_aarch64b(disasmEngine):

--- a/miasm2/arch/arm/disasm.py
+++ b/miasm2/arch/arm/disasm.py
@@ -2,8 +2,7 @@ from miasm2.core.asmbloc import asm_constraint, disasmEngine
 from miasm2.arch.arm.arch import mn_arm, mn_armt
 
 
-def cb_arm_fix_call(
-    mn, attrib, pool_bin, cur_bloc, offsets_to_dis, symbol_pool):
+def cb_arm_fix_call(mn, cur_bloc, symbol_pool, offsets_to_dis, *args, **kwargs):
     """
     for arm:
     MOV        LR, PC
@@ -19,11 +18,11 @@ def cb_arm_fix_call(
         return
     if l2.name != "MOV":
         return
-    # print cur_bloc
-    # print l1
-    if not l1.args[0] in mn.pc.values():
+
+    values = mn.pc.values()
+    if not l1.args[0] in values:
         return
-    if not l2.args[1] in mn.pc.values():
+    if not l2.args[1] in values:
         return
     cur_bloc.add_cst(l1.offset + 4, asm_constraint.c_next, symbol_pool)
     offsets_to_dis.add(l1.offset + 4)
@@ -31,9 +30,9 @@ def cb_arm_fix_call(
 cb_arm_funcs = [cb_arm_fix_call]
 
 
-def cb_arm_disasm(mn, attrib, pool_bin, cur_bloc, offsets_to_dis, symbol_pool):
+def cb_arm_disasm(*args, **kwargs):
     for func in cb_arm_funcs:
-        func(mn, attrib, pool_bin, cur_bloc, offsets_to_dis, symbol_pool)
+        func(*args, **kwargs)
 
 
 class dis_armb(disasmEngine):

--- a/miasm2/arch/x86/disasm.py
+++ b/miasm2/arch/x86/disasm.py
@@ -3,7 +3,7 @@ from miasm2.expression.expression import ExprId
 from miasm2.arch.x86.arch import mn_x86
 
 
-def cb_x86_callpop(mn, attrib, pool_bin, cur_bloc, offsets_to_dis, symbol_pool):
+def cb_x86_callpop(cur_bloc, *args, **kwargs):
     """
     1000: call 1005
     1005: pop
@@ -14,7 +14,6 @@ def cb_x86_callpop(mn, attrib, pool_bin, cur_bloc, offsets_to_dis, symbol_pool):
     1005: pop
 
     """
-
     if len(cur_bloc.lines) < 1:
         return
     l = cur_bloc.lines[-1]
@@ -33,9 +32,9 @@ def cb_x86_callpop(mn, attrib, pool_bin, cur_bloc, offsets_to_dis, symbol_pool):
 cb_x86_funcs = [cb_x86_callpop]
 
 
-def cb_x86_disasm(mn, attrib, pool_bin, cur_bloc, offsets_to_dis, symbol_pool):
+def cb_x86_disasm(*args, **kwargs):
     for func in cb_x86_funcs:
-        func(mn, attrib, pool_bin, cur_bloc, offsets_to_dis, symbol_pool)
+        func(*args, **kwargs)
 
 
 class dis_x86(disasmEngine):

--- a/miasm2/arch/x86/disasm.py
+++ b/miasm2/arch/x86/disasm.py
@@ -1,35 +1,8 @@
-from miasm2.core.asmbloc import asm_constraint, asm_label, disasmEngine
-from miasm2.expression.expression import ExprId
+from miasm2.core.asmbloc import disasmEngine
 from miasm2.arch.x86.arch import mn_x86
 
 
-def cb_x86_callpop(cur_bloc, *args, **kwargs):
-    """
-    1000: call 1005
-    1005: pop
-
-    Will give:
-
-    1000: push 1005
-    1005: pop
-
-    """
-    if len(cur_bloc.lines) < 1:
-        return
-    l = cur_bloc.lines[-1]
-    if l.name != 'CALL':
-        return
-    dst = l.args[0]
-    if not (isinstance(dst, ExprId) and isinstance(dst.name, asm_label)):
-        return
-    if dst.name.offset != l.offset + l.l:
-        return
-    l.name = 'PUSH'
-    cur_bloc.bto = set()
-    cur_bloc.add_cst(dst.name.offset, asm_constraint.c_next, symbol_pool)
-
-
-cb_x86_funcs = [cb_x86_callpop]
+cb_x86_funcs = []
 
 
 def cb_x86_disasm(*args, **kwargs):

--- a/miasm2/core/asmbloc.py
+++ b/miasm2/core/asmbloc.py
@@ -440,8 +440,9 @@ def dis_bloc(mnemo, pool_bin, cur_bloc, offset, job_done, symbol_pool,
         offsets_to_dis.add(offset)
 
     if dis_bloc_callback is not None:
-        dis_bloc_callback(
-            mnemo, attrib, pool_bin, cur_bloc, offsets_to_dis, symbol_pool)
+        dis_bloc_callback(mn=mnemo, attrib=attrib, pool_bin=pool_bin,
+                          cur_bloc=cur_bloc, offsets_to_dis=offsets_to_dis,
+                          symbol_pool=symbol_pool)
     # print 'dst', [hex(x) for x in offsets_to_dis]
     return offsets_to_dis
 
@@ -482,9 +483,9 @@ def split_bloc(mnemo, attrib, pool_bin, blocs,
                 offsets_to_dis = set(
                     [x.label.offset for x in new_b.bto
                      if isinstance(x.label, asm_label)])
-                dis_bloc_callback(
-                    mnemo, attrib, pool_bin, new_b, offsets_to_dis,
-                    symbol_pool)
+                dis_bloc_callback(mn=mnemo, attrib=attrib, pool_bin=pool_bin,
+                                  cur_bloc=new_b, offsets_to_dis=offsets_to_dis,
+                                  symbol_pool=symbol_pool)
             blocs.append(new_b)
             a, b = cb.get_range()
 

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -250,6 +250,7 @@ class ExampleDisassembler(Example):
 
 
 for script, prods in [(["single_instr.py"], []),
+                      (["callback.py"], []),
                       (["function.py"], ["graph.txt"]),
                       (["file.py", Example.get_sample("box_upx.exe"),
                         "0x407570"], ["graph.txt"]),


### PR DESCRIPTION
With this PR, disasm callback are called with named arguments, avoiding declaring callback with:
```Python
def callback(mn, attrib, pool_bin, cur_bloc, offsets_to_dis, symbol_pool)
```
But only with required arguments:
```Python
def callback(cur_bloc, mn, *args, **kwargs):
```