### PR TITLE
Fix sem x86

### DIFF
--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -482,7 +482,12 @@ def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None, left=False):
 
     res = m2_expr.ExprOp(op, a, shifter)
     cf_from_dst = m2_expr.ExprOp(op, a,
-                                 (shifter - m2_expr.ExprInt_from(a, 1)))[:1]
+                                 (shifter - m2_expr.ExprInt_from(a, 1)))
+    if left:
+        cf_from_dst = cf_from_dst.msb()
+    else:
+        cf_from_dst = cf_from_dst[:1]
+
     i1 = m2_expr.ExprInt(1, size=a.size)
     if c is not None:
         # There is a source for new bits
@@ -491,11 +496,12 @@ def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None, left=False):
 
         # An overflow can occured, emulate the 'undefined behavior'
         # Overflow behavior if (shift / size % 2)
-        cond_overflow = ((c - m2_expr.ExprInt(1, size=c.size)) &
-                         m2_expr.ExprInt(a.size, c.size))
+        base_cond_overflow = c if left else (c - m2_expr.ExprInt(1, size=c.size))
+        cond_overflow = base_cond_overflow & m2_expr.ExprInt(a.size, c.size)
         if left:
-            mask = ~mask
-        mask = m2_expr.ExprCond(cond_overflow, ~mask, mask)
+            mask = m2_expr.ExprCond(cond_overflow, mask, ~mask)
+        else:
+            mask = m2_expr.ExprCond(cond_overflow, ~mask, mask)
 
         # Build res with dst and src
         res = ((m2_expr.ExprOp(op, a, shifter) & mask) |
@@ -503,7 +509,11 @@ def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None, left=False):
 
         # Overflow case: cf come from src (bit number shifter % size)
         cf_from_src = m2_expr.ExprOp(op, b,
-                                     (c.zeroExtend(b.size) & m2_expr.ExprInt(a.size - 1, b.size)) - i1)[:1]
+                                     (c.zeroExtend(b.size) & m2_expr.ExprInt(a.size - 1, b.size)) - i1)
+        if left:
+            cf_from_src = cf_from_src.msb()
+        else:
+            cf_from_src = cf_from_src[:1]
         new_cf = m2_expr.ExprCond(cond_overflow, cf_from_src, cf_from_dst)
 
     else:

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -563,7 +563,7 @@ def sar(ir, instr, a, b):
 
 
 def shr(ir, instr, a, b):
-    return _shift_tpl(">>", ir, instr, a, b)
+    return _shift_tpl(">>", ir, instr, a, b, custom_of=a.msb())
 
 
 def shrd_cl(ir, instr, a, b):

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -512,7 +512,9 @@ def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None):
 
     e_do = [
         m2_expr.ExprAff(cf, new_cf),
-        m2_expr.ExprAff(of, m2_expr.ExprInt_from(of, 0)),
+        m2_expr.ExprAff(of, m2_expr.ExprCond(shifter - m2_expr.ExprInt(1, size=shifter.size),
+                                             m2_expr.ExprInt_from(of, 0),
+                                             b[:1] ^ a.msb())),
         m2_expr.ExprAff(a, res),
     ]
 

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -415,11 +415,12 @@ def get_shift(a, b):
     shift = expr_simp(shift)
     return shift
 
-def _rotate_tpl(ir, instr, a, b, op, op_cf=None):
+def _rotate_tpl(ir, instr, a, b, op, op_cf=None, left=False):
     """Template for generate rotater with operation @op
     A temporary basic block is generated to handle 0-rotate
     @op: operation to execute
     @op_cf (optional): operation to use for carry flag. If not set, use @op
+    @left (optional): indicates a left rotate if set, default is False
     """
     if op_cf is None:
         op_cf = op
@@ -478,21 +479,11 @@ def l_ror(ir, instr, a, b):
 
 
 def rcl(ir, instr, a, b):
-    return _rotate_tpl(ir, instr, a, b, '<<<c_rez', '<<<c_cf')
+    return _rotate_tpl(ir, instr, a, b, '<<<c_rez', '<<<c_cf', left=True)
 
 
 def rcr(ir, instr, a, b):
-    e = []
-    shifter = get_shift(a, b)
-    c = m2_expr.ExprOp('>>>c_rez', a, shifter, cf.zeroExtend(a.size))
-    new_cf = m2_expr.ExprOp('>>>c_cf', a, shifter, cf.zeroExtend(a.size))[:1]
-
-    e.append(m2_expr.ExprAff(cf, new_cf))
-    # hack (only valid if b=1)
-    e.append(m2_expr.ExprAff(of, (a ^ c).msb()))
-    e.append(m2_expr.ExprAff(a, c))
-
-    return e, []
+    return _rotate_tpl(ir, instr, a, b, '>>>c_rez', '>>>c_cf')
 
 
 def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None, left=False):

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -429,11 +429,13 @@ def _rotate_tpl(ir, instr, a, b, op, op_cf=None, left=False):
     res = m2_expr.ExprOp(op, a, shifter, cf.zeroExtend(a.size))
     new_cf = m2_expr.ExprOp(op_cf, a, shifter, cf.zeroExtend(a.size))[:1]
 
+    new_of = m2_expr.ExprCond(b - m2_expr.ExprInt(1, size=b.size),
+                              m2_expr.ExprInt(0, size=of.size),
+                              res.msb() ^ new_cf if left else (a ^ res).msb())
     # Build basic blocks
     e_do = [
         m2_expr.ExprAff(cf, new_cf),
-        # hack (only valid if b=1)
-        m2_expr.ExprAff(of, res.msb() ^ new_cf),
+        m2_expr.ExprAff(of, new_of),
         m2_expr.ExprAff(a, res),
     ]
 

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -605,19 +605,7 @@ def sal(ir, instr, a, b):
 
 
 def shl(ir, instr, a, b):
-    e = []
-    shifter = get_shift(a, b)
-    c = a << shifter
-    new_cf = (a >> (m2_expr.ExprInt_from(a, a.size) - shifter))[:1]
-    e.append(m2_expr.ExprAff(cf, m2_expr.ExprCond(shifter,
-                                  new_cf,
-                                  cf)
-                     )
-             )
-    e += update_flag_znp(c)
-    e.append(m2_expr.ExprAff(of, c.msb() ^ new_cf))
-    e.append(m2_expr.ExprAff(a, c))
-    return e, []
+    return _shift_tpl("<<", ir, instr, a, b, left=True)
 
 
 def shld_cl(ir, instr, a, b):

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -1345,8 +1345,7 @@ def jno(ir, instr, dst):
 def loop(ir, instr, dst):
     e = []
     meip = mRIP[instr.mode]
-    s = instr.v_opmode()
-    opmode, admode = s, instr.v_admode()
+    admode = instr.v_admode()
     myecx = mRCX[instr.mode][:admode]
 
     n = m2_expr.ExprId(ir.get_next_label(instr), instr.mode)
@@ -1363,13 +1362,12 @@ def loop(ir, instr, dst):
 def loopne(ir, instr, dst):
     e = []
     meip = mRIP[instr.mode]
-    s = instr.v_opmode()
-    opmode, admode = s, instr.v_admode()
+    admode = instr.v_admode()
     myecx = mRCX[instr.mode][:admode]
 
     n = m2_expr.ExprId(ir.get_next_label(instr), instr.mode)
 
-    c = m2_expr.ExprCond(mRCX[instr.mode][:s] - m2_expr.ExprInt(1, s),
+    c = m2_expr.ExprCond(myecx - m2_expr.ExprInt(1, size=myecx.size),
                  m2_expr.ExprInt1(1),
                  m2_expr.ExprInt1(0))
     c &= zf ^ m2_expr.ExprInt1(1)
@@ -1386,12 +1384,11 @@ def loopne(ir, instr, dst):
 def loope(ir, instr, dst):
     e = []
     meip = mRIP[instr.mode]
-    s = instr.v_opmode()
-    opmode, admode = s, instr.v_admode()
+    admode = instr.v_admode()
     myecx = mRCX[instr.mode][:admode]
 
     n = m2_expr.ExprId(ir.get_next_label(instr), instr.mode)
-    c = m2_expr.ExprCond(mRCX[instr.mode][:s] - m2_expr.ExprInt(1, s),
+    c = m2_expr.ExprCond(myecx - m2_expr.ExprInt(1, size=myecx.size),
                  m2_expr.ExprInt1(1),
                  m2_expr.ExprInt1(0))
     c &= zf

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -461,16 +461,7 @@ def _rotate_tpl(ir, instr, a, b, op, left=False, include_cf=False):
 
 
 def l_rol(ir, instr, a, b):
-    e = []
-    shifter = get_shift(a, b)
-    c = m2_expr.ExprOp('<<<', a, shifter)
-
-    new_cf = c[:1]
-    e.append(m2_expr.ExprAff(cf, new_cf))
-    # hack (only valid if b=1)
-    e.append(m2_expr.ExprAff(of, c.msb() ^ new_cf))
-    e.append(m2_expr.ExprAff(a, c))
-    return e, []
+    return _rotate_tpl(ir, instr, a, b, '<<<', left=True)
 
 
 def l_ror(ir, instr, a, b):

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -73,8 +73,8 @@ def update_flag_pf(a):
                                            a & m2_expr.ExprInt_from(a, 0xFF)))]
 
 
-def update_flag_af(expr):
-    return [m2_expr.ExprAff(af, expr[4:5])]
+def update_flag_af(op1, op2, res):
+    return [m2_expr.ExprAff(af, (op1 ^ op2 ^ res)[4:5])]
 
 
 def update_flag_znp(a):
@@ -286,7 +286,7 @@ def add(ir, instr, a, b):
     e = []
     c = a + b
     e += update_flag_arith(c)
-    e += update_flag_af(c)
+    e += update_flag_af(a, b, c)
     e += update_flag_add(a, b, c)
     e.append(m2_expr.ExprAff(a, c))
     return e, []
@@ -296,7 +296,7 @@ def xadd(ir, instr, a, b):
     e = []
     c = a + b
     e += update_flag_arith(c)
-    e += update_flag_af(c)
+    e += update_flag_af(a, b, c)
     e += update_flag_add(b, a, c)
     e.append(m2_expr.ExprAff(b, a))
     e.append(m2_expr.ExprAff(a, c))
@@ -309,7 +309,7 @@ def adc(ir, instr, a, b):
                                        1, a.size),
                               (cf, 0, 1)]))
     e += update_flag_arith(c)
-    e += update_flag_af(c)
+    e += update_flag_af(a, b, c)
     e += update_flag_add(a, b, c)
     e.append(m2_expr.ExprAff(a, c))
     return e, []
@@ -319,7 +319,7 @@ def sub(ir, instr, a, b):
     e = []
     c = a - b
     e += update_flag_arith(c)
-    e += update_flag_af(c)
+    e += update_flag_af(a, b, c)
     e += update_flag_sub(a, b, c)
     e.append(m2_expr.ExprAff(a, c))
     return e, []
@@ -333,7 +333,7 @@ def sbb(ir, instr, a, b):
                                        1, a.size),
                               (cf, 0, 1)]))
     e += update_flag_arith(c)
-    e += update_flag_af(c)
+    e += update_flag_af(a, b, c)
     e += update_flag_sub(a, b, c)
     e.append(m2_expr.ExprAff(a, c))
     return e, []
@@ -346,7 +346,7 @@ def neg(ir, instr, b):
     c = a - b
     e += update_flag_arith(c)
     e += update_flag_sub(a, b, c)
-    e += update_flag_af(c)
+    e += update_flag_af(a, b, c)
     e.append(m2_expr.ExprAff(b, c))
     return e, []
 
@@ -363,7 +363,7 @@ def l_cmp(ir, instr, a, b):
     c = a - b
     e += update_flag_arith(c)
     e += update_flag_sub(a, b, c)
-    e += update_flag_af(c)
+    e += update_flag_af(a, b, c)
     return e, []
 
 
@@ -659,7 +659,7 @@ def inc(ir, instr, a):
     b = m2_expr.ExprInt_from(a, 1)
     c = a + b
     e += update_flag_arith(c)
-    e += update_flag_af(c)
+    e += update_flag_af(a, b, c)
 
     e.append(update_flag_add_of(a, b, c))
     e.append(m2_expr.ExprAff(a, c))
@@ -670,7 +670,7 @@ def dec(ir, instr, a):
     b = m2_expr.ExprInt_from(a, -1)
     c = a + b
     e += update_flag_arith(c)
-    e += update_flag_af(c)
+    e += update_flag_af(a, b, ~c)
 
     e.append(update_flag_add_of(a, b, c))
     e.append(m2_expr.ExprAff(a, c))

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -416,7 +416,7 @@ def get_shift(a, b):
     return shift
 
 def _rotate_tpl(ir, instr, a, b, op, left=False, include_cf=False):
-    """Template for generate rotater with operation @op
+    """Template to generate a rotater with operation @op
     A temporary basic block is generated to handle 0-rotate
     @op: operation to execute
     @left (optional): indicates a left rotate if set, default is False
@@ -478,7 +478,7 @@ def rcr(ir, instr, a, b):
 
 def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None, left=False,
                custom_of=None):
-    """Template for generate shifter with operation @op
+    """Template to generate a shifter with operation @op
     A temporary basic block is generated to handle 0-shift
     @op: operation to execute
     @c (optional): if set, instruction has a bit provider

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -483,9 +483,9 @@ def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None, left=False):
     res = m2_expr.ExprOp(op, a, shifter)
     cf_from_dst = m2_expr.ExprOp(op, a,
                                  (shifter - m2_expr.ExprInt_from(a, 1)))[:1]
+    i1 = m2_expr.ExprInt(1, size=a.size)
     if c is not None:
         # There is a source for new bits
-        i1 = m2_expr.ExprInt(1, size=a.size)
         isize = m2_expr.ExprInt(a.size, size=a.size)
         mask = m2_expr.ExprOp(op_inv, i1, (isize - shifter)) - i1
 
@@ -512,11 +512,12 @@ def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None, left=False):
     lbl_do = m2_expr.ExprId(ir.gen_label(), instr.mode)
     lbl_skip = m2_expr.ExprId(ir.get_next_label(instr), instr.mode)
 
+    value_of = a.msb() ^ a[-2:-1] if left else b[:1] ^ a.msb()
     e_do = [
         m2_expr.ExprAff(cf, new_cf),
-        m2_expr.ExprAff(of, m2_expr.ExprCond(shifter - m2_expr.ExprInt(1, size=shifter.size),
+        m2_expr.ExprAff(of, m2_expr.ExprCond(shifter - i1,
                                              m2_expr.ExprInt_from(of, 0),
-                                             b[:1] ^ a.msb())),
+                                             value_of)),
         m2_expr.ExprAff(a, res),
     ]
 

--- a/miasm2/expression/simplifications_common.py
+++ b/miasm2/expression/simplifications_common.py
@@ -45,10 +45,11 @@ def simp_cst_propagation(e_s, e):
                 x2 = mod_size2int[i2.arg.size](i2.arg)
                 o = mod_size2uint[i1.arg.size](x1 >> x2)
             elif op == '>>>':
-                rounds = i2.arg
-                o = i1.arg >> i2.arg | i1.arg << (i1.size - i2.arg)
+                o = (i1.arg >> (i2.arg % i2.size) |
+                     i1.arg << ((i1.size - i2.arg) % i2.size))
             elif op == '<<<':
-                o = i1.arg << i2.arg | i1.arg >> (i1.size - i2.arg)
+                o = (i1.arg << (i2.arg % i2.size) |
+                     i1.arg >> ((i1.size - i2.arg) % i2.size))
             elif op == '/':
                 o = i1.arg / i2.arg
             elif op == '%':

--- a/miasm2/ir/translators/C.py
+++ b/miasm2/ir/translators/C.py
@@ -23,9 +23,7 @@ class TranslatorC(Translator):
                'div32': "div_op",
                'idiv32': "div_op",  # XXX to test
                '<<<c_rez': 'rcl_rez_op',
-               '<<<c_cf': 'rcl_cf_op',
                '>>>c_rez': 'rcr_rez_op',
-               '>>>c_cf': 'rcr_cf_op',
                }
 
 

--- a/miasm2/jitter/vm_mngr.c
+++ b/miasm2/jitter/vm_mngr.c
@@ -850,47 +850,37 @@ uint64_t rot_right(uint64_t size, uint64_t a, uint64_t b)
 unsigned int rcl_rez_op(unsigned int size, unsigned int a, unsigned int b, unsigned int cf)
 {
     uint64_t tmp;
+    uint64_t tmp_count;
+    uint64_t tmp_cf;
 
-
-    size++;
-    b %= size;
-
-    if (b == 0) {
-	    switch(size){
-		    case 8+1:
-			    return a&0xff;
-		    case 16+1:
-			    return a&0xffff;
-		    case 32+1:
-			    return a&0xffffffff;
-		    default:
-			    fprintf(stderr, "inv size in rclleft %d\n", size);
-			    exit(0);
-	    }
+    tmp = a;
+    // TODO 64bit mode
+    tmp_count = (b & 0x1f) % (size + 1);
+    while (tmp_count != 0) {
+	    tmp_cf = (tmp >> (size - 1)) & 1;
+	    tmp = (tmp << 1) + cf;
+	    cf = tmp_cf;
+	    tmp_count -= 1;
     }
-
-    tmp = (a<<1) | cf;
-    b -=1;
-    switch(size){
-	    case 8+1:
-		    tmp = (tmp << b) | ((a&0x1FF) >> (size-b-1));
-		    return tmp&0xff;
-	    case 16+1:
-		    tmp = (tmp << b) | ((a&0x1FFFF) >> (size-b-1));
-		    return tmp&0xffff;
-	    case 32+1:
-		    tmp = (tmp << b) | ((a&0x1FFFFFFFFULL) >> (size-b-1));
-		    return tmp&0xffffffff;
-	    default:
-		    fprintf(stderr, "inv size in rclleft %d\n", size);
-		    exit(0);
-    }
+    return tmp;
 }
 
 unsigned int rcr_rez_op(unsigned int size, unsigned int a, unsigned int b, unsigned int cf)
 {
-	return rcl_rez_op(size, a, size+1-b, cf);
+    uint64_t tmp;
+    uint64_t tmp_count;
+    uint64_t tmp_cf;
 
+    tmp = a;
+    // TODO 64bit mode
+    tmp_count = (b & 0x1f) % (size + 1);
+    while (tmp_count != 0) {
+	    tmp_cf = tmp & 1;
+	    tmp = (tmp >> 1) + (cf << (size - 1));
+	    cf = tmp_cf;
+	    tmp_count -= 1;
+    }
+    return tmp;
 }
 
 unsigned int x86_bsr(uint64_t src, unsigned int size)

--- a/miasm2/jitter/vm_mngr.c
+++ b/miasm2/jitter/vm_mngr.c
@@ -847,7 +847,7 @@ uint64_t rot_right(uint64_t size, uint64_t a, uint64_t b)
 }
 
 
-int rcl_rez_op(unsigned int size, unsigned int a, unsigned int b, unsigned int cf)
+unsigned int rcl_rez_op(unsigned int size, unsigned int a, unsigned int b, unsigned int cf)
 {
     uint64_t tmp;
 
@@ -887,41 +887,10 @@ int rcl_rez_op(unsigned int size, unsigned int a, unsigned int b, unsigned int c
     }
 }
 
-int rcr_rez_op(unsigned int size, unsigned int a, unsigned int b, unsigned int cf)
+unsigned int rcr_rez_op(unsigned int size, unsigned int a, unsigned int b, unsigned int cf)
 {
 	return rcl_rez_op(size, a, size+1-b, cf);
 
-}
-
-
-int rcl_cf_op(unsigned int size, unsigned int a, unsigned int b, unsigned int cf)
-{
-    uint64_t tmp;
-
-    tmp = (cf<< size) | a;
-
-    size++;
-    b %= size;
-
-    switch(size){
-	    case 8+1:
-		    tmp = (tmp << b) | ((tmp&0x1FF) >> (size-b));
-		    return (tmp>>8)&1;
-	    case 16+1:
-		    tmp = (tmp << b) | ((tmp&0x1FFFF) >> (size-b));
-		    return (tmp>>16)&1;
-	    case 32+1:
-		    tmp = (tmp << b) | ((tmp&0x1FFFFFFFFULL) >> (size-b));
-		    return (tmp>>32)&1;
-	    default:
-		    fprintf(stderr, "inv size in rclleft %d\n", size);
-		    exit(0);
-    }
-}
-
-int rcr_cf_op(unsigned int size, unsigned int a, unsigned int b, unsigned int cf)
-{
-	return rcl_cf_op(size, a, size+1-b, cf);
 }
 
 unsigned int x86_bsr(uint64_t src, unsigned int size)

--- a/miasm2/jitter/vm_mngr.c
+++ b/miasm2/jitter/vm_mngr.c
@@ -873,13 +873,13 @@ int rcl_rez_op(unsigned int size, unsigned int a, unsigned int b, unsigned int c
     b -=1;
     switch(size){
 	    case 8+1:
-		    tmp = (tmp << b) | ((tmp&0x1FF) >> (size-b));
+		    tmp = (tmp << b) | ((a&0x1FF) >> (size-b-1));
 		    return tmp&0xff;
 	    case 16+1:
-		    tmp = (tmp << b) | ((tmp&0x1FFFF) >> (size-b));
+		    tmp = (tmp << b) | ((a&0x1FFFF) >> (size-b-1));
 		    return tmp&0xffff;
 	    case 32+1:
-		    tmp = (tmp << b) | ((tmp&0x1FFFFFFFFULL) >> (size-b));
+		    tmp = (tmp << b) | ((a&0x1FFFFFFFFULL) >> (size-b-1));
 		    return tmp&0xffffffff;
 	    default:
 		    fprintf(stderr, "inv size in rclleft %d\n", size);

--- a/miasm2/jitter/vm_mngr.h
+++ b/miasm2/jitter/vm_mngr.h
@@ -206,8 +206,7 @@ unsigned int div_op(unsigned int size, unsigned int a, unsigned int b, unsigned 
 unsigned int rem_op(unsigned int size, unsigned int a, unsigned int b, unsigned int c);
 uint64_t rot_left(uint64_t size, uint64_t a, uint64_t b);
 uint64_t rot_right(uint64_t size, uint64_t a, uint64_t b);
-int rcl_rez_op(unsigned int size, unsigned int a, unsigned int b, unsigned int cf);
-int rcl_cf_op(unsigned int size, unsigned int a, unsigned int b, unsigned int cf);
+unsigned int rcl_rez_op(unsigned int size, unsigned int a, unsigned int b, unsigned int cf);
 
 
 #define UDIV(sizeA)						\

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -60,7 +60,10 @@ to_test = [(ExprInt32(1) - ExprInt32(1), ExprInt32(0)),
             ExprOp('<<<', a, (b-c))),
            (ExprOp('>>>', ExprOp('<<<', a, b), b),
             a),
-
+           (ExprOp(">>>", ExprInt16(0x1000), ExprInt16(0x11)),
+            ExprInt16(0x800)),
+           (ExprOp("<<<", ExprInt16(0x1000), ExprInt16(0x11)),
+            ExprInt16(0x2000)),
 
            (ExprOp('>>>', ExprOp('<<<', a, ExprInt32(10)), ExprInt32(2)),
             ExprOp('<<<', a, ExprInt32(8))),


### PR DESCRIPTION
This PR aims to fix the semantic of some x86 instructions, and corresponding TCC implementations (like #265 ).
Special note for `SHRD`, `SHLD`: the implemtation takes care of "unspecified state" according to the result obtained on my host, and on QEMU.