### PR TITLE
Refactor asmlabel

### DIFF
--- a/miasm2/arch/mips32/arch.py
+++ b/miasm2/arch/mips32/arch.py
@@ -189,7 +189,7 @@ class instruction_mips32(cpu.instruction):
 
 
 class mn_mips32(cpu.cls_mn):
-    delayslot = 0
+    delayslot = 1
     name = "mips32"
     regs = regs
     bintree = {}

--- a/miasm2/arch/mips32/arch.py
+++ b/miasm2/arch/mips32/arch.py
@@ -297,7 +297,7 @@ class mips32_fccreg(mips32_reg):
     parser = reg_info.parser
 
 class mips32_imm(cpu.imm_noarg):
-    parser = cpu.base_expr
+    parser = base_expr
 
 
 class mips32_s16imm_noarg(mips32_imm):

--- a/miasm2/core/asmbloc.py
+++ b/miasm2/core/asmbloc.py
@@ -77,7 +77,7 @@ class asm_constraint(object):
     c_next = "c_next"
     c_bad = "c_bad"
 
-    def __init__(self, label=None, c_t=c_to):
+    def __init__(self, label, c_t=c_to):
         self.label = label
         self.c_t = c_t
 
@@ -87,21 +87,21 @@ class asm_constraint(object):
 
 class asm_constraint_next(asm_constraint):
 
-    def __init__(self, label=None):
+    def __init__(self, label):
         super(asm_constraint_next, self).__init__(
             label, c_t=asm_constraint.c_next)
 
 
 class asm_constraint_to(asm_constraint):
 
-    def __init__(self, label=None):
+    def __init__(self, label):
         super(asm_constraint_to, self).__init__(
             label, c_t=asm_constraint.c_to)
 
 
 class asm_constraint_bad(asm_constraint):
 
-    def __init__(self, label=None):
+    def __init__(self, label):
         super(asm_constraint_bad, self).__init__(
             label, c_t=asm_constraint.c_bad)
 

--- a/miasm2/core/asmbloc.py
+++ b/miasm2/core/asmbloc.py
@@ -78,6 +78,9 @@ class asm_constraint(object):
     c_bad = "c_bad"
 
     def __init__(self, label, c_t=c_to):
+        # Sanity check
+        assert isinstance(label, asm_label)
+
         self.label = label
         self.c_t = c_t
 

--- a/miasm2/core/asmbloc.py
+++ b/miasm2/core/asmbloc.py
@@ -501,8 +501,6 @@ def split_bloc(mnemo, attrib, pool_bin, blocs,
     bloc_dst = [symbol_pool._offset2label[x] for x in more_ref]
     for b in blocs:
         for c in b.bto:
-            if not isinstance(c.label, asm_label):
-                continue
             if c.c_t == asm_constraint.c_bad:
                 continue
             bloc_dst.append(c.label)
@@ -525,9 +523,7 @@ def split_bloc(mnemo, attrib, pool_bin, blocs,
                 log_asmbloc.error("cannot split %x!!", off)
                 continue
             if dis_bloc_callback:
-                offsets_to_dis = set(
-                    [x.label.offset for x in new_b.bto
-                     if isinstance(x.label, asm_label)])
+                offsets_to_dis = set(x.label.offset for x in new_b.bto)
                 dis_bloc_callback(mn=mnemo, attrib=attrib, pool_bin=pool_bin,
                                   cur_bloc=new_b, offsets_to_dis=offsets_to_dis,
                                   symbol_pool=symbol_pool)
@@ -628,15 +624,7 @@ def bloc2graph(blocks, label=False, lines=True):
     # Generate links
     for block in blocks:
         for next_b in block.bto:
-            if (isinstance(next_b.label, m2_expr.ExprId) or
-                    isinstance(next_b.label, asm_label)):
-                src, dst, cst = block.label.name, next_b.label.name, next_b.c_t
-            else:
-                continue
-            if isinstance(src, asm_label):
-                src = src.name
-            if isinstance(dst, asm_label):
-                dst = dst.name
+            src, dst, cst = block.label.name, next_b.label.name, next_b.c_t
 
             edge_color = "black"
             if next_b.c_t == asm_constraint.c_next:
@@ -1145,8 +1133,7 @@ class basicblocs:
         self.blocs[b.label] = b
         self.g.add_node(b.label)
         for dst in b.bto:
-            if isinstance(dst.label, asm_label):
-                self.g.add_edge(b.label, dst.label)
+            self.g.add_edge(b.label, dst.label)
 
     def add_blocs(self, ab):
         for b in ab:
@@ -1164,7 +1151,7 @@ class basicblocs:
 def find_parents(blocs, l):
     p = set()
     for b in blocs:
-        if l in [x.label for x in b.bto if isinstance(x.label, asm_label)]:
+        if l in [x.label for x in b.bto]:
             p.add(b.label)
     return p
 
@@ -1312,8 +1299,6 @@ def bloc_merge(blocs, dont_merge=[]):
 
         # update parents
         for s in b.bto:
-            if not isinstance(s.label, asm_label):
-                continue
             if s.label.name == None:
                 continue
             if not s.label in blocby_label:

--- a/miasm2/core/parse_asm.py
+++ b/miasm2/core/parse_asm.py
@@ -305,7 +305,7 @@ def parse_txt(mnemo, attrib, txt, symbol_pool=None):
                             continue
                         if dst in mnemo.regs.all_regs_ids:
                             continue
-                        cur_block.addto(asmbloc.asm_constraint(dst, C_TO))
+                        cur_block.addto(asmbloc.asm_constraint(dst.name, C_TO))
 
                 if not line.splitflow():
                     block_to_nlink = None

--- a/miasm2/core/parse_asm.py
+++ b/miasm2/core/parse_asm.py
@@ -238,10 +238,9 @@ def parse_txt(mnemo, attrib, txt, symbol_pool=None):
     delayslot = 0
     while i < len(lines):
         if delayslot:
+            delayslot -= 1
             if delayslot == 0:
                 state = STATE_NO_BLOC
-            else:
-                delayslot -= 1
         line = lines[i]
         # no current block
         if state == STATE_NO_BLOC:
@@ -311,9 +310,7 @@ def parse_txt(mnemo, attrib, txt, symbol_pool=None):
                 if not line.splitflow():
                     block_to_nlink = None
 
-                delayslot = line.delayslot
-                if delayslot == 0:
-                    state = STATE_NO_BLOC
+                delayslot = line.delayslot + 1
             else:
                 raise RuntimeError("unknown class %s" % line.__class__)
         i += 1

--- a/miasm2/core/parse_asm.py
+++ b/miasm2/core/parse_asm.py
@@ -316,5 +316,9 @@ def parse_txt(mnemo, attrib, txt, symbol_pool=None):
         i += 1
 
     for block in blocks:
+        # Fix multiple constraints
+        block.fix_constraints()
+
+        # Log block
         asmbloc.log_asmbloc.info(block)
     return blocks, symbol_pool


### PR DESCRIPTION
With this PR:
* `asm_constraint` always takes a `label` at init, and this `label` must be an  `asm_label` instance
* block list of ASM returned during disassembling / assembling have this property: for a given block and a given destination:
 * there is only one constraint between these two blocks (starting from the first block)
 * if, during construction, there are several constraint with the same type, pick one of them
 * if, during construction, there are several type of constraint with at least one `c_bad`, raise an error
 * if, during construction, there are both `c_next` and `c_to`, conserve only `c_to`

For instance:
```
JNZ next
next:
    ....
```
now returns only one constraint `c_next` for the `JNZ` block (in order to simplify algorithms).

In addition, a fix on delayslot management in MIPS32 architecture was necessary (creds @serpilliere ).