### PR TITLE
Assignblock

### DIFF
--- a/example/expression/get_read_write.py
+++ b/example/expression/get_read_write.py
@@ -1,6 +1,8 @@
 from miasm2.arch.x86.arch import mn_x86
 from miasm2.expression.expression import get_rw
 from miasm2.arch.x86.ira import ir_a_x86_32
+
+
 print """
 Simple expression manipulation demo.
 Get read/written registers for a given instruction

--- a/miasm2/analysis/depgraph.py
+++ b/miasm2/analysis/depgraph.py
@@ -832,11 +832,11 @@ class DependencyGraph(object):
             read = set()
             modifier = False
 
-            for affect in self._get_affblock(depnode):
-                if affect.dst == depnode.element:
-                    elements = self._follow_apply_cb(affect.src)
-                    read.update(elements)
-                    modifier = True
+            assignblk = self._get_affblock(depnode)
+            if depnode.element in assignblk:
+                elements = self._follow_apply_cb(assignblk[depnode.element])
+                read.update(elements)
+                modifier = True
 
             # If it's not a modifier affblock, reinject current element
             if not modifier:

--- a/miasm2/arch/arm/ira.py
+++ b/miasm2/arch/arm/ira.py
@@ -2,7 +2,7 @@
 #-*- coding:utf-8 -*-
 
 from miasm2.expression.expression import *
-from miasm2.ir.ir import ir, irbloc
+from miasm2.ir.ir import ir, irbloc, AssignBlock
 from miasm2.ir.analysis import ira
 from miasm2.arch.arm.sem import ir_arml, ir_armtl, ir_armb, ir_armtb
 from miasm2.arch.arm.regs import *
@@ -33,26 +33,14 @@ class ir_a_arml(ir_a_arml_base):
         b.rw[-1][1].add(self.arch.regs.of)
         b.rw[-1][1].add(self.arch.regs.cf)
 
-    def call_effects(self, ad):
-        irs = [[ExprAff(self.ret_reg, ExprOp('call_func_ret', ad, self.sp)),
-                ExprAff(self.sp, ExprOp('call_func_stack', ad, self.sp)),
-                ]]
-        return irs
-
     def post_add_bloc(self, bloc, ir_blocs):
         ir.post_add_bloc(self, bloc, ir_blocs)
-        # flow_graph = DiGraph()
         for irb in ir_blocs:
-            # print 'X'*40
-            # print irb
             pc_val = None
             lr_val = None
-            for exprs in irb.irs:
-                for e in exprs:
-                    if e.dst == PC:
-                        pc_val = e.src
-                    if e.dst == LR:
-                        lr_val = e.src
+            for assignblk in irb.irs:
+                pc_val = assignblk.get(PC, pc_val)
+                lr_val = assignblk.get(LR, lr_val)
             if pc_val is None or lr_val is None:
                 continue
             if not isinstance(lr_val, ExprInt):
@@ -61,50 +49,17 @@ class ir_a_arml(ir_a_arml_base):
             l = bloc.lines[-1]
             if lr_val.arg != l.offset + l.l:
                 continue
-            # print 'IS CALL!'
+
+            # CALL
             lbl = bloc.get_next()
             new_lbl = self.gen_label()
             irs = self.call_effects(pc_val)
-            irs.append([ExprAff(self.IRDst, ExprId(lbl, size=self.pc.size))])
+            irs.append(AssignBlock([ExprAff(self.IRDst,
+                                            ExprId(lbl, size=self.pc.size))]))
             nbloc = irbloc(new_lbl, irs)
-            nbloc.lines = [l]*len(irs)
+            nbloc.lines = [l] * len(irs)
             self.blocs[new_lbl] = nbloc
             irb.dst = ExprId(new_lbl, size=self.pc.size)
-
-        """
-        if not bloc.lines:
-            return
-        l = bloc.lines[-1]
-        sub_call_dst = None
-        if not l.is_subcall():
-            return
-        sub_call_dst = l.args[0]
-        if self.ExprIsLabel(sub_call_dst):
-            sub_call_dst = sub_call_dst.name
-        for b in ir_blocs:
-            l = b.lines[-1]
-            sub_call_dst_b = None
-            sub_call_dst_b = l.args[0]
-            #if self.ExprIsLabel(sub_call_dst_b):
-            #    sub_call_dst_b = sub_call_dst.name
-            #if str(b.dst) == str(sub_call_dst_b):
-            #    pass
-            if not l.is_subcall():
-                continue
-            if b.dst != sub_call_dst_b:
-                continue
-            sub_call_dst_b = l.args[0]
-            if self.ExprIsLabel(sub_call_dst_b):
-                sub_call_dst_b = sub_call_dst.name
-            lbl = bloc.get_next()
-            new_lbl = self.gen_label()
-            irs = self.call_effects(l.args[0])
-            nbloc = irbloc(new_lbl, ExprId(lbl, size=self.pc.size), irs)
-            nbloc.lines = [l]
-            self.blocs[new_lbl] = nbloc
-            b.dst = ExprId(new_lbl, size=self.pc.size)
-        return
-        """
 
     def get_out_regs(self, b):
         return set([self.ret_reg, self.sp])

--- a/miasm2/arch/mips32/ira.py
+++ b/miasm2/arch/mips32/ira.py
@@ -2,7 +2,7 @@
 #-*- coding:utf-8 -*-
 
 from miasm2.expression.expression import *
-from miasm2.ir.ir import ir, irbloc
+from miasm2.ir.ir import ir, irbloc, AssignBlock
 from miasm2.ir.analysis import ira
 from miasm2.arch.mips32.sem import ir_mips32l, ir_mips32b
 from miasm2.arch.mips32.regs import *
@@ -18,26 +18,15 @@ class ir_a_mips32l(ir_mips32l, ira):
     def set_dead_regs(self, b):
         pass
 
-    def call_effects(self, ad):
-        irs = [[ExprAff(self.ret_reg, ExprOp('call_func_ret', ad, self.sp)),
-                ExprAff(self.sp, ExprOp('call_func_stack', ad, self.sp)),
-                ]]
-        return irs
-
     def post_add_bloc(self, bloc, ir_blocs):
         ir.post_add_bloc(self, bloc, ir_blocs)
         for irb in ir_blocs:
-            # print 'X'*40
-            # print irb
             pc_val = None
             lr_val = None
-            for exprs in irb.irs:
-                for e in exprs:
-                    if e.dst == PC:
-                        pc_val = e.src
-                    if e.dst == RA:
-                        lr_val = e.src
-            #print "XXX", pc_val, lr_val
+            for assignblk in irb.irs:
+                pc_val = assignblk.get(PC, pc_val)
+                lr_val = assignblk.get(RA, lr_val)
+
             if pc_val is None or lr_val is None:
                 continue
             if not expr_is_int_or_label(lr_val):
@@ -46,18 +35,17 @@ class ir_a_mips32l(ir_mips32l, ira):
                 lr_val = ExprInt32(lr_val.name.offset)
 
             l = bloc.lines[-2]
-            #print 'TEST', l, hex(lr_val.arg), hex(l.offset + 8)
-            #print lr_val.arg, hex(l.offset + l.l)
             if lr_val.arg != l.offset + 8:
                 raise ValueError("Wrong arg")
 
-            # print 'IS CALL!'
+            # CALL
             lbl = bloc.get_next()
             new_lbl = self.gen_label()
             irs = self.call_effects(pc_val)
-            irs.append([ExprAff(self.IRDst, ExprId(lbl, size=self.pc.size))])
+            irs.append(AssignBlock([ExprAff(self.IRDst,
+                                            ExprId(lbl, size=self.pc.size))]))
             nbloc = irbloc(new_lbl, irs)
-            nbloc.lines = [l]
+            nbloc.lines = [l] * len(irs)
             self.blocs[new_lbl] = nbloc
             irb.dst = ExprId(new_lbl, size=self.pc.size)
 

--- a/miasm2/arch/msp430/ira.py
+++ b/miasm2/arch/msp430/ira.py
@@ -2,7 +2,7 @@
 #-*- coding:utf-8 -*-
 
 from miasm2.expression.expression import *
-from miasm2.ir.ir import ir, irbloc
+from miasm2.ir.ir import ir, irbloc, AssignBlock
 from miasm2.ir.analysis import ira
 from miasm2.arch.msp430.sem import ir_msp430
 from miasm2.arch.msp430.regs import *
@@ -35,39 +35,27 @@ class ir_a_msp430(ir_a_msp430_base):
         b.rw[-1][1].add(self.arch.regs.cpuoff)
         b.rw[-1][1].add(self.arch.regs.gie)
 
-    def call_effects(self, ad):
-        irs = [[ExprAff(self.ret_reg, ExprOp('call_func_ret', ad, self.sp)),
-                ExprAff(self.sp, ExprOp('call_func_stack', ad, self.sp)),
-                ]]
-        return irs
-
     def post_add_bloc(self, bloc, ir_blocs):
         ir.post_add_bloc(self, bloc, ir_blocs)
-        # flow_graph = DiGraph()
-
         l = bloc.lines[-1]
         if not l.is_subcall():
             return
 
         for irb in ir_blocs:
-            # print 'X'*40
-            # print irb
             pc_val = None
-            for exprs in irb.irs:
-                for e in exprs:
-                    if e.dst == PC:
-                        pc_val = e.src
+            for assignblk in irb.irs:
+                pc_val = assignblk.get(PC, pc_val)
             if pc_val is None:
                 continue
 
             l = bloc.lines[-1]
-            # print str(l), 'IS CALL!'
             lbl = bloc.get_next()
             new_lbl = self.gen_label()
             irs = self.call_effects(pc_val)
-            irs.append([ExprAff(self.IRDst, ExprId(lbl, size=self.pc.size))])
+            irs.append(AssignBlock([ExprAff(self.IRDst,
+                                            ExprId(lbl, size=self.pc.size))]))
             nbloc = irbloc(new_lbl, irs)
-            nbloc.lines = [l]
+            nbloc.lines = [l] * len(irs)
             self.blocs[new_lbl] = nbloc
             irb.dst = ExprId(new_lbl, size=self.pc.size)
 

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -319,7 +319,8 @@ def xadd(ir, instr, a, b):
     e += update_flag_arith(c)
     e += update_flag_af(a, b, c)
     e += update_flag_add(b, a, c)
-    e.append(m2_expr.ExprAff(b, a))
+    if a != b:
+        e.append(m2_expr.ExprAff(b, a))
     e.append(m2_expr.ExprAff(a, c))
     return e, []
 

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -2537,7 +2537,7 @@ def fldcw(ir, instr, a):
 
 
 def fwait(ir, instr):
-    return [], None
+    return [], []
 
 
 def fcmovb(ir, instr, arg1, arg2):
@@ -2988,7 +2988,7 @@ def btr(ir, instr, a, b):
 
 
 def into(ir, instr):
-    return [], None
+    return [], []
 
 
 def l_in(ir, instr, a, b):
@@ -3105,12 +3105,12 @@ def lsl(ir, instr, a, b):
 
 def fclex(ir, instr):
     # XXX TODO
-    return [], None
+    return [], []
 
 
 def fnclex(ir, instr):
     # XXX TODO
-    return [], None
+    return [], []
 
 
 def l_str(ir, instr, a):

--- a/miasm2/expression/expression.py
+++ b/miasm2/expression/expression.py
@@ -1368,9 +1368,6 @@ def get_list_rw(exprs, mem_read=False, cst_read=True):
         # each cst is indexed
         o_r_rw = set()
         for r in o_r:
-            # if isinstance(r, ExprInt):
-            #    r = ExprOp('cst_%d'%cst_num, r)
-            #    cst_num += 1
             o_r_rw.add(r)
         o_r = o_r_rw
         list_rw.append((o_r, o_w))

--- a/miasm2/ir/ir.py
+++ b/miasm2/ir/ir.py
@@ -212,33 +212,20 @@ class irbloc(object):
         Initialize attributes needed for in/out and reach computation.
         @regs_ids : ids of registers used in IR
         """
-        self.r = []
-        self.w = []
-        self.cur_reach = [{reg: set() for reg in regs_ids}
-                          for _ in xrange(len(self.irs))]
-        self.prev_reach = [{reg: set() for reg in regs_ids}
-                           for _ in xrange(len(self.irs))]
-        self.cur_kill = [{reg: set() for reg in regs_ids}
-                         for _ in xrange(len(self.irs))]
-        self.prev_kill = [{reg: set() for reg in regs_ids}
-                          for _ in xrange(len(self.irs))]
-        # LineNumber -> dict:
-        #               Register: set(definition(irb label, index))
-        self.defout = [{reg: set() for reg in regs_ids}
-                       for _ in xrange(len(self.irs))]
         keep_exprid = lambda elts: filter(lambda expr: isinstance(expr,
                                                                   m2_expr.ExprId),
                                           elts)
         for idx, assignblk in enumerate(self.irs):
-            read, write = map(keep_exprid,
-                              (assignblk.get_r(mem_read=True),
-                               assignblk.get_w()))
-
-            self.defout[idx].update({dst: set([(self.label, idx, dst)])
+            assignblk.cur_reach = {reg: set() for reg in regs_ids}
+            assignblk.prev_reach = {reg: set() for reg in regs_ids}
+            assignblk.cur_kill = {reg: set() for reg in regs_ids}
+            assignblk.prev_kill = {reg: set() for reg in regs_ids}
+            # LineNumber -> dict:
+            #               Register: set(definition(irb label, index))
+            assignblk.defout = {reg: set() for reg in regs_ids}
+            assignblk.defout.update({dst: set([(self.label, idx, dst)])
                                      for dst in assignblk
                                      if isinstance(dst, m2_expr.ExprId)})
-            self.r.append(read)
-            self.w.append(write)
 
     def __str__(self):
         out = []

--- a/miasm2/ir/ir.py
+++ b/miasm2/ir/ir.py
@@ -18,7 +18,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-
+from itertools import chain
 
 import miasm2.expression.expression as m2_expr
 from miasm2.expression.expression_helper import get_missing_interval
@@ -26,6 +26,135 @@ from miasm2.expression.simplifications import expr_simp
 from miasm2.core.asmbloc import asm_symbol_pool, expr_is_label, asm_label, \
     asm_bloc
 from miasm2.core.graph import DiGraph
+
+
+class AssignBlock(dict):
+
+    def __init__(self, irs=None):
+        """@irs seq"""
+        if irs is None:
+            irs = []
+        super(AssignBlock, self).__init__()
+
+        for expraff in irs:
+            # Concurrent assignments are handled in __setitem__
+            self[expraff.dst] = expraff.src
+
+    def __setitem__(self, dst, src):
+        """
+        Special cases:
+        * if dst is an ExprSlice, expand it to affect the full Expression
+        * if dst already known, sources are merged
+        """
+
+        if dst.size != src.size:
+            raise RuntimeError(
+                "sanitycheck: args must have same size! %s" %
+                ([(str(arg), arg.size) for arg in [dst, src]]))
+
+        if isinstance(dst, m2_expr.ExprSlice):
+            # Complete the source with missing slice parts
+            new_dst = dst.arg
+            rest = [(m2_expr.ExprSlice(dst.arg, r[0], r[1]), r[0], r[1])
+                    for r in dst.slice_rest()]
+            all_a = [(src, dst.start, dst.stop)] + rest
+            all_a.sort(key=lambda x: x[1])
+            new_src = m2_expr.ExprCompose(all_a)
+        else:
+            new_dst, new_src = dst, src
+
+        if new_dst in self and isinstance(new_src, m2_expr.ExprCompose):
+            if not isinstance(self[new_dst], m2_expr.ExprCompose):
+                # prev_RAX = 0x1122334455667788
+                # input_RAX[0:8] = 0x89
+                # final_RAX -> ? (assignment are in parallel)
+                raise RuntimeError("Concurent access on same bit not allowed")
+
+            # Consider slice grouping
+            expr_list = [(new_dst, new_src),
+                         (new_dst, self[new_dst])]
+            # Find collision
+            e_colision = reduce(lambda x, y: x.union(y),
+                                (self.get_modified_slice(dst, src)
+                                 for (dst, src) in expr_list),
+                                set())
+
+            # Sort interval collision
+            known_intervals = sorted([(x[1], x[2]) for x in e_colision])
+
+            for i, (_, stop) in enumerate(known_intervals[:-1]):
+                if stop > known_intervals[i + 1][0]:
+                    raise RuntimeError(
+                        "Concurent access on same bit not allowed")
+
+            # Fill with missing data
+            missing_i = get_missing_interval(known_intervals, 0, new_dst.size)
+            remaining = ((m2_expr.ExprSlice(new_dst, *interval),
+                          interval[0],
+                          interval[1])
+                         for interval in missing_i)
+
+            # Build the merging expression
+            new_src = m2_expr.ExprCompose(e_colision.union(remaining))
+
+        super(AssignBlock, self).__setitem__(new_dst, new_src)
+
+    @staticmethod
+    def get_modified_slice(dst, src):
+        """Return an Expr list of extra expressions needed during the
+        object instanciation"""
+
+        if not isinstance(src, m2_expr.ExprCompose):
+            raise ValueError("Get mod slice not on expraff slice", str(self))
+        modified_s = []
+        for arg in src.args:
+            if (not isinstance(arg[0], m2_expr.ExprSlice) or
+                    arg[0].arg != dst or
+                    arg[1] != arg[0].start or
+                    arg[2] != arg[0].stop):
+                # If x is not the initial expression
+                modified_s.append(arg)
+        return modified_s
+
+    def get_w(self):
+        """Return a set of elements written"""
+        return set(self.keys())
+
+    def get_rw(self, mem_read=False, cst_read=False):
+        """Return a dictionnary associating written expressions to a set of
+        their read requirements
+        @mem_read: (optional) mem_read argument of `get_r`
+        @cst_read: (optional) cst_read argument of `get_r`
+        """
+        out = {}
+        for dst, src in self.iteritems():
+            src_read = src.get_r(mem_read=mem_read, cst_read=cst_read)
+            if isinstance(dst, m2_expr.ExprMem):
+                # Read on destination happens only with ExprMem
+                src_read.update(dst.arg.get_r(mem_read=mem_read,
+                                              cst_read=cst_read))
+            out[dst] = src_read
+        return out
+
+    def get_r(self, mem_read=False, cst_read=False):
+        """Return a set of elements reads
+        @mem_read: (optional) mem_read argument of `get_r`
+        @cst_read: (optional) cst_read argument of `get_r`
+        """
+        return set(
+            chain.from_iterable(self.get_rw(mem_read=mem_read,
+                                            cst_read=cst_read).itervalues()))
+
+    def __str__(self):
+        out = []
+        for dst, src in sorted(self.iteritems()):
+            out.append("%s = %s" % (dst, src))
+        return "\n".join(out)
+
+    def dst2ExprAff(self, dst):
+        """Return an ExprAff corresponding to @dst equation
+        @dst: Expr instance"""
+        return m2_expr.ExprAff(dst, self[dst])
 
 
 class irbloc(object):
@@ -45,26 +174,29 @@ class irbloc(object):
         """Find the IRDst affectation and update dst, dst_linenb accordingly"""
         if self._dst is not None:
             return self._dst
-        dst = None
-        for linenb, ir in enumerate(self.irs):
-            for i in ir:
-                if isinstance(i.dst, m2_expr.ExprId) and i.dst.name == "IRDst":
-                    if dst is not None:
+        final_dst = None
+        for linenb, assignblk in enumerate(self.irs):
+            for dst, src in assignblk.iteritems():
+                if isinstance(dst, m2_expr.ExprId) and dst.name == "IRDst":
+                    if final_dst is not None:
                         raise ValueError('Multiple destinations!')
-                    dst = i.src
-        self._dst = dst
+                    final_dst = src
+        self._dst = final_dst
         self._dst_linenb = linenb
-        return dst
+        return final_dst
 
     def _set_dst(self, value):
         """Find and replace the IRDst affectation's source by @value"""
         if self._dst_linenb is None:
             self._get_dst()
 
-        ir = self.irs[self._dst_linenb]
-        for i, expr in enumerate(ir):
-            if isinstance(expr.dst, m2_expr.ExprId) and expr.dst.name == "IRDst":
-                ir[i] = m2_expr.ExprAff(expr.dst, value)
+        assignblk = self.irs[self._dst_linenb]
+        for dst in assignblk:
+            if isinstance(dst, m2_expr.ExprId) and dst.name == "IRDst":
+                del(assignblk[dst])
+                assignblk[dst] = value
+                # Sanity check is already done in _get_dst
+                break
         self._dst = value
 
     dst = property(_get_dst, _set_dst)
@@ -90,34 +222,32 @@ class irbloc(object):
                          for _ in xrange(len(self.irs))]
         self.prev_kill = [{reg: set() for reg in regs_ids}
                           for _ in xrange(len(self.irs))]
+        # LineNumber -> dict:
+        #               Register: set(definition(irb label, index))
         self.defout = [{reg: set() for reg in regs_ids}
                        for _ in xrange(len(self.irs))]
+        keep_exprid = lambda elts: filter(lambda expr: isinstance(expr,
+                                                                  m2_expr.ExprId),
+                                          elts)
+        for idx, assignblk in enumerate(self.irs):
+            read, write = map(keep_exprid,
+                              (assignblk.get_r(mem_read=True),
+                               assignblk.get_w()))
 
-        for k, ir in enumerate(self.irs):
-            r, w = set(), set()
-            for i in ir:
-                r.update(x for x in i.get_r(True)
-                         if isinstance(x, m2_expr.ExprId))
-                w.update(x for x in i.get_w()
-                         if isinstance(x, m2_expr.ExprId))
-                if isinstance(i.dst, m2_expr.ExprMem):
-                    r.update(x for x in i.dst.arg.get_r(True)
-                             if isinstance(x, m2_expr.ExprId))
-                self.defout[k].update((x, {(self.label, k, i)})
-                                      for x in i.get_w()
-                                      if isinstance(x, m2_expr.ExprId))
-            self.r.append(r)
-            self.w.append(w)
+            self.defout[idx].update({dst: set([(self.label, idx, dst)])
+                                     for dst in assignblk
+                                     if isinstance(dst, m2_expr.ExprId)})
+            self.r.append(read)
+            self.w.append(write)
 
     def __str__(self):
-        o = []
-        o.append('%s' % self.label)
-        for expr in self.irs:
-            for e in expr:
-                o.append('\t%s' % e)
-            o.append("")
-
-        return "\n".join(o)
+        out = []
+        out.append('%s' % self.label)
+        for assignblk in self.irs:
+            for dst, src in assignblk.iteritems():
+                out.append('\t%s = %s' % (dst, src))
+            out.append("")
+        return "\n".join(out)
 
 
 class DiGraphIR(DiGraph):
@@ -139,13 +269,14 @@ class DiGraphIR(DiGraph):
         if node not in self._blocks:
             yield [self.DotCellDescription(text="NOT PRESENT", attr={})]
             raise StopIteration
-        for i, exprs in enumerate(self._blocks[node].irs):
-            for expr in exprs:
+        for i, assignblk in enumerate(self._blocks[node].irs):
+            for dst, src in assignblk.iteritems():
+                line = "%s = %s" % (dst, src)
                 if self._dot_offset:
                     yield [self.DotCellDescription(text="%-4d" % i, attr={}),
-                           self.DotCellDescription(text=str(expr), attr={})]
+                           self.DotCellDescription(text=line, attr={})]
                 else:
-                    yield self.DotCellDescription(text=str(expr), attr={})
+                    yield self.DotCellDescription(text=line, attr={})
             yield self.DotCellDescription(text="", attr={})
 
     def edge_attr(self, src, dst):
@@ -190,9 +321,15 @@ class ir(object):
         # Lazy structure
         self._graph = None
 
+    def get_ir(self, instr):
+        raise NotImplementedError("Abstract Method")
+
     def instr2ir(self, l):
-        ir_bloc_cur, ir_blocs_extra = self.get_ir(l)
-        return ir_bloc_cur, ir_blocs_extra
+        ir_bloc_cur, extra_assignblk = self.get_ir(l)
+        assignblk = AssignBlock(ir_bloc_cur)
+        for irb in extra_assignblk:
+            irb.irs = map(AssignBlock, irb.irs)
+        return assignblk, extra_assignblk
 
     def get_label(self, ad):
         """Transforms an ExprId/ExprInt/label/int into a label
@@ -221,62 +358,6 @@ class ir(object):
         b.lines = [l]
         self.add_bloc(b, gen_pc_updt)
 
-    def merge_multi_affect(self, affect_list):
-        """
-        If multiple affection to a same ExprId are present in @affect_list,
-        merge them (in place).
-        For instance, XCGH AH, AL semantic is
-        [
-            RAX = {RAX[0:8],0,8, RAX[0:8],8,16, RAX[16:64],16,64}
-            RAX = {RAX[8:16],0,8, RAX[8:64],8,64}
-        ]
-        This function will update @affect_list to replace previous ExprAff by
-        [
-            RAX = {RAX[8:16],0,8, RAX[0:8],8,16, RAX[16:64],16,64}
-        ]
-        """
-
-        # Extract side effect
-        effect = {}
-        for expr in affect_list:
-            effect[expr.dst] = effect.get(expr.dst, []) + [expr]
-
-        # Find candidates
-        for dst, expr_list in effect.items():
-            if len(expr_list) <= 1:
-                continue
-
-            # Only treat ExprCompose list
-            if any(map(lambda e: not(isinstance(e.src, m2_expr.ExprCompose)),
-                       expr_list)):
-                continue
-
-            # Find collision
-            e_colision = reduce(lambda x, y: x.union(y),
-                                (e.get_modified_slice() for e in expr_list),
-                                set())
-            # Sort interval collision
-            known_intervals = sorted([(x[1], x[2]) for x in e_colision])
-
-            # Fill with missing data
-            missing_i = get_missing_interval(known_intervals, 0, dst.size)
-
-            remaining = ((m2_expr.ExprSlice(dst, *interval),
-                          interval[0],
-                          interval[1])
-                         for interval in missing_i)
-
-            # Build the merging expression
-            slices = sorted(e_colision.union(remaining), key=lambda x: x[1])
-            final_dst = m2_expr.ExprCompose(slices)
-
-            # Remove unused expression
-            for expr in expr_list:
-                affect_list.remove(expr)
-
-            # Add the merged one
-            affect_list.append(m2_expr.ExprAff(dst, final_dst))
-
     def getby_offset(self, offset):
         out = set()
         for irb in self.blocs.values():
@@ -286,8 +367,9 @@ class ir(object):
         return out
 
     def gen_pc_update(self, c, l):
-        c.irs.append([m2_expr.ExprAff(self.pc, m2_expr.ExprInt_from(self.pc,
-                                                                    l.offset))])
+        c.irs.append(AssignBlock([m2_expr.ExprAff(self.pc,
+                                                  m2_expr.ExprInt_from(self.pc,
+                                                                       l.offset))]))
         c.lines.append(l)
 
     def add_bloc(self, bloc, gen_pc_updt=False):
@@ -298,12 +380,12 @@ class ir(object):
                 label = self.get_instr_label(l)
                 c = irbloc(label, [], [])
                 ir_blocs_all.append(c)
-            ir_bloc_cur, ir_blocs_extra = self.instr2ir(l)
+            assignblk, ir_blocs_extra = self.instr2ir(l)
 
             if gen_pc_updt is not False:
                 self.gen_pc_update(c, l)
 
-            c.irs.append(ir_bloc_cur)
+            c.irs.append(assignblk)
             c.lines.append(l)
 
             if ir_blocs_extra:
@@ -337,22 +419,14 @@ class ir(object):
                 continue
             dst = m2_expr.ExprId(self.get_next_label(bloc.lines[-1]),
                                  self.pc.size)
-            b.irs.append([m2_expr.ExprAff(self.IRDst, dst)])
+            b.irs.append(AssignBlock([m2_expr.ExprAff(self.IRDst, dst)]))
             b.lines.append(b.lines[-1])
-
-    def gen_edges(self, bloc, ir_blocs):
-        pass
 
     def post_add_bloc(self, bloc, ir_blocs):
         self.set_empty_dst_to_next(bloc, ir_blocs)
-        self.gen_edges(bloc, ir_blocs)
 
         for irb in ir_blocs:
             self.irbloc_fix_regs_for_mode(irb, self.attrib)
-
-            # Detect multi-affectation
-            for affect_list in irb.irs:
-                self.merge_multi_affect(affect_list)
 
             self.blocs[irb.label] = irb
 
@@ -375,15 +449,17 @@ class ir(object):
         return l
 
     def simplify_blocs(self):
-        for b in self.blocs.values():
-            for ir in b.irs:
-                for i, r in enumerate(ir):
-                    ir[i] = m2_expr.ExprAff(expr_simp(r.dst), expr_simp(r.src))
+        for irb in self.blocs.values():
+            for assignblk in irb.irs:
+                for dst, src in assignblk.items():
+                    del assignblk[dst]
+                    assignblk[expr_simp(dst)] = expr_simp(src)
 
     def replace_expr_in_ir(self, bloc, rep):
-        for irs in bloc.irs:
-            for i, l in enumerate(irs):
-                irs[i] = l.replace_expr(rep)
+        for assignblk in bloc.irs:
+            for dst, src in assignblk.items():
+                del assignblk[dst]
+                assignblk[dst.replace_expr(rep)] = src.replace_expr(rep)
 
     def get_rw(self, regs_ids=None):
         """
@@ -395,7 +471,11 @@ class ir(object):
         for b in self.blocs.values():
             b.get_rw(regs_ids)
 
-    def sort_dst(self, todo, done):
+    def _extract_dst(self, todo, done):
+        """
+        Naive extraction of @todo destinations
+        WARNING: @todo and @done are modified
+        """
         out = set()
         while todo:
             dst = todo.pop()
@@ -412,30 +492,26 @@ class ir(object):
                 done.add(dst)
         return out
 
-    def dst_trackback(self, b):
-        dst = b.dst
-        todo = set([dst])
+    def dst_trackback(self, irb):
+        """
+        Naive backtracking of IRDst
+        @irb: irbloc instance
+        """
+        todo = set([irb.dst])
         done = set()
 
-        for irs in reversed(b.irs):
-            if len(todo) == 0:
+        for assignblk in reversed(irb.irs):
+            if not todo:
                 break
-            out = self.sort_dst(todo, done)
+            out = self._extract_dst(todo, done)
             found = set()
             follow = set()
-            for i in irs:
-                if not out:
-                    break
-                for o in out:
-                    if i.dst == o:
-                        follow.add(i.src)
-                        found.add(o)
-                for o in found:
-                    out.remove(o)
+            for dst in out:
+                if dst in assignblk:
+                    follow.add(assignblk[dst])
+                    found.add(dst)
 
-            for o in out:
-                if o not in found:
-                    follow.add(o)
+            follow.update(out.difference(found))
             todo = follow
 
         return done

--- a/miasm2/ir/ir.py
+++ b/miasm2/ir/ir.py
@@ -216,10 +216,10 @@ class irbloc(object):
                                                                   m2_expr.ExprId),
                                           elts)
         for idx, assignblk in enumerate(self.irs):
-            assignblk.cur_reach = {reg: set() for reg in regs_ids}
-            assignblk.prev_reach = {reg: set() for reg in regs_ids}
-            assignblk.cur_kill = {reg: set() for reg in regs_ids}
-            assignblk.prev_kill = {reg: set() for reg in regs_ids}
+            assignblk._cur_reach = {reg: set() for reg in regs_ids}
+            assignblk._prev_reach = {reg: set() for reg in regs_ids}
+            assignblk._cur_kill = {reg: set() for reg in regs_ids}
+            assignblk._prev_kill = {reg: set() for reg in regs_ids}
             # LineNumber -> dict:
             #               Register: set(definition(irb label, index))
             assignblk.defout = {reg: set() for reg in regs_ids}

--- a/test/analysis/depgraph.py
+++ b/test/analysis/depgraph.py
@@ -2,7 +2,7 @@
 from miasm2.expression.expression import ExprId, ExprInt32, ExprAff, ExprCond
 from miasm2.core.asmbloc import asm_label
 from miasm2.ir.analysis import ira
-from miasm2.ir.ir import ir, irbloc
+from miasm2.ir.ir import ir, irbloc, AssignBlock
 from miasm2.core.graph import DiGraph
 from miasm2.analysis.depgraph import DependencyNode, DependencyGraph,\
     DependencyDict
@@ -48,13 +48,20 @@ LBL4 = asm_label("lbl4")
 LBL5 = asm_label("lbl5")
 LBL6 = asm_label("lbl6")
 
-
-def gen_irbloc(lbl, exprs):
+def gen_irbloc(label, exprs_list):
     """ Returns an IRBlock with empty lines.
     Used only for tests purpose
     """
-    lines = [None for _ in xrange(len(exprs))]
-    return irbloc(lbl, exprs, lines)
+    lines = [None for _ in xrange(len(exprs_list))]
+    irs = []
+    for exprs in exprs_list:
+        if isinstance(exprs, AssignBlock):
+            irs.append(exprs)
+        else:
+            irs.append(AssignBlock(exprs))
+
+    irbl = irbloc(label, irs, lines)
+    return irbl
 
 
 class Regs(object):

--- a/test/core/sembuilder.py
+++ b/test/core/sembuilder.py
@@ -57,5 +57,9 @@ for statement in res[0]:
     print statement
 
 print "[+] Blocks:"
-for block in res[1]:
-    print block
+for irb in res[1]:
+    print irb.label
+    for exprs in irb.irs:
+        for expr in exprs:
+            print expr
+        print

--- a/test/ir/analysis.py
+++ b/test/ir/analysis.py
@@ -2,7 +2,7 @@
 from miasm2.expression.expression import ExprId, ExprInt32, ExprAff, ExprMem
 from miasm2.core.asmbloc import asm_label
 from miasm2.ir.analysis import ira
-from miasm2.ir.ir import irbloc
+from miasm2.ir.ir import irbloc, AssignBlock
 
 a = ExprId("a")
 b = ExprId("b")
@@ -33,9 +33,16 @@ LBL6 = asm_label("lbl6")
 
 
 
-def gen_irbloc(label, exprs):
-    lines = [None for _ in xrange(len(exprs))]
-    irbl = irbloc(label, exprs, lines)
+def gen_irbloc(label, exprs_list):
+    lines = [None for _ in xrange(len(exprs_list))]
+    irs = []
+    for exprs in exprs_list:
+        if isinstance(exprs, AssignBlock):
+            irs.append(exprs)
+        else:
+            irs.append(AssignBlock(exprs))
+
+    irbl = irbloc(label, irs, lines)
     return irbl
 
 
@@ -671,12 +678,4 @@ for test_nb, test in enumerate([(G1_IRA, G1_EXP_IRA),
     # Check that each expr in the blocs are the same
     for lbl, irb in g_ira.blocs.iteritems():
         exp_irb = g_exp_ira.blocs[lbl]
-        assert len(irb.irs) == len(exp_irb.irs), "(%s)  %d / %d" %(
-            lbl, len(irb.irs), len(exp_irb.irs))
-        for i in xrange(0, len(exp_irb.irs)):
-            assert len(irb.irs[i]) == len(exp_irb.irs[i]), "(%s:%d) %d / %d" %(
-                lbl, i, len(irb.irs[i]), len(exp_irb.irs[i]))
-            for s_instr in xrange(len(irb.irs[i])):
-                assert irb.irs[i][s_instr] == exp_irb.irs[i][s_instr],\
-                    "(%s:%d)  %s / %s" %(
-                        lbl, i, irb.irs[i][s_instr], exp_irb.irs[i][s_instr])
+        assert exp_irb.irs == irb.irs


### PR DESCRIPTION
This PR introduces the new `AssignBlock` object representing (and replacing) parallel `ExprAff`.
IR parallels side effects were represented using a list of `ExprAff`. The list has no point here, as the affectations are not ordered. `AssignBlock` is a dictionnary based object. Its keys are the affected objects, the values are their equations.

:warning:  This PR breaks some API, but code modification should be minimal.
Work realized with @commial: Big thanks!