### PR TITLE
Instruction slots

### DIFF
--- a/miasm2/arch/aarch64/arch.py
+++ b/miasm2/arch/aarch64/arch.py
@@ -325,6 +325,7 @@ conds_inv_expr, _, conds_inv_info = gen_regs(CONDS_INV, {})
 
 
 class instruction_aarch64(instruction):
+    __slots__ = []
     delayslot = 0
 
     def __init__(self, *args, **kargs):

--- a/miasm2/arch/arm/arch.py
+++ b/miasm2/arch/arm/arch.py
@@ -278,6 +278,7 @@ class additional_info:
 
 
 class instruction_arm(instruction):
+    __slots__ = []
     delayslot = 0
 
     def __init__(self, *args, **kargs):
@@ -420,6 +421,8 @@ class instruction_arm(instruction):
         return ExprInt_from(expr, self.offset+8)
 
 class instruction_armt(instruction_arm):
+    __slots__ = []
+    delayslot = 0
 
     def __init__(self, *args, **kargs):
         super(instruction_armt, self).__init__(*args, **kargs)

--- a/miasm2/arch/mips32/arch.py
+++ b/miasm2/arch/mips32/arch.py
@@ -78,6 +78,7 @@ br_2 = ['BEQ', 'BEQL', 'BNE']
 
 
 class instruction_mips32(cpu.instruction):
+    __slots__ = []
     delayslot = 1
 
     def __init__(self, *args, **kargs):

--- a/miasm2/arch/msp430/arch.py
+++ b/miasm2/arch/msp430/arch.py
@@ -107,6 +107,7 @@ class additional_info:
 
 
 class instruction_msp430(instruction):
+    __slots__ = []
     delayslot = 0
 
     def dstflow(self):

--- a/miasm2/arch/sh4/arch.py
+++ b/miasm2/arch/sh4/arch.py
@@ -386,6 +386,7 @@ class additional_info:
 
 
 class instruction_sh4(instruction):
+    __slots__ = []
     delayslot = 0
 
     def __init__(self, *args, **kargs):

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -465,6 +465,7 @@ class additional_info:
 
 
 class instruction_x86(instruction):
+    __slots__ = []
     delayslot = 0
 
     def __init__(self, *args, **kargs):

--- a/miasm2/core/cpu.py
+++ b/miasm2/core/cpu.py
@@ -910,6 +910,9 @@ class metamn(type):
 
 
 class instruction(object):
+    __slots__ = ["name", "mode", "args",
+                 "l", "b", "offset", "data",
+                 "additional_info", "delayslot"]
 
     def __init__(self, name, mode, args, additional_info=None):
         self.name = name

--- a/miasm2/expression/expression_helper.py
+++ b/miasm2/expression/expression_helper.py
@@ -293,8 +293,7 @@ class Variables_Identifier(object):
         if not isinstance(expr, m2_expr.ExprId):
             return False
 
-        return hasattr(expr, cls.is_var_ident) and \
-            getattr(expr, cls.is_var_ident) == True
+        return expr.is_var_ident
 
     def find_variables_rec(self, expr):
         """Recursive method called by find_variable to expand @expr.
@@ -311,7 +310,7 @@ class Variables_Identifier(object):
                 identifier = m2_expr.ExprId("%s%s" % (self.var_prefix,
                                                       self.var_indice.next()),
                                             size = expr.size)
-                setattr(identifier, self.__class__.is_var_ident, True)
+                identifier.is_var_ident = True
                 self._vars[identifier] = expr
 
             # Recursion stop case


### PR DESCRIPTION
Uses `__slots__` in `Expression` and in `Instruction` classes to limit memory usage.