### PR TITLE
Test/Depgraph: the error status was not checked

### DIFF
--- a/test/analysis/depgraph.py
+++ b/test/analysis/depgraph.py
@@ -1248,3 +1248,6 @@ if FAILED:
         print i,
 else:
     print "SUCCESS"
+
+# Return an error status on error
+assert not FAILED


### PR DESCRIPTION
Since b8b0e21a, `test/analysis/depgraph.py` has been leaved unchecked by regression test framework.