### PR TITLE
Introduce Container.symbol_pool, containing container symbols (if any)

### DIFF
--- a/example/disasm/full.py
+++ b/example/disasm/full.py
@@ -78,7 +78,7 @@ mn, dis_engine = machine.mn, machine.dis_engine
 ira, ir = machine.ira, machine.ir
 log.info('ok')
 
-mdis = dis_engine(bs)
+mdis = dis_engine(bs, symbol_pool=cont.symbol_pool)
 # configure disasm engine
 mdis.dontdis_retcall = args.dontdis_retcall
 mdis.blocs_wd = args.blockwatchdog
@@ -86,7 +86,13 @@ mdis.dont_dis_nulstart_bloc = not args.dis_nulstart_block
 mdis.follow_call = args.followcall
 
 todo = []
-addrs = [int(a, 0) for a in args.address]
+addrs = []
+for addr in args.address:
+    try:
+        addrs.append(int(addr, 0))
+    except ValueError:
+        # Second chance, try with symbol
+        addrs.append(mdis.symbol_pool.getby_name(addr).offset)
 
 if len(addrs) == 0 and default_addr is not None:
     addrs.append(default_addr)

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -459,6 +459,10 @@ testset += ExampleDisasmFull(["x86_64", Example.get_sample("demo_x86_64.bin"),
                               "0x401000"], depends=[test_x86_64])
 testset += ExampleDisasmFull(["aarch64l", Example.get_sample("md5_aarch64l"),
                               "0x400A00"], depends=[test_aarch64l])
+testset += ExampleDisasmFull(["x86_32", os.path.join("..", "..", "test",
+                                                     "arch", "x86", "qemu",
+                                                     "test-i386"),
+                              "func_iret"])
 
 
 ## Expression


### PR DESCRIPTION
Introduce `Container.symbol_pool`, a `asm_symbol_pool` instance with detected symbols.
To use it, one should use:
```Python
with open(...) as fdesc:
   cont = Container.from_stream(fdesc)

mdis = disasm_engine(cont.bin_stream, symbol_pool=cont.symbol_pool)
```

This behavior has been added to `disasm/full.py` example:
```
$ python disasm/full.py ../test/arch/x86/qemu/test-i386 test_lea
...
INFO : func ok 000000000804b8f0 (0)
...
```
`graph_execflow.dot`:
![elf_symbol](https://cloud.githubusercontent.com/assets/4194483/13923952/d2dab5de-ef82-11e5-8796-dedbf6b5897c.png)


Fix #338 