### PR TITLE
Fix x86 bcd

### DIFF
--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -2619,6 +2619,7 @@ def aam(ir, instr, a):
                          ])
     e += [m2_expr.ExprAff(mRAX[instr.mode], newEAX)]
     e += update_flag_arith(newEAX)
+    e.append(m2_expr.ExprAff(af, m2_expr.ExprInt1(0)))
     return e, []
 
 

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -2637,32 +2637,24 @@ def aad(ir, instr, a):
     return e, []
 
 
-def aaa(ir, instr, ):
+def aaa(ir, instr):
     e = []
-    c = (mRAX[instr.mode][:8] & m2_expr.ExprInt8(0xf)) - m2_expr.ExprInt8(9)
+    r_al = mRAX[instr.mode][:8]
+    r_ah = mRAX[instr.mode][8:16]
+    r_ax = mRAX[instr.mode][:16]
+    i0 = m2_expr.ExprInt1(0)
+    i1 = m2_expr.ExprInt1(1)
+    # cond: if (al & 0xf) > 9 OR af == 1
+    cond = (r_al & m2_expr.ExprInt8(0xf)) - m2_expr.ExprInt8(9)
+    cond = ~cond.msb() & m2_expr.ExprCond(cond, i1, i0)
+    cond |= af & i1
 
-    c = m2_expr.ExprCond(c.msb(),
-                 m2_expr.ExprInt1(0),
-                 m2_expr.ExprInt1(1)) & \
-        m2_expr.ExprCond(c,
-                 m2_expr.ExprInt1(1),
-                 m2_expr.ExprInt1(0))
-
-    c |= af & m2_expr.ExprInt1(1)
+    to_add = m2_expr.ExprInt(0x106, size=r_ax.size)
+    new_ax = (r_ax + to_add) & m2_expr.ExprInt(0xff0f, size=r_ax.size)
     # set AL
-    m_al = m2_expr.ExprCond(c,
-                            (mRAX[instr.mode][:8] + m2_expr.ExprInt8(6)) & \
-                                m2_expr.ExprInt8(0xF),
-                            mRAX[instr.mode][:8] & m2_expr.ExprInt8(0xF))
-    m_ah = m2_expr.ExprCond(c,
-                            mRAX[instr.mode][8:16] + m2_expr.ExprInt8(1),
-                            mRAX[instr.mode][8:16])
-
-    e.append(m2_expr.ExprAff(mRAX[instr.mode], m2_expr.ExprCompose([
-        (m_al, 0, 8), (m_ah, 8, 16),
-        (mRAX[instr.mode][16:], 16, mRAX[instr.mode].size)])))
-    e.append(m2_expr.ExprAff(af, c))
-    e.append(m2_expr.ExprAff(cf, c))
+    e.append(m2_expr.ExprAff(r_ax, m2_expr.ExprCond(cond, new_ax, r_ax)))
+    e.append(m2_expr.ExprAff(af, cond))
+    e.append(m2_expr.ExprAff(cf, cond))
     return e, []
 
 

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -2574,6 +2574,7 @@ def daa(ir, instr):
                               al_c1 + m2_expr.ExprInt8(0x60),
                               al_c1)
     e.append(m2_expr.ExprAff(r_al, new_al))
+    e += update_flag_znp(new_al)
     return e, []
 
 def das(ir, instr):

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -2605,6 +2605,7 @@ def das(ir, instr):
                               al_c1 - m2_expr.ExprInt8(0x60),
                               al_c1)
     e.append(m2_expr.ExprAff(r_al, new_al))
+    e += update_flag_znp(new_al)
     return e, []
 
 

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -2635,6 +2635,7 @@ def aad(ir, instr, a):
             ])
     e += [m2_expr.ExprAff(mRAX[instr.mode], newEAX)]
     e += update_flag_arith(newEAX)
+    e.append(m2_expr.ExprAff(af, m2_expr.ExprInt1(0)))
     return e, []
 
 

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -107,8 +107,9 @@ QEMU_TESTS = {
     "lea": ("tcc", "python"),
     "self_modifying_code": ("tcc", "python"),
     "conv": ("tcc", "python"),
+    "bcd": ("tcc", "python"),
     # Unsupported
-    # "floats", "bcd", "xchg", "string", "misc", "segs", "code16", "exceptions",
+    # "floats", "xchg", "string", "misc", "segs", "code16", "exceptions",
     # "single_step"
 }
 


### PR DESCRIPTION
Fix the semantic of BCD instructions in x86, according to QEMU ( see #274 ).
The behavior used in AAA/AAS comes from this [errata](http://www.hugi.scene.org/online/coding/hugi%2017%20-%20coaax.htm).