### PR TITLE
Fix python emul

### DIFF
--- a/miasm2/expression/modint.py
+++ b/miasm2/expression/modint.py
@@ -44,9 +44,9 @@ class moduint(object):
     def __div__(self, y):
         if isinstance(y, moduint):
             cls = self.maxcast(y)
-            return cls(self.arg / y.arg)
+            return cls(int(float(self.arg) / y.arg))
         else:
-            return self.__class__(self.arg / y)
+            return self.__class__(int(float(self.arg) / y))
 
     def __int__(self):
         return int(self.arg)

--- a/miasm2/expression/modint.py
+++ b/miasm2/expression/modint.py
@@ -67,9 +67,9 @@ class moduint(object):
     def __mod__(self, y):
         if isinstance(y, moduint):
             cls = self.maxcast(y)
-            return cls(self.arg % y.arg)
+            return cls(self.arg - (y.arg * int(float(self.arg)/y.arg)))
         else:
-            return self.__class__(self.arg % y)
+            return self.__class__(self.arg - (y * int(float(self.arg)/y)))
 
     def __mul__(self, y):
         if isinstance(y, moduint):

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -18,8 +18,10 @@ f = ExprId('f', size=64)
 m = ExprMem(a)
 s = a[:8]
 
+i0 = ExprInt(uint32(0x0))
 i1 = ExprInt(uint32(0x1))
 i2 = ExprInt(uint32(0x2))
+icustom = ExprInt(uint32(0x12345678))
 cc = ExprCond(a, b, c)
 
 o = ExprCompose([(a[:8], 8, 16),
@@ -301,6 +303,18 @@ to_test = [(ExprInt32(1) - ExprInt32(1), ExprInt32(0)),
     (expr_cmps(ExprInt32(-10), ExprInt32(-5)),
      ExprInt1(0)),
 
+    (ExprOp("<<<c_rez", i1, i0, i0),
+     i1),
+    (ExprOp("<<<c_rez", i1, i1, i0),
+     ExprInt32(2)),
+    (ExprOp("<<<c_rez", i1, i1, i1),
+     ExprInt32(3)),
+    (ExprOp(">>>c_rez", icustom, i0, i0),
+     icustom),
+    (ExprOp(">>>c_rez", icustom, i1, i0),
+     ExprInt32(0x91A2B3C)),
+    (ExprOp(">>>c_rez", icustom, i1, i1),
+     ExprInt32(0x891A2B3C)),
 ]
 
 for e, e_check in to_test[:]:

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -317,6 +317,9 @@ to_test = [(ExprInt32(1) - ExprInt32(1), ExprInt32(0)),
      ExprInt32(0x891A2B3C)),
     (ExprOp("idiv", ExprInt16(0x0123), ExprInt16(0xfffb))[:8],
      ExprInt8(0xc6)),
+    (ExprOp("imod", ExprInt16(0x0123), ExprInt16(0xfffb))[:8],
+     ExprInt8(0x01)),
+
 ]
 
 for e, e_check in to_test[:]:

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -315,6 +315,8 @@ to_test = [(ExprInt32(1) - ExprInt32(1), ExprInt32(0)),
      ExprInt32(0x91A2B3C)),
     (ExprOp(">>>c_rez", icustom, i1, i1),
      ExprInt32(0x891A2B3C)),
+    (ExprOp("idiv", ExprInt16(0x0123), ExprInt16(0xfffb))[:8],
+     ExprInt8(0xc6)),
 ]
 
 for e, e_check in to_test[:]:


### PR DESCRIPTION
Fix `idiv` and `imod` constant propagation computing.
Add `>>>c_rez` and `>>>c_rez` constant propagation calculation.