### PR TITLE
ELF: Add relative address computation from symtab

### DIFF
--- a/miasm2/analysis/binary.py
+++ b/miasm2/analysis/binary.py
@@ -208,6 +208,19 @@ class ContainerELF(Container):
                                                                        self._symbol_pool.getby_offset(offset)))
                         continue
 
+    """Given a address, compute a label under the form:
+    my_proc + 0xX if any pair symbol, size matches this address.
+    @addr: The given address, as an integer
+    """
+    def compute_relative_label(self, addr):
+        symtab = self._executable.getsectionbyname(".symtab")
+        if symtab is not None:
+            for name, symb in symtab.symbols.iteritems():
+                offset = symb.value
+                offset_end = offset + symb.size
+                if offset != 0 and (offset <= addr <= offset_end):
+                    return name + "+0x%x" % (addr - offset)
+        return None
 
 
 class ContainerUnknown(Container):


### PR DESCRIPTION
Hi,

This pull request is more a "start" than what I actually wanted to achieve, but I would like to have your opinion on the subject, to see if it fits in the project ambitions/goals.

I don't know how far you're willing to go in that direction, but it also possible to represent some label in the form: myfunc_ + 0xX, by using the size field.

What I mean is that it is always more comfortable to see a label under the form func + 0xX on your graph or output than just an address. The problem is: asm_label objects have no size field (and it would make no sense to put a size to an asm label anyway. But the thing is: we add symbol from .symtab (which do contains a size information) into a list of asm_label. So the information is lost.

What I did when I needed to have label under a relative form, was:
1.disassemble from Container.bin_stream
2. Iterate over the disasmEngine symbol_pool
2.1   for each "symbol", try to find a matching address. If not found, try to find a range of address corresponding to a symbol + its size that contains the wanted address.
2.2 If anything has been found, replace the lab, or let it as it was.

Everything is written under the [draft.txt](https://github.com/cea-sec/miasm/files/184166/draft.txt) uploaded with this pull request. Note that the get_symbol_by_addr() is just a look up in the symbol_pool (+ .plt), and find_related_symbol() is equivalent to compute_relative_label()

The problem now is that we actually need to modify the symbol_pool field of the disasmEngine class to have some effect on the diassembly / output graph / ir. But we only have access to the ELF and PE information through the Container class.

I wanted this pull request because it allows the user to have some interface with the ELF and its information through the container, but I do not think this is the "right" solution to my problem.

I can still open an issue for that, but a pull request make it easier to see code changes I'm currently working on.

PS: it would be good to fetch information from the plt and rel/rela section for the external symbols too ?