### PR TITLE
Refactor ira

### DIFF
--- a/example/disasm/full.py
+++ b/example/disasm/full.py
@@ -194,6 +194,7 @@ if args.gen_ir:
     log.info("Print blocs (with analyse)")
     for label, bloc in ir_arch_a.blocs.iteritems():
         print bloc
+    ir_arch.gen_graph()
     ir_arch_a.gen_graph()
 
     if args.simplify:
@@ -201,3 +202,5 @@ if args.gen_ir:
 
     out = ir_arch_a.graph()
     open('graph_irflow.dot', 'w').write(out)
+    out = ir_arch.graph()
+    open('graph_irflow_raw.dot', 'w').write(out)

--- a/example/disasm/full.py
+++ b/example/disasm/full.py
@@ -194,13 +194,11 @@ if args.gen_ir:
     log.info("Print blocs (with analyse)")
     for label, bloc in ir_arch_a.blocs.iteritems():
         print bloc
-    ir_arch.gen_graph()
-    ir_arch_a.gen_graph()
 
     if args.simplify:
         ir_arch_a.dead_simp()
 
-    out = ir_arch_a.graph()
+    out = ir_arch_a.graph.dot()
     open('graph_irflow.dot', 'w').write(out)
-    out = ir_arch.graph()
+    out = ir_arch.graph.dot()
     open('graph_irflow_raw.dot', 'w').write(out)

--- a/example/expression/asm_to_ir.py
+++ b/example/expression/asm_to_ir.py
@@ -45,13 +45,10 @@ for lbl, b in ir_arch.blocs.items():
     print b
 
 # Dead propagation
-ir_arch.gen_graph()
-out = ir_arch.graph()
-open('graph.dot', 'w').write(out)
+open('graph.dot', 'w').write(ir_arch.graph.dot())
 print '*' * 80
 ir_arch.dead_simp()
-out2 = ir_arch.graph()
-open('graph2.dot', 'w').write(out2)
+open('graph2.dot', 'w').write(ir_arch.graph.dot())
 
 # Display new IR
 print 'new ir blocs'

--- a/example/expression/get_read_write.py
+++ b/example/expression/get_read_write.py
@@ -21,6 +21,5 @@ for lbl, b in ir_arch.blocs.items():
         print 'read:   ', [str(x) for x in o_r]
         print 'written:', [str(x) for x in o_w]
         print
-ir_arch.gen_graph()
-g = ir_arch.graph()
-open('graph_instr.dot', 'w').write(g)
+
+open('graph_instr.dot', 'w').write(ir_arch.graph.dot())

--- a/example/expression/graph_dataflow.py
+++ b/example/expression/graph_dataflow.py
@@ -114,7 +114,6 @@ def gen_bloc_data_flow_graph(ir_arch, ad, block_flow_cb):
     for irbloc in ir_arch.blocs.values():
         print irbloc
 
-    ir_arch.gen_graph()
     ir_arch.dead_simp()
 
     irbloc_0 = None

--- a/example/ida/depgraph.py
+++ b/example/ida/depgraph.py
@@ -136,9 +136,6 @@ for irb in ir_arch.blocs.values():
         for i, expr in enumerate(irs):
             irs[i] = m2_expr.ExprAff(expr_simp(expr.dst), expr_simp(expr.src))
 
-# Build the IRA Graph
-ir_arch.gen_graph()
-
 # Get settings
 settings = depGraphSettingsForm(ir_arch)
 settings.Execute()

--- a/example/ida/graph_ir.py
+++ b/example/ida/graph_ir.py
@@ -56,7 +56,7 @@ class GraphMiasmIR(GraphViewer):
                 continue
             dst = ir_arch.dst_trackback(irbloc)
             for d in dst:
-                if not self.ir_arch.ExprIsLabel(d):
+                if not expr_is_label(d):
                     continue
 
                 d = d.name

--- a/example/ida/graph_ir.py
+++ b/example/ida/graph_ir.py
@@ -138,8 +138,7 @@ for irb in ir_arch.blocs.values():
         for i, expr in enumerate(irs):
             irs[i] = ExprAff(expr_simp(expr.dst), expr_simp(expr.src))
 
-ir_arch.gen_graph()
-out = ir_arch.graph()
+out = ir_arch.graph.dot()
 open(os.path.join(tempfile.gettempdir(), 'graph.dot'), 'wb').write(out)
 
 
@@ -197,7 +196,6 @@ def get_modified_symbols(sb):
 def gen_bloc_data_flow_graph(ir_arch, in_str, ad):  # arch, attrib, pool_bin, bloc, symbol_pool):
     out_str = ""
 
-    ir_arch.gen_graph()
     # ir_arch.dead_simp()
 
     irbloc_0 = None

--- a/example/symbol_exec/depgraph.py
+++ b/example/symbol_exec/depgraph.py
@@ -61,9 +61,6 @@ blocks = mdis.dis_multibloc(int(args.func_addr, 0))
 for block in blocks:
     ir_arch.add_bloc(block)
 
-# Build the IRA Graph
-ir_arch.gen_graph()
-
 # Get the instance
 dg = DependencyGraph(ir_arch, implicit=args.implicit,
 		     apply_simp=not(args.do_not_simplify),

--- a/miasm2/analysis/data_analysis.py
+++ b/miasm2/analysis/data_analysis.py
@@ -150,7 +150,7 @@ def inter_bloc_flow_link(ir_arch, flow_graph, todo, link_exec_to_data):
     x_nodes = tuple(sorted(list(irb.dst.get_r())))
 
     todo = set()
-    for lbl_dst in ir_arch.g.successors(irb.label):
+    for lbl_dst in ir_arch.graph.successors(irb.label):
         todo.add((lbl_dst, tuple(current_nodes.items()), x_nodes))
 
     # pp(('OUT', lbl, [(str(x[0]), str(x[1])) for x in current_nodes.items()]))
@@ -166,7 +166,7 @@ def create_implicit_flow(ir_arch, flow_graph):
     while todo:
         lbl = todo.pop()
         irb = ir_arch.blocs[lbl]
-        for lbl_son in ir_arch.g.successors(irb.label):
+        for lbl_son in ir_arch.graph.successors(irb.label):
             if not lbl_son in ir_arch.blocs:
                 print "cannot find bloc!!", lbl
                 continue
@@ -189,7 +189,7 @@ def create_implicit_flow(ir_arch, flow_graph):
                     irb.in_nodes[n_r] = irb.label, 0, n_r
                 node_n_r = irb.in_nodes[n_r]
                 # print "###", node_n_r
-                for lbl_p in ir_arch.g.predecessors(irb.label):
+                for lbl_p in ir_arch.graph.predecessors(irb.label):
                     todo.add(lbl_p)
 
                 flow_graph.add_uniq_edge(node_n_r, node_n_w)

--- a/miasm2/analysis/depgraph.py
+++ b/miasm2/analysis/depgraph.py
@@ -686,7 +686,6 @@ class DependencyGraph(object):
     def __init__(self, ira, implicit=False, apply_simp=True, follow_mem=True,
                  follow_call=True):
         """Create a DependencyGraph linked to @ira
-        The IRA graph must have been computed
 
         @ira: IRAnalysis instance
         @implicit: (optional) Imply implicit dependencies
@@ -701,9 +700,6 @@ class DependencyGraph(object):
         self._implicit = implicit
         self._step_counter = itertools.count()
         self._current_step = next(self._step_counter)
-
-        # The IRA graph must be computed
-        assert hasattr(self._ira, 'g')
 
         # Create callback filters. The order is relevant.
         self._cb_follow = []
@@ -892,7 +888,7 @@ class DependencyGraph(object):
     def _get_previousblocks(self, label):
         """Return an iterator on predecessors blocks of @label, with their
         lengths"""
-        preds = self._ira.g.predecessors_iter(label)
+        preds = self._ira.graph.predecessors_iter(label)
         for pred_label in preds:
             length = len(self._get_irs(pred_label))
             yield (pred_label, length)

--- a/miasm2/arch/x86/ira.py
+++ b/miasm2/arch/x86/ira.py
@@ -3,6 +3,7 @@
 
 from miasm2.expression.expression import ExprAff, ExprOp, ExprId
 from miasm2.core.graph import DiGraph
+from miasm2.core.asmbloc import expr_is_label
 from miasm2.ir.ir import ir, irbloc
 from miasm2.ir.analysis import ira
 from miasm2.arch.x86.sem import ir_x86_16, ir_x86_32, ir_x86_64
@@ -46,7 +47,7 @@ class ir_a_x86_16(ir_x86_16, ira):
         if not l.is_subcall():
             return
         sub_call_dst = l.args[0]
-        if self.ExprIsLabel(sub_call_dst):
+        if expr_is_label(sub_call_dst):
             sub_call_dst = sub_call_dst.name
         for b in ir_blocs:
             l = b.lines[-1]
@@ -54,7 +55,7 @@ class ir_a_x86_16(ir_x86_16, ira):
             if not l.is_subcall():
                 continue
             sub_call_dst = l.args[0]
-            if self.ExprIsLabel(sub_call_dst):
+            if expr_is_label(sub_call_dst):
                 sub_call_dst = sub_call_dst.name
             lbl = bloc.get_next()
             new_lbl = self.gen_label()

--- a/miasm2/ir/analysis.py
+++ b/miasm2/ir/analysis.py
@@ -4,7 +4,6 @@
 import logging
 
 from miasm2.ir.symbexec import symbexec
-from miasm2.core.graph import DiGraph
 from miasm2.expression.expression \
     import ExprAff, ExprCond, ExprId, ExprInt, ExprMem
 
@@ -19,103 +18,6 @@ class ira:
     def ira_regs_ids(self):
         """Returns ids of all registers used in the IR"""
         return self.arch.regs.all_regs_ids + [self.IRDst]
-
-    def sort_dst(self, todo, done):
-        out = set()
-        while todo:
-            dst = todo.pop()
-            if self.ExprIsLabel(dst):
-                done.add(dst)
-            elif isinstance(dst, ExprMem) or isinstance(dst, ExprInt):
-                done.add(dst)
-            elif isinstance(dst, ExprCond):
-                todo.add(dst.src1)
-                todo.add(dst.src2)
-            elif isinstance(dst, ExprId):
-                out.add(dst)
-            else:
-                done.add(dst)
-        return out
-
-    def dst_trackback(self, b):
-        dst = b.dst
-        todo = set([dst])
-        done = set()
-
-        for irs in reversed(b.irs):
-            if len(todo) == 0:
-                break
-            out = self.sort_dst(todo, done)
-            found = set()
-            follow = set()
-            for i in irs:
-                if not out:
-                    break
-                for o in out:
-                    if i.dst == o:
-                        follow.add(i.src)
-                        found.add(o)
-                for o in found:
-                    out.remove(o)
-
-            for o in out:
-                if o not in found:
-                    follow.add(o)
-            todo = follow
-
-        return done
-
-    def gen_graph(self, link_all = True):
-        """
-        Gen irbloc digraph
-        @link_all: also gen edges to non present irblocs
-        """
-        self.g = DiGraph()
-        for lbl, b in self.blocs.items():
-            # print 'add', lbl
-            self.g.add_node(lbl)
-            # dst = self.get_bloc_dst(b)
-            dst = self.dst_trackback(b)
-            # print "\tdst", dst
-            for d in dst:
-                if isinstance(d, ExprInt):
-                    d = ExprId(
-                        self.symbol_pool.getby_offset_create(int(d.arg)))
-                if self.ExprIsLabel(d):
-                    if d.name in self.blocs or link_all is True:
-                        self.g.add_edge(lbl, d.name)
-
-    def graph(self):
-        """Output the graphviz script"""
-        out = """
-    digraph asm_graph {
-    size="80,50";
-    node [
-    fontsize = "16",
-    shape = "box"
-    ];
-        """
-        all_lbls = {}
-        for lbl in self.g.nodes():
-            if lbl not in self.blocs:
-                continue
-            irb = self.blocs[lbl]
-            ir_txt = [str(lbl)]
-            for irs in irb.irs:
-                for l in irs:
-                    ir_txt.append(str(l))
-                ir_txt.append("")
-            ir_txt.append("")
-            all_lbls[hash(lbl)] = "\l\\\n".join(ir_txt)
-        for l, v in all_lbls.items():
-            # print l, v
-            out += '%s [label="%s"];\n' % (l, v)
-
-        for a, b in self.g.edges():
-            # print 'edge', a, b, hash(a), hash(b)
-            out += '%s -> %s;\n' % (hash(a), hash(b))
-        out += '}'
-        return out
 
     def remove_dead_instr(self, irb, useful):
         """Remove dead affectations using previous reaches analysis

--- a/miasm2/ir/analysis.py
+++ b/miasm2/ir/analysis.py
@@ -61,12 +61,12 @@ class ira(ir):
 
         useful = set()
 
-        for node in self.g.nodes():
+        for node in self.graph.nodes():
             if node not in self.blocs:
                 continue
 
             block = self.blocs[node]
-            successors = self.g.successors(node)
+            successors = self.graph.successors(node)
             has_son = bool(successors)
             for p_son in successors:
                 if p_son not in self.blocs:
@@ -186,7 +186,7 @@ class ira(ir):
                       for key, value in irb.cur_reach[0].iteritems()}
 
         # Compute reach from predecessors
-        for n_pred in self.g.predecessors(irb.label):
+        for n_pred in self.graph.predecessors(irb.label):
             p_block = self.blocs[n_pred]
 
             # Handle each register definition
@@ -225,7 +225,7 @@ class ira(ir):
         analysis"""
 
         fixed = True
-        for node in self.g.nodes():
+        for node in self.graph.nodes():
             if node in self.blocs:
                 irb = self.blocs[node]
                 if (irb.cur_reach != irb.prev_reach or
@@ -241,13 +241,11 @@ class ira(ir):
 
         Source : Kennedy, K. (1979). A survey of data flow analysis techniques.
         IBM Thomas J. Watson Research Division, page 43
-
-        PRE: gen_graph()
         """
         fixed_point = False
         log.debug('iteration...')
         while not fixed_point:
-            for node in self.g.nodes():
+            for node in self.graph.nodes():
                 if node in self.blocs:
                     self.compute_reach_block(self.blocs[node])
             fixed_point = self._test_kill_reach_fix()
@@ -259,8 +257,6 @@ class ira(ir):
 
         Source : Kennedy, K. (1979). A survey of data flow analysis techniques.
         IBM Thomas J. Watson Research Division, page 43
-
-        PRE: gen_graph()
         """
         # Update r/w variables for all irblocs
         self.get_rw(self.ira_regs_ids())

--- a/miasm2/ir/analysis.py
+++ b/miasm2/ir/analysis.py
@@ -4,6 +4,7 @@
 import logging
 
 from miasm2.ir.symbexec import symbexec
+from miasm2.ir.ir import ir
 from miasm2.expression.expression \
     import ExprAff, ExprCond, ExprId, ExprInt, ExprMem
 
@@ -13,7 +14,8 @@ console_handler.setFormatter(logging.Formatter("%(levelname)-5s: %(message)s"))
 log.addHandler(console_handler)
 log.setLevel(logging.WARNING)
 
-class ira:
+
+class ira(ir):
     """IR Analysis
     This class provides higher level manipulations on IR, such as dead
     instruction removals.

--- a/miasm2/ir/analysis.py
+++ b/miasm2/ir/analysis.py
@@ -14,6 +14,14 @@ log.addHandler(console_handler)
 log.setLevel(logging.WARNING)
 
 class ira:
+    """IR Analysis
+    This class provides higher level manipulations on IR, such as dead
+    instruction removals.
+
+    This class can be used as a common parent with `miasm2.ir.ir::ir` class.
+    For instance:
+        class ira_x86_16(ir_x86_16, ira)
+    """
 
     def ira_regs_ids(self):
         """Returns ids of all registers used in the IR"""

--- a/miasm2/ir/ir.py
+++ b/miasm2/ir/ir.py
@@ -335,16 +335,11 @@ class ir(object):
         for b in self.blocs.values():
             b.get_rw(regs_ids)
 
-    def ExprIsLabel(self, l):
-        #TODO : use expression helper
-        return isinstance(l, m2_expr.ExprId) and isinstance(l.name,
-                                                            asmbloc.asm_label)
-
     def sort_dst(self, todo, done):
         out = set()
         while todo:
             dst = todo.pop()
-            if self.ExprIsLabel(dst):
+            if asmbloc.expr_is_label(dst):
                 done.add(dst)
             elif isinstance(dst, m2_expr.ExprMem) or isinstance(dst, m2_expr.ExprInt):
                 done.add(dst)
@@ -401,7 +396,7 @@ class ir(object):
                 if isinstance(d, m2_expr.ExprInt):
                     d = m2_expr.ExprId(
                         self.symbol_pool.getby_offset_create(int(d.arg)))
-                if self.ExprIsLabel(d):
+                if asmbloc.expr_is_label(d):
                     if d.name in self.blocs or link_all is True:
                         self.g.add_edge(lbl, d.name)
 

--- a/miasm2/ir/ir.py
+++ b/miasm2/ir/ir.py
@@ -423,13 +423,12 @@ class ir(object):
 
         return done
 
-    def _gen_graph(self, link_all = True):
+    def _gen_graph(self):
         """
         Gen irbloc digraph
-        @link_all: also gen edges to non present irblocs
         """
         self._graph = DiGraphIR(self.blocs)
-        for lbl, b in self.blocs.items():
+        for lbl, b in self.blocs.iteritems():
             self._graph.add_node(lbl)
             dst = self.dst_trackback(b)
             for d in dst:

--- a/miasm2/ir/ir.py
+++ b/miasm2/ir/ir.py
@@ -343,6 +343,8 @@ class ir(object):
 
             self.blocs[irb.label] = irb
 
+        # Forget graph if any
+        self._graph = None
 
     def get_instr_label(self, instr):
         """Returns the label associated to an instruction

--- a/test/analysis/depgraph.py
+++ b/test/analysis/depgraph.py
@@ -206,8 +206,8 @@ G1_IRB0 = gen_irbloc(LBL0, [[ExprAff(C, CST1)]])
 G1_IRB1 = gen_irbloc(LBL1, [[ExprAff(B, C)]])
 G1_IRB2 = gen_irbloc(LBL2, [[ExprAff(A, B)]])
 
-G1_IRA.g.add_uniq_edge(G1_IRB0.label, G1_IRB1.label)
-G1_IRA.g.add_uniq_edge(G1_IRB1.label, G1_IRB2.label)
+G1_IRA.graph.add_uniq_edge(G1_IRB0.label, G1_IRB1.label)
+G1_IRA.graph.add_uniq_edge(G1_IRB1.label, G1_IRB2.label)
 
 G1_IRA.blocs = dict([(irb.label, irb) for irb in [G1_IRB0, G1_IRB1, G1_IRB2]])
 
@@ -220,8 +220,8 @@ G2_IRB0 = gen_irbloc(LBL0, [[ExprAff(C, CST1)]])
 G2_IRB1 = gen_irbloc(LBL1, [[ExprAff(B, CST2)]])
 G2_IRB2 = gen_irbloc(LBL2, [[ExprAff(A, B + C)]])
 
-G2_IRA.g.add_uniq_edge(G2_IRB0.label, G2_IRB1.label)
-G2_IRA.g.add_uniq_edge(G2_IRB1.label, G2_IRB2.label)
+G2_IRA.graph.add_uniq_edge(G2_IRB0.label, G2_IRB1.label)
+G2_IRA.graph.add_uniq_edge(G2_IRB1.label, G2_IRB2.label)
 
 G2_IRA.blocs = dict([(irb.label, irb) for irb in [G2_IRB0, G2_IRB1, G2_IRB2]])
 
@@ -236,10 +236,10 @@ G3_IRB1 = gen_irbloc(LBL1, [[ExprAff(B, CST2)]])
 G3_IRB2 = gen_irbloc(LBL2, [[ExprAff(B, CST3)]])
 G3_IRB3 = gen_irbloc(LBL3, [[ExprAff(A, B + C)]])
 
-G3_IRA.g.add_uniq_edge(G3_IRB0.label, G3_IRB1.label)
-G3_IRA.g.add_uniq_edge(G3_IRB0.label, G3_IRB2.label)
-G3_IRA.g.add_uniq_edge(G3_IRB1.label, G3_IRB3.label)
-G3_IRA.g.add_uniq_edge(G3_IRB2.label, G3_IRB3.label)
+G3_IRA.graph.add_uniq_edge(G3_IRB0.label, G3_IRB1.label)
+G3_IRA.graph.add_uniq_edge(G3_IRB0.label, G3_IRB2.label)
+G3_IRA.graph.add_uniq_edge(G3_IRB1.label, G3_IRB3.label)
+G3_IRA.graph.add_uniq_edge(G3_IRB2.label, G3_IRB3.label)
 
 G3_IRA.blocs = dict([(irb.label, irb) for irb in [G3_IRB0, G3_IRB1,
                                                   G3_IRB2, G3_IRB3]])
@@ -257,9 +257,9 @@ G4_IRB1 = gen_irbloc(LBL1, [[ExprAff(C, C + CST2)],
 
 G4_IRB2 = gen_irbloc(LBL2, [[ExprAff(A, B)]])
 
-G4_IRA.g.add_uniq_edge(G4_IRB0.label, G4_IRB1.label)
-G4_IRA.g.add_uniq_edge(G4_IRB1.label, G4_IRB2.label)
-G4_IRA.g.add_uniq_edge(G4_IRB1.label, G4_IRB1.label)
+G4_IRA.graph.add_uniq_edge(G4_IRB0.label, G4_IRB1.label)
+G4_IRA.graph.add_uniq_edge(G4_IRB1.label, G4_IRB2.label)
+G4_IRA.graph.add_uniq_edge(G4_IRB1.label, G4_IRB1.label)
 
 G4_IRA.blocs = dict([(irb.label, irb) for irb in [G4_IRB0, G4_IRB1, G4_IRB2]])
 
@@ -277,9 +277,9 @@ G5_IRB1 = gen_irbloc(LBL1, [[ExprAff(B, B + CST2)],
 
 G5_IRB2 = gen_irbloc(LBL2, [[ExprAff(A, B)]])
 
-G5_IRA.g.add_uniq_edge(G5_IRB0.label, G5_IRB1.label)
-G5_IRA.g.add_uniq_edge(G5_IRB1.label, G5_IRB2.label)
-G5_IRA.g.add_uniq_edge(G5_IRB1.label, G5_IRB1.label)
+G5_IRA.graph.add_uniq_edge(G5_IRB0.label, G5_IRB1.label)
+G5_IRA.graph.add_uniq_edge(G5_IRB1.label, G5_IRB2.label)
+G5_IRA.graph.add_uniq_edge(G5_IRB1.label, G5_IRB1.label)
 
 G5_IRA.blocs = dict([(irb.label, irb) for irb in [G5_IRB0, G5_IRB1, G5_IRB2]])
 
@@ -291,8 +291,8 @@ G6_IRA.g = GraphTest(G6_IRA)
 G6_IRB0 = gen_irbloc(LBL0, [[ExprAff(B, CST1)]])
 G6_IRB1 = gen_irbloc(LBL1, [[ExprAff(A, B)]])
 
-G6_IRA.g.add_uniq_edge(G6_IRB0.label, G6_IRB1.label)
-G6_IRA.g.add_uniq_edge(G6_IRB1.label, G6_IRB1.label)
+G6_IRA.graph.add_uniq_edge(G6_IRB0.label, G6_IRB1.label)
+G6_IRA.graph.add_uniq_edge(G6_IRB1.label, G6_IRB1.label)
 
 G6_IRA.blocs = dict([(irb.label, irb) for irb in [G6_IRB0, G6_IRB1]])
 
@@ -305,9 +305,9 @@ G7_IRB0 = gen_irbloc(LBL0, [[ExprAff(C, CST1)]])
 G7_IRB1 = gen_irbloc(LBL1, [[ExprAff(B, C)], [ExprAff(A, B)]])
 G7_IRB2 = gen_irbloc(LBL2, [[ExprAff(D, A)]])
 
-G7_IRA.g.add_uniq_edge(G7_IRB0.label, G7_IRB1.label)
-G7_IRA.g.add_uniq_edge(G7_IRB1.label, G7_IRB1.label)
-G7_IRA.g.add_uniq_edge(G7_IRB1.label, G7_IRB2.label)
+G7_IRA.graph.add_uniq_edge(G7_IRB0.label, G7_IRB1.label)
+G7_IRA.graph.add_uniq_edge(G7_IRB1.label, G7_IRB1.label)
+G7_IRA.graph.add_uniq_edge(G7_IRB1.label, G7_IRB2.label)
 
 G7_IRA.blocs = dict([(irb.label, irb) for irb in [G7_IRB0, G7_IRB1, G7_IRB2]])
 
@@ -320,9 +320,9 @@ G8_IRB0 = gen_irbloc(LBL0, [[ExprAff(C, CST1)]])
 G8_IRB1 = gen_irbloc(LBL1, [[ExprAff(B, C)], [ExprAff(C, D)]])
 G8_IRB2 = gen_irbloc(LBL2, [[ExprAff(A, B)]])
 
-G8_IRA.g.add_uniq_edge(G8_IRB0.label, G8_IRB1.label)
-G8_IRA.g.add_uniq_edge(G8_IRB1.label, G8_IRB1.label)
-G8_IRA.g.add_uniq_edge(G8_IRB1.label, G8_IRB2.label)
+G8_IRA.graph.add_uniq_edge(G8_IRB0.label, G8_IRB1.label)
+G8_IRA.graph.add_uniq_edge(G8_IRB1.label, G8_IRB1.label)
+G8_IRA.graph.add_uniq_edge(G8_IRB1.label, G8_IRB2.label)
 
 G8_IRA.blocs = dict([(irb.label, irb) for irb in [G8_IRB0, G8_IRB1, G8_IRB2]])
 
@@ -336,8 +336,8 @@ G10_IRA.g = GraphTest(G10_IRA)
 G10_IRB1 = gen_irbloc(LBL1, [[ExprAff(B, B + CST2)]])
 G10_IRB2 = gen_irbloc(LBL2, [[ExprAff(A, B)]])
 
-G10_IRA.g.add_uniq_edge(G10_IRB1.label, G10_IRB2.label)
-G10_IRA.g.add_uniq_edge(G10_IRB1.label, G10_IRB1.label)
+G10_IRA.graph.add_uniq_edge(G10_IRB1.label, G10_IRB2.label)
+G10_IRA.graph.add_uniq_edge(G10_IRB1.label, G10_IRB1.label)
 
 G10_IRA.blocs = dict([(irb.label, irb) for irb in [G10_IRB1, G10_IRB2]])
 
@@ -352,8 +352,8 @@ G11_IRB1 = gen_irbloc(LBL1, [[ExprAff(A, B),
                               ExprAff(B, A)]])
 G11_IRB2 = gen_irbloc(LBL2, [[ExprAff(A, A - B)]])
 
-G11_IRA.g.add_uniq_edge(G11_IRB0.label, G11_IRB1.label)
-G11_IRA.g.add_uniq_edge(G11_IRB1.label, G11_IRB2.label)
+G11_IRA.graph.add_uniq_edge(G11_IRB0.label, G11_IRB1.label)
+G11_IRA.graph.add_uniq_edge(G11_IRB1.label, G11_IRB2.label)
 
 G11_IRA.blocs = dict([(irb.label, irb)
                      for irb in [G11_IRB0, G11_IRB1, G11_IRB2]])
@@ -367,9 +367,9 @@ G12_IRB0 = gen_irbloc(LBL0, [[ExprAff(B, CST1)]])
 G12_IRB1 = gen_irbloc(LBL1, [[ExprAff(A, B)], [ExprAff(B, B + CST2)]])
 G12_IRB2 = gen_irbloc(LBL2, [[ExprAff(B, A)]])
 
-G12_IRA.g.add_uniq_edge(G12_IRB0.label, G12_IRB1.label)
-G12_IRA.g.add_uniq_edge(G12_IRB1.label, G12_IRB2.label)
-G12_IRA.g.add_uniq_edge(G12_IRB1.label, G12_IRB1.label)
+G12_IRA.graph.add_uniq_edge(G12_IRB0.label, G12_IRB1.label)
+G12_IRA.graph.add_uniq_edge(G12_IRB1.label, G12_IRB2.label)
+G12_IRA.graph.add_uniq_edge(G12_IRB1.label, G12_IRB1.label)
 
 G12_IRA.blocs = dict([(irb.label, irb) for irb in [G12_IRB0, G12_IRB1,
                                                    G12_IRB2]])
@@ -396,10 +396,10 @@ G13_IRB2 = gen_irbloc(LBL2, [[ExprAff(B, A + CST3)], [ExprAff(A, B + CST3)],
 
 G13_IRB3 = gen_irbloc(LBL3, [[ExprAff(R, C)]])
 
-G13_IRA.g.add_uniq_edge(G13_IRB0.label, G13_IRB1.label)
-G13_IRA.g.add_uniq_edge(G13_IRB1.label, G13_IRB2.label)
-G13_IRA.g.add_uniq_edge(G13_IRB2.label, G13_IRB1.label)
-G13_IRA.g.add_uniq_edge(G13_IRB1.label, G13_IRB3.label)
+G13_IRA.graph.add_uniq_edge(G13_IRB0.label, G13_IRB1.label)
+G13_IRA.graph.add_uniq_edge(G13_IRB1.label, G13_IRB2.label)
+G13_IRA.graph.add_uniq_edge(G13_IRB2.label, G13_IRB1.label)
+G13_IRA.graph.add_uniq_edge(G13_IRB1.label, G13_IRB3.label)
 
 G13_IRA.blocs = dict([(irb.label, irb) for irb in [G13_IRB0, G13_IRB1,
                                                    G13_IRB2, G13_IRB3]])
@@ -427,10 +427,10 @@ G14_IRB2 = gen_irbloc(LBL2, [[ExprAff(D, A)],
 
 G14_IRB3 = gen_irbloc(LBL3, [[ExprAff(R, D + B)]])
 
-G14_IRA.g.add_uniq_edge(G14_IRB0.label, G14_IRB1.label)
-G14_IRA.g.add_uniq_edge(G14_IRB1.label, G14_IRB2.label)
-G14_IRA.g.add_uniq_edge(G14_IRB2.label, G14_IRB1.label)
-G14_IRA.g.add_uniq_edge(G14_IRB1.label, G14_IRB3.label)
+G14_IRA.graph.add_uniq_edge(G14_IRB0.label, G14_IRB1.label)
+G14_IRA.graph.add_uniq_edge(G14_IRB1.label, G14_IRB2.label)
+G14_IRA.graph.add_uniq_edge(G14_IRB2.label, G14_IRB1.label)
+G14_IRA.graph.add_uniq_edge(G14_IRB1.label, G14_IRB3.label)
 
 G14_IRA.blocs = dict([(irb.label, irb) for irb in [G14_IRB0, G14_IRB1,
                                                    G14_IRB2, G14_IRB3]])
@@ -446,9 +446,9 @@ G15_IRB1 = gen_irbloc(LBL1, [[ExprAff(D, A + B)],
                              [ExprAff(B, C)]])
 G15_IRB2 = gen_irbloc(LBL2, [[ExprAff(R, B)]])
 
-G15_IRA.g.add_uniq_edge(G15_IRB0.label, G15_IRB1.label)
-G15_IRA.g.add_uniq_edge(G15_IRB1.label, G15_IRB2.label)
-G15_IRA.g.add_uniq_edge(G15_IRB1.label, G15_IRB1.label)
+G15_IRA.graph.add_uniq_edge(G15_IRB0.label, G15_IRB1.label)
+G15_IRA.graph.add_uniq_edge(G15_IRB1.label, G15_IRB2.label)
+G15_IRA.graph.add_uniq_edge(G15_IRB1.label, G15_IRB1.label)
 
 G15_IRA.blocs = dict([(irb.label, irb) for irb in [G15_IRB0, G15_IRB1,
                                                    G15_IRB2]])
@@ -465,14 +465,14 @@ G16_IRB3 = gen_irbloc(LBL3, [[ExprAff(R, D)]])
 G16_IRB4 = gen_irbloc(LBL4, [[ExprAff(R, A)]])
 G16_IRB5 = gen_irbloc(LBL5, [[ExprAff(R, A)]])
 
-G16_IRA.g.add_uniq_edge(G16_IRB0.label, G16_IRB1.label)
-G16_IRA.g.add_uniq_edge(G16_IRB1.label, G16_IRB2.label)
-G16_IRA.g.add_uniq_edge(G16_IRB2.label, G16_IRB1.label)
-G16_IRA.g.add_uniq_edge(G16_IRB1.label, G16_IRB3.label)
-G16_IRA.g.add_uniq_edge(G16_IRB3.label, G16_IRB1.label)
-G16_IRA.g.add_uniq_edge(G16_IRB1.label, G16_IRB4.label)
-G16_IRA.g.add_uniq_edge(G16_IRB4.label, G16_IRB1.label)
-G16_IRA.g.add_uniq_edge(G16_IRB1.label, G16_IRB5.label)
+G16_IRA.graph.add_uniq_edge(G16_IRB0.label, G16_IRB1.label)
+G16_IRA.graph.add_uniq_edge(G16_IRB1.label, G16_IRB2.label)
+G16_IRA.graph.add_uniq_edge(G16_IRB2.label, G16_IRB1.label)
+G16_IRA.graph.add_uniq_edge(G16_IRB1.label, G16_IRB3.label)
+G16_IRA.graph.add_uniq_edge(G16_IRB3.label, G16_IRB1.label)
+G16_IRA.graph.add_uniq_edge(G16_IRB1.label, G16_IRB4.label)
+G16_IRA.graph.add_uniq_edge(G16_IRB4.label, G16_IRB1.label)
+G16_IRA.graph.add_uniq_edge(G16_IRB1.label, G16_IRB5.label)
 
 G16_IRA.blocs = dict([(irb.label, irb) for irb in [G16_IRB0, G16_IRB1,
                                                    G16_IRB2, G16_IRB3,
@@ -489,8 +489,8 @@ G17_IRB1 = gen_irbloc(LBL1, [[ExprAff(A, D),
                               ExprAff(B, D)]])
 G17_IRB2 = gen_irbloc(LBL2, [[ExprAff(A, A - B)]])
 
-G17_IRA.g.add_uniq_edge(G17_IRB0.label, G17_IRB1.label)
-G17_IRA.g.add_uniq_edge(G17_IRB1.label, G17_IRB2.label)
+G17_IRA.graph.add_uniq_edge(G17_IRB0.label, G17_IRB1.label)
+G17_IRA.graph.add_uniq_edge(G17_IRB1.label, G17_IRB2.label)
 
 G17_IRA.blocs = dict([(irb.label, irb) for irb in [G17_IRB0, G17_IRB1,
                                                    G17_IRB2]])
@@ -1116,7 +1116,7 @@ for test_nb, test in enumerate([(G1_IRA, G1_INPUT, G1_OUTPUT),
     print "[+] Test", test_nb + 1
     g_ira, (depnodes, heads), g_test_output = test
 
-    open("graph_%02d.dot" % (test_nb + 1), "w").write(g_ira.g.dot())
+    open("graph_%02d.dot" % (test_nb + 1), "w").write(g_ira.graph.dot())
 
     # Different options
     suffix_key_list = ["", "_nosimp", "_nomem", "_nocall",

--- a/test/analysis/depgraph.py
+++ b/test/analysis/depgraph.py
@@ -76,13 +76,13 @@ class Arch(object):
         return SP
 
 
-class IRATest(ir, ira):
+class IRATest(ira):
 
     """Fake IRA class for tests"""
 
     def __init__(self, symbol_pool=None):
         arch = Arch()
-        ir.__init__(self, arch, 32, symbol_pool)
+        super(IRATest, self).__init__(arch, 32, symbol_pool)
         self.IRDst = PC
         self.ret_reg = R
 

--- a/test/ir/analysis.py
+++ b/test/ir/analysis.py
@@ -73,10 +73,8 @@ G1_IRB0 = gen_irbloc(LBL0, [[ExprAff(a, CST1)], [ExprAff(b, CST2)]])
 G1_IRB1 = gen_irbloc(LBL1, [[ExprAff(a, b)]])
 G1_IRB2 = gen_irbloc(LBL2, [[ExprAff(r, a)]])
 
-G1_IRA.gen_graph()
-
-G1_IRA.g.add_uniq_edge(G1_IRB0.label, G1_IRB1.label)
-G1_IRA.g.add_uniq_edge(G1_IRB1.label, G1_IRB2.label)
+G1_IRA.graph.add_uniq_edge(G1_IRB0.label, G1_IRB1.label)
+G1_IRA.graph.add_uniq_edge(G1_IRB1.label, G1_IRB2.label)
 
 G1_IRA.blocs = {irb.label : irb for irb in [G1_IRB0, G1_IRB1, G1_IRB2]}
 
@@ -98,11 +96,9 @@ G2_IRB0 = gen_irbloc(LBL0, [[ExprAff(a, CST1)], [ExprAff(r, CST1)]])
 G2_IRB1 = gen_irbloc(LBL1, [[ExprAff(a, a+CST1)]])
 G2_IRB2 = gen_irbloc(LBL2, [[ExprAff(a, r)]])
 
-G2_IRA.gen_graph()
-
-G2_IRA.g.add_uniq_edge(G2_IRB0.label, G2_IRB1.label)
-G2_IRA.g.add_uniq_edge(G2_IRB1.label, G2_IRB2.label)
-G2_IRA.g.add_uniq_edge(G2_IRB1.label, G2_IRB1.label)
+G2_IRA.graph.add_uniq_edge(G2_IRB0.label, G2_IRB1.label)
+G2_IRA.graph.add_uniq_edge(G2_IRB1.label, G2_IRB2.label)
+G2_IRA.graph.add_uniq_edge(G2_IRB1.label, G2_IRB1.label)
 
 G2_IRA.blocs = {irb.label : irb for irb in [G2_IRB0, G2_IRB1, G2_IRB2]}
 
@@ -124,11 +120,9 @@ G3_IRB0 = gen_irbloc(LBL0, [[ExprAff(a, CST1)]])
 G3_IRB1 = gen_irbloc(LBL1, [[ExprAff(a, a+CST1)]])
 G3_IRB2 = gen_irbloc(LBL2, [[ExprAff(r, a)]])
 
-G3_IRA.gen_graph()
-
-G3_IRA.g.add_uniq_edge(G3_IRB0.label, G3_IRB1.label)
-G3_IRA.g.add_uniq_edge(G3_IRB1.label, G3_IRB2.label)
-G3_IRA.g.add_uniq_edge(G3_IRB1.label, G3_IRB1.label)
+G3_IRA.graph.add_uniq_edge(G3_IRB0.label, G3_IRB1.label)
+G3_IRA.graph.add_uniq_edge(G3_IRB1.label, G3_IRB2.label)
+G3_IRA.graph.add_uniq_edge(G3_IRB1.label, G3_IRB1.label)
 
 G3_IRA.blocs = {irb.label : irb for irb in [G3_IRB0, G3_IRB1, G3_IRB2]}
 
@@ -151,12 +145,10 @@ G4_IRB1 = gen_irbloc(LBL1, [[ExprAff(a, a+CST1)]])
 G4_IRB2 = gen_irbloc(LBL2, [[ExprAff(a, a+CST2)]])
 G4_IRB3 = gen_irbloc(LBL3, [[ExprAff(a, CST3)], [ExprAff(r, a)]])
 
-G4_IRA.gen_graph()
-
-G4_IRA.g.add_uniq_edge(G4_IRB0.label, G4_IRB1.label)
-G4_IRA.g.add_uniq_edge(G4_IRB0.label, G4_IRB2.label)
-G4_IRA.g.add_uniq_edge(G4_IRB1.label, G4_IRB3.label)
-G4_IRA.g.add_uniq_edge(G4_IRB2.label, G4_IRB3.label)
+G4_IRA.graph.add_uniq_edge(G4_IRB0.label, G4_IRB1.label)
+G4_IRA.graph.add_uniq_edge(G4_IRB0.label, G4_IRB2.label)
+G4_IRA.graph.add_uniq_edge(G4_IRB1.label, G4_IRB3.label)
+G4_IRA.graph.add_uniq_edge(G4_IRB2.label, G4_IRB3.label)
 
 G4_IRA.blocs = {irb.label : irb for irb in [G4_IRB0, G4_IRB1, G4_IRB2,
                                             G4_IRB3]}
@@ -168,8 +160,6 @@ G4_EXP_IRB0 = gen_irbloc(LBL0, [[]])
 G4_EXP_IRB1 = gen_irbloc(LBL1, [[]])
 G4_EXP_IRB2 = gen_irbloc(LBL2, [[]])
 G4_EXP_IRB3 = gen_irbloc(LBL3, [[ExprAff(a, CST3)], [ExprAff(r, a)]])
-
-G4_EXP_IRA.gen_graph()
 
 G4_EXP_IRA.blocs = {irb.label : irb for irb in [G4_EXP_IRB0, G4_EXP_IRB1,
                                                 G4_EXP_IRB2, G4_EXP_IRB3]}
@@ -185,15 +175,13 @@ G5_IRB3 = gen_irbloc(LBL3, [[ExprAff(a, a+CST3)]])
 G5_IRB4 = gen_irbloc(LBL4, [[ExprAff(a, a+CST1)]])
 G5_IRB5 = gen_irbloc(LBL5, [[ExprAff(a, r)]])
 
-G5_IRA.gen_graph()
-
-G5_IRA.g.add_uniq_edge(G5_IRB0.label, G5_IRB1.label)
-G5_IRA.g.add_uniq_edge(G5_IRB1.label, G5_IRB2.label)
-G5_IRA.g.add_uniq_edge(G5_IRB1.label, G5_IRB3.label)
-G5_IRA.g.add_uniq_edge(G5_IRB2.label, G5_IRB4.label)
-G5_IRA.g.add_uniq_edge(G5_IRB3.label, G5_IRB4.label)
-G5_IRA.g.add_uniq_edge(G5_IRB4.label, G5_IRB5.label)
-G5_IRA.g.add_uniq_edge(G5_IRB4.label, G5_IRB1.label)
+G5_IRA.graph.add_uniq_edge(G5_IRB0.label, G5_IRB1.label)
+G5_IRA.graph.add_uniq_edge(G5_IRB1.label, G5_IRB2.label)
+G5_IRA.graph.add_uniq_edge(G5_IRB1.label, G5_IRB3.label)
+G5_IRA.graph.add_uniq_edge(G5_IRB2.label, G5_IRB4.label)
+G5_IRA.graph.add_uniq_edge(G5_IRB3.label, G5_IRB4.label)
+G5_IRA.graph.add_uniq_edge(G5_IRB4.label, G5_IRB5.label)
+G5_IRA.graph.add_uniq_edge(G5_IRB4.label, G5_IRB1.label)
 
 G5_IRA.blocs = {irb.label : irb for irb in [G5_IRB0, G5_IRB1, G5_IRB2, G5_IRB3,
                                             G5_IRB4, G5_IRB5]}
@@ -207,8 +195,6 @@ G5_EXP_IRB2 = gen_irbloc(LBL2, [[]])
 G5_EXP_IRB3 = gen_irbloc(LBL3, [[]])
 G5_EXP_IRB4 = gen_irbloc(LBL4, [[]])
 G5_EXP_IRB5 = gen_irbloc(LBL5, [[]])
-
-G5_EXP_IRA.gen_graph()
 
 G5_EXP_IRA.blocs = {irb.label : irb for irb in [G5_EXP_IRB0, G5_EXP_IRB1,
                                                 G5_EXP_IRB2, G5_EXP_IRB3,
@@ -225,12 +211,10 @@ G6_IRB2 = gen_irbloc(LBL2, [[ExprAff(a, b)]])
 G6_IRB3 = gen_irbloc(LBL3, [[ExprAff(r, CST2)]])
 
 
-G6_IRA.gen_graph()
-
-G6_IRA.g.add_uniq_edge(G6_IRB0.label, G6_IRB1.label)
-G6_IRA.g.add_uniq_edge(G6_IRB1.label, G6_IRB2.label)
-G6_IRA.g.add_uniq_edge(G6_IRB2.label, G6_IRB1.label)
-G6_IRA.g.add_uniq_edge(G6_IRB2.label, G6_IRB3.label)
+G6_IRA.graph.add_uniq_edge(G6_IRB0.label, G6_IRB1.label)
+G6_IRA.graph.add_uniq_edge(G6_IRB1.label, G6_IRB2.label)
+G6_IRA.graph.add_uniq_edge(G6_IRB2.label, G6_IRB1.label)
+G6_IRA.graph.add_uniq_edge(G6_IRB2.label, G6_IRB3.label)
 
 G6_IRA.blocs = {irb.label : irb for irb in [G6_IRB0, G6_IRB1, G6_IRB2,
                                             G6_IRB3]}
@@ -256,13 +240,11 @@ G7_IRB2 = gen_irbloc(LBL2, [[ExprAff(a, a+CST2)]])
 G7_IRB3 = gen_irbloc(LBL3, [[ExprAff(a, r)]])
 
 
-G7_IRA.gen_graph()
-
-G7_IRA.g.add_uniq_edge(G7_IRB0.label, G7_IRB1.label)
-G7_IRA.g.add_uniq_edge(G7_IRB1.label, G7_IRB2.label)
-G7_IRA.g.add_uniq_edge(G7_IRB2.label, G7_IRB1.label)
-G7_IRA.g.add_uniq_edge(G7_IRB2.label, G7_IRB3.label)
-G7_IRA.g.add_uniq_edge(G7_IRB0.label, G7_IRB2.label)
+G7_IRA.graph.add_uniq_edge(G7_IRB0.label, G7_IRB1.label)
+G7_IRA.graph.add_uniq_edge(G7_IRB1.label, G7_IRB2.label)
+G7_IRA.graph.add_uniq_edge(G7_IRB2.label, G7_IRB1.label)
+G7_IRA.graph.add_uniq_edge(G7_IRB2.label, G7_IRB3.label)
+G7_IRA.graph.add_uniq_edge(G7_IRB0.label, G7_IRB2.label)
 
 
 G7_IRA.blocs = {irb.label : irb for irb in [G7_IRB0, G7_IRB1, G7_IRB2,
@@ -289,13 +271,11 @@ G8_IRB2 = gen_irbloc(LBL2, [[ExprAff(b, b+CST2)]])
 G8_IRB3 = gen_irbloc(LBL3, [[ExprAff(a, b)]])
 
 
-G8_IRA.gen_graph()
-
-G8_IRA.g.add_uniq_edge(G8_IRB0.label, G8_IRB1.label)
-G8_IRA.g.add_uniq_edge(G8_IRB1.label, G8_IRB2.label)
-G8_IRA.g.add_uniq_edge(G8_IRB2.label, G8_IRB1.label)
-G8_IRA.g.add_uniq_edge(G8_IRB2.label, G8_IRB3.label)
-G8_IRA.g.add_uniq_edge(G8_IRB3.label, G8_IRB2.label)
+G8_IRA.graph.add_uniq_edge(G8_IRB0.label, G8_IRB1.label)
+G8_IRA.graph.add_uniq_edge(G8_IRB1.label, G8_IRB2.label)
+G8_IRA.graph.add_uniq_edge(G8_IRB2.label, G8_IRB1.label)
+G8_IRA.graph.add_uniq_edge(G8_IRB2.label, G8_IRB3.label)
+G8_IRA.graph.add_uniq_edge(G8_IRB3.label, G8_IRB2.label)
 
 
 G8_IRA.blocs = {irb.label : irb for irb in [G8_IRB0, G8_IRB1, G8_IRB2,
@@ -324,16 +304,14 @@ G9_IRB3 = gen_irbloc(LBL3, [[ExprAff(a, b)]])
 G9_IRB4 = gen_irbloc(LBL4, [[ExprAff(r, a)], [ExprAff(r, b)]])
 
 
-G9_IRA.gen_graph()
-
-G9_IRA.g.add_uniq_edge(G9_IRB0.label, G9_IRB4.label)
-G9_IRA.g.add_uniq_edge(G9_IRB0.label, G9_IRB1.label)
-G9_IRA.g.add_uniq_edge(G9_IRB1.label, G9_IRB0.label)
-G9_IRA.g.add_uniq_edge(G9_IRB1.label, G9_IRB4.label)
-G9_IRA.g.add_uniq_edge(G9_IRB1.label, G9_IRB2.label)
-G9_IRA.g.add_uniq_edge(G9_IRB2.label, G9_IRB0.label)
-G9_IRA.g.add_uniq_edge(G9_IRB2.label, G9_IRB3.label)
-G9_IRA.g.add_uniq_edge(G9_IRB3.label, G9_IRB4.label)
+G9_IRA.graph.add_uniq_edge(G9_IRB0.label, G9_IRB4.label)
+G9_IRA.graph.add_uniq_edge(G9_IRB0.label, G9_IRB1.label)
+G9_IRA.graph.add_uniq_edge(G9_IRB1.label, G9_IRB0.label)
+G9_IRA.graph.add_uniq_edge(G9_IRB1.label, G9_IRB4.label)
+G9_IRA.graph.add_uniq_edge(G9_IRB1.label, G9_IRB2.label)
+G9_IRA.graph.add_uniq_edge(G9_IRB2.label, G9_IRB0.label)
+G9_IRA.graph.add_uniq_edge(G9_IRB2.label, G9_IRB3.label)
+G9_IRA.graph.add_uniq_edge(G9_IRB3.label, G9_IRB4.label)
 
 
 G9_IRA.blocs = {irb.label : irb for irb in [G9_IRB0, G9_IRB1, G9_IRB2,
@@ -364,12 +342,10 @@ G10_IRB2 = gen_irbloc(LBL2, [[ExprAff(a, b)]])
 G10_IRB3 = gen_irbloc(LBL3, [[ExprAff(r, CST1)]])
 
 
-G10_IRA.gen_graph()
-
-G10_IRA.g.add_uniq_edge(G10_IRB0.label, G10_IRB1.label)
-G10_IRA.g.add_uniq_edge(G10_IRB1.label, G10_IRB2.label)
-G10_IRA.g.add_uniq_edge(G10_IRB2.label, G10_IRB1.label)
-G10_IRA.g.add_uniq_edge(G10_IRB2.label, G10_IRB3.label)
+G10_IRA.graph.add_uniq_edge(G10_IRB0.label, G10_IRB1.label)
+G10_IRA.graph.add_uniq_edge(G10_IRB1.label, G10_IRB2.label)
+G10_IRA.graph.add_uniq_edge(G10_IRB2.label, G10_IRB1.label)
+G10_IRA.graph.add_uniq_edge(G10_IRB2.label, G10_IRB3.label)
 
 G10_IRA.blocs = {irb.label : irb for irb in [G10_IRB0, G10_IRB1,
                                              G10_IRB2, G10_IRB3]}
@@ -396,13 +372,11 @@ G11_IRB3 = gen_irbloc(LBL3, [[ExprAff(a, a+CST1)]])
 G11_IRB4 = gen_irbloc(LBL4, [[ExprAff(b, b+CST1)]])
 
 
-G11_IRA.gen_graph()
-
-G11_IRA.g.add_uniq_edge(G11_IRB0.label, G11_IRB1.label)
-#G11_IRA.g.add_uniq_edge(G11_IRB3.label, G11_IRB1.label)
-G11_IRA.g.add_uniq_edge(G11_IRB1.label, G11_IRB0.label)
-#G11_IRA.g.add_uniq_edge(G11_IRB4.label, G11_IRB0.label)
-G11_IRA.g.add_uniq_edge(G11_IRB1.label, G11_IRB2.label)
+G11_IRA.graph.add_uniq_edge(G11_IRB0.label, G11_IRB1.label)
+#G11_IRA.graph.add_uniq_edge(G11_IRB3.label, G11_IRB1.label)
+G11_IRA.graph.add_uniq_edge(G11_IRB1.label, G11_IRB0.label)
+#G11_IRA.graph.add_uniq_edge(G11_IRB4.label, G11_IRB0.label)
+G11_IRA.graph.add_uniq_edge(G11_IRB1.label, G11_IRB2.label)
 
 G11_IRA.blocs = {irb.label : irb for irb in [G11_IRB0, G11_IRB1, G11_IRB2]}
 
@@ -430,13 +404,11 @@ G12_IRB3 = gen_irbloc(LBL3, [[ExprAff(r, CST3)]])
 G12_IRB4 = gen_irbloc(LBL4, [[ExprAff(r, CST2)]])
 G12_IRB5 = gen_irbloc(LBL5, [[ExprAff(r, b)]])
 
-G12_IRA.gen_graph()
-
-G12_IRA.g.add_uniq_edge(G12_IRB0.label, G12_IRB1.label)
-G12_IRA.g.add_uniq_edge(G12_IRB0.label, G12_IRB2.label)
-G12_IRA.g.add_uniq_edge(G12_IRB2.label, G12_IRB3.label)
-G12_IRA.g.add_uniq_edge(G12_IRB2.label, G12_IRB4.label)
-G12_IRA.g.add_uniq_edge(G12_IRB4.label, G12_IRB5.label)
+G12_IRA.graph.add_uniq_edge(G12_IRB0.label, G12_IRB1.label)
+G12_IRA.graph.add_uniq_edge(G12_IRB0.label, G12_IRB2.label)
+G12_IRA.graph.add_uniq_edge(G12_IRB2.label, G12_IRB3.label)
+G12_IRA.graph.add_uniq_edge(G12_IRB2.label, G12_IRB4.label)
+G12_IRA.graph.add_uniq_edge(G12_IRB4.label, G12_IRB5.label)
 
 G12_IRA.blocs = {irb.label : irb for irb in [G12_IRB0, G12_IRB1, G12_IRB2,
                                              G12_IRB3, G12_IRB4, G12_IRB5]}
@@ -467,12 +439,10 @@ G13_IRB2 = gen_irbloc(LBL2, [[ExprAff(d, CST2)], [ExprAff(a, b+CST1),
 G13_IRB3 = gen_irbloc(LBL3, [[]]) # lost son
 G13_IRB4 = gen_irbloc(LBL4, [[ExprAff(b, CST2)]])
 
-G13_IRA.gen_graph()
-
-G13_IRA.g.add_uniq_edge(G13_IRB0.label, G13_IRB1.label)
-G13_IRA.g.add_uniq_edge(G13_IRB0.label, G13_IRB4.label)
-G13_IRA.g.add_uniq_edge(G13_IRB2.label, G13_IRB3.label)
-G13_IRA.g.add_uniq_edge(G13_IRB4.label, G13_IRB2.label)
+G13_IRA.graph.add_uniq_edge(G13_IRB0.label, G13_IRB1.label)
+G13_IRA.graph.add_uniq_edge(G13_IRB0.label, G13_IRB4.label)
+G13_IRA.graph.add_uniq_edge(G13_IRB2.label, G13_IRB3.label)
+G13_IRA.graph.add_uniq_edge(G13_IRB4.label, G13_IRB2.label)
 
 G13_IRA.blocs = {irb.label : irb for irb in [G13_IRB0, G13_IRB1, G13_IRB2,
                                              G13_IRB4]}
@@ -501,9 +471,7 @@ G14_IRB0 = gen_irbloc(LBL0, [[ExprAff(a, CST1)], [ExprAff(c, a)],
                              [ExprAff(a, CST2)]])
 G14_IRB1 = gen_irbloc(LBL1, [[ExprAff(r, a+c)]])
 
-G14_IRA.gen_graph()
-
-G14_IRA.g.add_uniq_edge(G14_IRB0.label, G14_IRB1.label)
+G14_IRA.graph.add_uniq_edge(G14_IRB0.label, G14_IRB1.label)
 
 G14_IRA.blocs = {irb.label : irb for irb in [G14_IRB0, G14_IRB1]}
 
@@ -526,9 +494,7 @@ G15_IRB0 = gen_irbloc(LBL0, [[ExprAff(a, CST2)], [ExprAff(a, CST1),
                                                   ExprAff(c, CST1)]])
 G15_IRB1 = gen_irbloc(LBL1, [[ExprAff(r, a)]])
 
-G15_IRA.gen_graph()
-
-G15_IRA.g.add_uniq_edge(G15_IRB0.label, G15_IRB1.label)
+G15_IRA.graph.add_uniq_edge(G15_IRB0.label, G15_IRB1.label)
 
 G15_IRA.blocs = {irb.label : irb for irb in [G15_IRB0, G15_IRB1]}
 
@@ -550,10 +516,8 @@ G16_IRB0 = gen_irbloc(LBL0, [[ExprAff(a, CST1), ExprAff(b, CST2),
 G16_IRB1 = gen_irbloc(LBL1, [[ExprAff(r, a+b)], [ExprAff(r, c+r)]])
 G16_IRB2 = gen_irbloc(LBL2, [[]])
 
-G16_IRA.gen_graph()
-
-G16_IRA.g.add_uniq_edge(G16_IRB0.label, G16_IRB1.label)
-G16_IRA.g.add_uniq_edge(G16_IRB1.label, G16_IRB2.label)
+G16_IRA.graph.add_uniq_edge(G16_IRB0.label, G16_IRB1.label)
+G16_IRA.graph.add_uniq_edge(G16_IRB1.label, G16_IRB2.label)
 
 G16_IRA.blocs = {irb.label : irb for irb in [G16_IRB0, G16_IRB1]}
 
@@ -624,11 +588,9 @@ G17_IRB0 = gen_irbloc(LBL0, [[ExprAff(a, a*b),
 
                          ])
 
-G17_IRA.gen_graph()
-
 G17_IRA.blocs = {irb.label : irb for irb in [G17_IRB0]}
 
-G17_IRA.g.add_node(G17_IRB0.label)
+G17_IRA.graph.add_node(G17_IRB0.label)
 
 # Expected output for graph 17
 G17_EXP_IRA = IRATest()
@@ -696,13 +658,13 @@ for test_nb, test in enumerate([(G1_IRA, G1_EXP_IRA),
     print "[+] Test", test_nb+1
 
     # Print initial graph, for debug
-    open("graph_%02d.dot" % (test_nb+1), "w").write(g_ira.graph())
+    open("graph_%02d.dot" % (test_nb+1), "w").write(g_ira.graph.dot())
 
     # Simplify graph
     g_ira.dead_simp()
 
     # Print simplified graph, for debug
-    open("simp_graph_%02d.dot" % (test_nb+1), "w").write(g_ira.graph())
+    open("simp_graph_%02d.dot" % (test_nb+1), "w").write(g_ira.graph.dot())
 
     # Same number of blocks
     assert len(g_ira.blocs) == len(g_exp_ira.blocs)

--- a/test/ir/analysis.py
+++ b/test/ir/analysis.py
@@ -2,7 +2,7 @@
 from miasm2.expression.expression import ExprId, ExprInt32, ExprAff, ExprMem
 from miasm2.core.asmbloc import asm_label
 from miasm2.ir.analysis import ira
-from miasm2.ir.ir import ir, irbloc
+from miasm2.ir.ir import irbloc
 
 a = ExprId("a")
 b = ExprId("b")
@@ -52,11 +52,13 @@ class Arch(object):
     def getsp(self, _):
         return sp
 
-class IRATest(ir, ira):
+class IRATest(ira):
+
+    """Fake IRA class for tests"""
 
     def __init__(self, symbol_pool=None):
         arch = Arch()
-        ir.__init__(self, arch, 32, symbol_pool)
+        super(IRATest, self).__init__(arch, 32, symbol_pool)
         self.IRDst = pc
         self.ret_reg = r
 

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -337,13 +337,15 @@ class ExampleDisasmFull(ExampleDisassembler):
     """DisasmFull specificities:
     - script: disasm/full.py
     - flags: -g -s
-    - @products: graph_execflow.dot, graph_irflow.dot, lines.dot, out.dot
+    - @products: graph_execflow.dot, graph_irflow.dot, graph_irflow_raw.dot,
+                 lines.dot, out.dot
     """
 
     def __init__(self, *args, **kwargs):
         super(ExampleDisasmFull, self).__init__(*args, **kwargs)
         self.command_line = ["full.py", "-g", "-s", "-m"] + self.command_line
-        self.products += ["graph_execflow.dot", "graph_irflow.dot", "lines.dot"]
+        self.products += ["graph_execflow.dot", "graph_irflow.dot",
+                          "graph_irflow_raw.dot", "lines.dot"]
 
 
 testset += ExampleDisasmFull(["arml", Example.get_sample("demo_arm_l.bin"),


### PR DESCRIPTION
This PR refactors the relation between IR and IRA.
The code which is always trustable (which does not depend on the current ABI, etc. such as `dead_simp`) has been transfered from IRA to IR.

In addition, IRA is no more an old-style object, but inherits from IR. That way, the presence of `self.blocs`, for instance, is ensured.

Finally, the associated graph (was `self.g`, now `self.graph`) is now lazy computed. The call to `gen_graph` is no more needed, avoiding some algorithm per-requisites (DependencyGraph, dead simp).

:warning: the API `.graph()` does not longer return the DOT text of the graph, but the `DiGraphIR` instance associated. DOT can be obtain thanks to `.graph.dot()`.