### PR TITLE
x86/Sem/RDTSC: update tsc2 value on tsc1 overflow

### DIFF
--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -2498,6 +2498,9 @@ def hlt(ir, instr):
 def rdtsc(ir, instr):
     e = []
     e.append(m2_expr.ExprAff(tsc1, tsc1 + m2_expr.ExprInt32(1)))
+    e.append(m2_expr.ExprAff(tsc2, tsc2 + ExprCond(tsc1 - tsc1.mask,
+                                                   ExprInt32(0),
+                                                   ExprInt32(1))))
     e.append(m2_expr.ExprAff(mRAX[32], tsc1))
     e.append(m2_expr.ExprAff(mRDX[32], tsc2))
     return e, []


### PR DESCRIPTION
Update `tsc2` value (`tsc1:tsc2` from `rdtsc`) on `tsc1` overflow