### PR TITLE
Fix symbexec example

### DIFF
--- a/example/symbol_exec/single_instr.py
+++ b/example/symbol_exec/single_instr.py
@@ -2,30 +2,42 @@
 from miasm2.core.bin_stream                 import bin_stream_str
 from miasm2.arch.x86.arch                   import mn_x86
 from miasm2.arch.x86.ira                    import ir_a_x86_32
-from miasm2.arch.x86.regs                   import all_regs_ids, all_regs_ids_init
+from miasm2.arch.x86.regs                   import regs_init
 from miasm2.ir.symbexec                     import symbexec
 from miasm2.arch.x86.disasm                 import dis_x86_32 as dis_engine
-import miasm2.expression.expression as m2_expr
+from miasm2.expression.expression           import ExprId
 
-l = mn_x86.fromstring("MOV EAX, EBX", 32)
-asm = mn_x86.asm(l)[0]
+START_ADDR = 0
 
+# Assemble and disassemble a MOV
+## Ensure that attributes 'offset' and 'l' are set
+line = mn_x86.fromstring("MOV EAX, EBX", 32)
+asm = mn_x86.asm(line)[0]
+
+# Get back block
 bin_stream = bin_stream_str(asm)
-
 mdis = dis_engine(bin_stream)
-disasm = mdis.dis_multibloc(0)
+asm_block = mdis.dis_bloc(START_ADDR)
 
+# Translate ASM -> IR
 ir = ir_a_x86_32(mdis.symbol_pool)
-for bbl in disasm: ir.add_bloc(bbl)
+ir.add_bloc(asm_block)
 
-symbols_init =  {}
-for i, r in enumerate(all_regs_ids):
-    symbols_init[r] = all_regs_ids_init[i]
-symb = symbexec(ir, symbols_init)
+# Instanciate a Symbolic Execution engine with default value for registers
+## EAX = EAX_init, ...
+symb = symbexec(ir, regs_init)
 
-block = ir.get_bloc(0)
+# Emulate one IR basic block
+## Emulation of several basic blocks can be done through .emul_ir_blocs
+cur_addr = symb.emul_ir_bloc(ir, START_ADDR)
 
-cur_addr = symb.emulbloc(block)
-assert(symb.symbols[m2_expr.ExprId("EAX")] == symbols_init[m2_expr.ExprId("EBX")])
-print 'modified registers:'
+# Modified elements
+print 'Modified registers:'
 symb.dump_id()
+print 'Modified memory (should be empty):'
+symb.dump_mem()
+
+# Check final status
+eax, ebx = map(ExprId, ["EAX", "EBX"])
+assert symb.symbols[eax] == regs_init[ebx]
+assert eax in symb.modified()

--- a/example/symbol_exec/single_instr.py
+++ b/example/symbol_exec/single_instr.py
@@ -1,35 +1,33 @@
 # Minimalist Symbol Exec example
-from miasm2.core.bin_stream                 import bin_stream_str
-from miasm2.arch.x86.arch                   import mn_x86
-from miasm2.arch.x86.ira                    import ir_a_x86_32
-from miasm2.arch.x86.regs                   import regs_init
-from miasm2.ir.symbexec                     import symbexec
-from miasm2.arch.x86.disasm                 import dis_x86_32 as dis_engine
-from miasm2.expression.expression           import ExprId
+from miasm2.core.bin_stream import bin_stream_str
+from miasm2.ir.symbexec import symbexec
+from miasm2.analysis.machine import Machine
 
 START_ADDR = 0
+machine = Machine("x86_32")
 
 # Assemble and disassemble a MOV
 ## Ensure that attributes 'offset' and 'l' are set
-line = mn_x86.fromstring("MOV EAX, EBX", 32)
-asm = mn_x86.asm(line)[0]
+line = machine.mn.fromstring("MOV EAX, EBX", 32)
+asm = machine.mn.asm(line)[0]
 
 # Get back block
 bin_stream = bin_stream_str(asm)
-mdis = dis_engine(bin_stream)
+mdis = machine.dis_engine(bin_stream)
 asm_block = mdis.dis_bloc(START_ADDR)
 
 # Translate ASM -> IR
-ir = ir_a_x86_32(mdis.symbol_pool)
-ir.add_bloc(asm_block)
+ira = machine.ira(mdis.symbol_pool)
+ira.add_bloc(asm_block)
 
 # Instanciate a Symbolic Execution engine with default value for registers
 ## EAX = EAX_init, ...
-symb = symbexec(ir, regs_init)
+symbols_init = ira.arch.regs.regs_init
+symb = symbexec(ira, symbols_init)
 
 # Emulate one IR basic block
 ## Emulation of several basic blocks can be done through .emul_ir_blocs
-cur_addr = symb.emul_ir_bloc(ir, START_ADDR)
+cur_addr = symb.emul_ir_bloc(ira, START_ADDR)
 
 # Modified elements
 print 'Modified registers:'
@@ -38,6 +36,6 @@ print 'Modified memory (should be empty):'
 symb.dump_mem()
 
 # Check final status
-eax, ebx = map(ExprId, ["EAX", "EBX"])
-assert symb.symbols[eax] == regs_init[ebx]
+eax, ebx = ira.arch.regs.EAX, ira.arch.regs.EBX
+assert symb.symbols[eax] == symbols_init[ebx]
 assert eax in symb.modified()


### PR DESCRIPTION
Rewrite `example/symbexec/single_instr.py` in order to be more comprehensible / to use more common Miasm APIs.