### PR TITLE
Eval_Expr in jitter context

### DIFF
--- a/miasm2/ir/symbexec.py
+++ b/miasm2/ir/symbexec.py
@@ -336,7 +336,6 @@ class symbexec(object):
                 val = self.symbols[a][ptr_diff * 8 + b.size:a.size]
                 out.append((m2_expr.ExprMem(ex, val.size), val))
         return out
-
     # give mem stored overlapping requested mem ptr
     def get_mem_overlapping(self, e, eval_cache=None):
         if eval_cache is None:
@@ -452,3 +451,16 @@ class symbexec(object):
             if m.arg == 1:
                 del self.symbols[mem]
 
+    def apply_expr(self, expr):
+        """Evaluate @expr and apply side effect if needed (ie. if expr is an
+        assignment). Return the evaluated value"""
+
+        # Eval expression
+        to_eval = expr.src if isinstance(expr, m2_expr.ExprAff) else expr
+        ret = self.expr_simp(self.eval_expr(to_eval))
+
+        # Update value if needed
+        if isinstance(expr, m2_expr.ExprAff):
+            self.eval_ir([m2_expr.ExprAff(expr.dst, ret)])
+
+        return ret

--- a/miasm2/jitter/emulatedsymbexec.py
+++ b/miasm2/jitter/emulatedsymbexec.py
@@ -1,0 +1,83 @@
+import miasm2.expression.expression as m2_expr
+from miasm2.ir.symbexec import symbexec
+
+
+class EmulatedSymbExec(symbexec):
+    """Symbolic exec instance linked with a jitter"""
+
+    def __init__(self, cpu, *args, **kwargs):
+        """Instanciate an EmulatedSymbExec, associated to CPU @cpu and bind
+        memory accesses.
+        @cpu: JitCpu instance
+        """
+        super(EmulatedSymbExec, self).__init__(*args, **kwargs)
+        self.cpu = cpu
+        self.func_read = self._func_read
+        self.func_write = self._func_write
+
+    def reset_regs(self):
+        """Set registers value to 0. Ignore register aliases"""
+        for reg in self.ir_arch.arch.regs.all_regs_ids_no_alias:
+            self.symbols.symbols_id[reg] = m2_expr.ExprInt(0, size=reg.size)
+
+    # Memory management
+    def _func_read(self, expr_mem):
+        """Memory read wrapper for symbolic execution
+        @expr_mem: ExprMem"""
+
+        addr = expr_mem.arg.arg.arg
+        size = expr_mem.size / 8
+        value = self.cpu.get_mem(addr, size)
+
+        return m2_expr.ExprInt(int(value[::-1].encode("hex"), 16),
+                               expr_mem.size)
+
+    def _func_write(self, symb_exec, dest, data):
+        """Memory read wrapper for symbolic execution
+        @symb_exec: symbexec instance
+        @dest: ExprMem instance
+        @data: Expr instance"""
+
+        # Get the content to write
+        data = self.expr_simp(data)
+        if not isinstance(data, m2_expr.ExprInt):
+            raise RuntimeError("A simplification is missing: %s" % data)
+        to_write = data.arg.arg
+
+        # Format information
+        addr = dest.arg.arg.arg
+        size = data.size / 8
+        content = hex(to_write).replace("0x", "").replace("L", "")
+        content = "0" * (size * 2 - len(content)) + content
+        content = content.decode("hex")[::-1]
+
+        # Write in VmMngr context
+        self.cpu.set_mem(addr, content)
+
+    # Interaction symbexec <-> jitter
+    def update_cpu_from_engine(self):
+        """Updates @cpu instance according to new CPU values"""
+
+        for symbol in self.symbols:
+            if isinstance(symbol, m2_expr.ExprId):
+                if hasattr(self.cpu, symbol.name):
+                    value = self.symbols.symbols_id[symbol]
+                    if not isinstance(value, m2_expr.ExprInt):
+                        raise ValueError("A simplification is missing: %s" % value)
+
+                    setattr(self.cpu, symbol.name, value.arg.arg)
+            else:
+                raise NotImplementedError("Type not handled: %s" % symbol)
+
+
+    def update_engine_from_cpu(self):
+        """Updates CPU values according to @cpu instance"""
+
+        for symbol in self.symbols:
+            if isinstance(symbol, m2_expr.ExprId):
+                if hasattr(self.cpu, symbol.name):
+                    value = m2_expr.ExprInt(getattr(self.cpu, symbol.name),
+                                            symbol.size)
+                    self.symbols.symbols_id[symbol] = value
+            else:
+                raise NotImplementedError("Type not handled: %s" % symbol)

--- a/miasm2/jitter/jitcore_python.py
+++ b/miasm2/jitter/jitcore_python.py
@@ -38,7 +38,6 @@ class JitCore_Python(jitcore.JitCore):
 
             # Keep current location in irblocs
             cur_label = label
-            loop = True
 
             # Required to detect new instructions
             offsets_jitted = set()
@@ -48,17 +47,15 @@ class JitCore_Python(jitcore.JitCore):
             exec_engine.cpu = cpu
 
             # For each irbloc inside irblocs
-            while loop is True:
+            while True:
 
                 # Get the current bloc
-                loop = False
                 for irb in irblocs:
                     if irb.label == cur_label:
-                        loop = True
                         break
-
-                # Irblocs must end with returning an ExprInt instance
-                assert(loop is not False)
+                else:
+                    raise RuntimeError("Irblocs must end with returning an "
+                                       "ExprInt instance")
 
                 # Refresh CPU values according to @cpu instance
                 exec_engine.update_engine_from_cpu()

--- a/test/ir/symbexec.py
+++ b/test/ir/symbexec.py
@@ -7,7 +7,8 @@ import unittest
 class TestSymbExec(unittest.TestCase):
 
     def test_ClassDef(self):
-        from miasm2.expression.expression import ExprInt32, ExprId, ExprMem, ExprCompose
+        from miasm2.expression.expression import ExprInt32, ExprId, ExprMem, \
+            ExprCompose, ExprAff
         from miasm2.arch.x86.sem import ir_x86_32
         from miasm2.ir.symbexec import symbexec
 
@@ -52,6 +53,9 @@ class TestSymbExec(unittest.TestCase):
         self.assertEqual(set(e.modified()), set(e.symbols))
         self.assertRaises(
             KeyError, e.symbols.__getitem__, ExprMem(ExprInt32(100)))
+        self.assertEqual(e.apply_expr(id_eax), addr0)
+        self.assertEqual(e.apply_expr(ExprAff(id_eax, addr9)), addr9)
+        self.assertEqual(e.apply_expr(id_eax), addr9)
 
 if __name__ == '__main__':
     testsuite = unittest.TestLoader().loadTestsFromTestCase(TestSymbExec)

--- a/test/jitter/jitload.py
+++ b/test/jitter/jitload.py
@@ -1,0 +1,49 @@
+from pdb import pm
+
+from miasm2.jitter.csts import PAGE_READ, PAGE_WRITE
+from miasm2.analysis.machine import Machine
+from miasm2.expression.expression import ExprId, ExprInt32, ExprInt64, ExprAff, \
+    ExprMem
+
+# Initial data: from 'example/samples/x86_32_sc.bin'
+data = "8d49048d5b0180f90174058d5bffeb038d5b0189d8c3".decode("hex")
+
+# Init jitter
+myjit = Machine("x86_32").jitter()
+myjit.init_stack()
+
+run_addr = 0x40000000
+myjit.vm.add_memory_page(run_addr, PAGE_READ | PAGE_WRITE, data)
+
+# Sentinelle called on terminate
+def code_sentinelle(jitter):
+    jitter.run = False
+    jitter.pc = 0
+    return True
+
+myjit.push_uint32_t(0x1337beef)
+myjit.add_breakpoint(0x1337beef, code_sentinelle)
+
+# Run
+myjit.init_run(run_addr)
+myjit.continue_run()
+
+# Check end
+assert myjit.run is False
+
+# Check resulting state / accessors
+assert myjit.cpu.EAX == 0
+assert myjit.cpu.ECX == 4
+
+# Check eval_expr
+eax = ExprId("RAX", 64)[:32]
+imm0, imm4, imm4_64 = ExprInt32(0), ExprInt32(4), ExprInt64(4)
+memdata = ExprMem(ExprInt32(run_addr), len(data) * 8)
+assert myjit.eval_expr(eax) == imm0
+## Due to ExprAff construction, imm4 is "promoted" to imm4_64
+assert myjit.eval_expr(ExprAff(eax, imm4)) == imm4_64
+assert myjit.eval_expr(eax) == imm4
+## Changes must be passed on myjit.cpu instance
+assert myjit.cpu.EAX == 4
+## Memory
+assert myjit.eval_expr(memdata).arg.arg == int(data[::-1].encode("hex"), 16)

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -242,6 +242,12 @@ testset += RegressionTest(["depgraph.py"], base_dir="analysis",
                                                         (14, 1), (15, 1)))
                            for fname in fnames])
 
+## Jitter
+for script in ["jitload.py",
+               ]:
+    testset += RegressionTest([script], base_dir="jitter")
+
+
 # Examples
 class Example(Test):
     """Examples specificities:


### PR DESCRIPTION
This PR introduces `jitter.eval_expr`, a way to eval Miasm IR expression in the execution context, and related tests. Side effects of the expression are taken into account (ie in case of `ExprAff`).
The redundant code snippets with the core of `miasm2.jitter.jitcore_python` have been moved in a new class `EmulatedSymbExec`.

For instance:
```Python
# Eval only
jitter.eval_expr(ExprId("RAX")) == jitter.cpu.RAX
# Eval with assignement
jitter.eval_expr(ExprAff("RAX", ExprInt64(14)) == ExprInt64(14)
# Result is reported in the jitter context
jitter.cpu.RAX == 14
```

For other example, see `test/jitter/jitload.py`.
