### PR TITLE
Jit gcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Reverse engineering framework in Python
 
-**Table of Contents** 
+**Table of Contents**
 
 - [What is Miasm?](#user-content-what-is-miasm)
 - [Basic examples](#user-content-basic-examples)
@@ -126,7 +126,7 @@ Working with IR, for instance by getting side effects:
 ...         print 'read:   ', [str(x) for x in o_r]
 ...         print 'written:', [str(x) for x in o_w]
 ...         print
-... 
+...
 read:    ['R8', 'R0']
 written: ['R2']
 
@@ -244,8 +244,8 @@ RAX 0000000000000000 RBX 0000000000000000 RCX 0000000000000004 RDX 0000000000000
 RSI 0000000000000000 RDI 0000000000000000 RSP 000000000123FFF8 RBP 0000000000000000
 zf 0000000000000000 nf 0000000000000000 of 0000000000000000 cf 0000000000000000
 RIP 0000000040000013
-40000015 RET        
->>> 
+40000015 RET
+>>>
 
 ```
 
@@ -270,7 +270,7 @@ Initializing the IR pool:
 >>> ira = machine.ira()
 >>> for b in blocs:
 ...    ira.add_bloc(b)
-... 
+...
 ```
 
 Initializing the engine with default symbolic values:
@@ -424,7 +424,7 @@ How does it work?
 Miasm embeds its own disassembler, intermediate language and
 instruction semantic. It is written in Python.
 
-To emulate code, it uses LibTCC, LLVM or Python to JIT the intermediate
+To emulate code, it uses LibTCC, LLVM, GCC or Python to JIT the intermediate
 representation. It can emulate shellcodes and all or parts of binaries. Python
 callbacks can be executed to interact with the execution, for instance to
 emulate library functions effects.
@@ -447,11 +447,14 @@ Software requirements
 
 Miasm uses:
 
-* LibTCC [tinycc (ONLY version 0.9.26)](http://repo.or.cz/w/tinycc.git), to JIT code for emulation mode
-* or LLVM v3.2 with python-llvm, see below
 * python-pyparsing
 * python-dev
 * elfesteem from [Elfesteem](https://github.com/serpilliere/elfesteem.git)
+
+To enable code JIT, one of the following module is mandatory:
+* GCC
+* LLVM v3.2 with python-llvm, see below
+* LibTCC [tinycc (ONLY version 0.9.26)](http://repo.or.cz/w/tinycc.git)
 
 Configuration
 -------------
@@ -464,7 +467,8 @@ python setup.py build
 sudo python setup.py install
 ```
 
-* To use the jitter, TCC or LLVM is recommended
+To use the jitter, GCC, TCC or LLVM is recommended
+* GCC (any version)
 * LibTCC needs to be configured with the `--disable-static` option
   * remove `libtcc-dev` from the system to avoid conflicts
   * clone [TinyCC](http://repo.or.cz/tinycc.git): `git clone http://repo.or.cz/tinycc.git`
@@ -494,7 +498,7 @@ Windows & IDA
 Most of Miasm's IDA plugins use a subset of Miasm functionnality.
 A quick way to have them working is to add:
 * `elfesteem` directory and `pyparsing.py` to `C:\...\IDA\python\` or `pip install pyparsing elfesteem`
-* `miasm2/miasm2` directory to `C:\...\IDA\python\` 
+* `miasm2/miasm2` directory to `C:\...\IDA\python\`
 
 All features excepting JITter related ones will be available. For a more complete installation, please refer to above paragraphs.
 

--- a/miasm2/jitter/Jitgcc.c
+++ b/miasm2/jitter/Jitgcc.c
@@ -1,0 +1,87 @@
+#include <Python.h>
+#include <inttypes.h>
+#include <stdint.h>
+
+typedef struct {
+	uint8_t is_local;
+	uint64_t address;
+} block_id;
+
+typedef int (*jitted_func)(block_id*, PyObject*);
+
+
+PyObject* gcc_exec_bloc(PyObject* self, PyObject* args)
+{
+	jitted_func func;
+	PyObject* jitcpu;
+	PyObject* func_py;
+	PyObject* lbl2ptr;
+	PyObject* breakpoints;
+	PyObject* retaddr = NULL;
+	int status;
+	block_id BlockDst;
+
+	if (!PyArg_ParseTuple(args, "OOOO", &retaddr, &jitcpu, &lbl2ptr, &breakpoints))
+		return NULL;
+
+	/* The loop will decref retaddr always once */
+	Py_INCREF(retaddr);
+
+	for (;;) {
+		// Init
+		BlockDst.is_local = 0;
+		BlockDst.address = 0;
+
+		// Get the expected jitted function address
+		func_py = PyDict_GetItem(lbl2ptr, retaddr);
+		if (func_py)
+			func = (jitted_func) PyInt_AsLong((PyObject*) func_py);
+		else {
+			if (BlockDst.is_local == 1) {
+				fprintf(stderr, "return on local label!\n");
+				exit(1);
+			}
+			// retaddr is not jitted yet
+			return retaddr;
+		}
+
+		// Execute it
+		status = func(&BlockDst, jitcpu);
+		Py_DECREF(retaddr);
+		retaddr = PyLong_FromUnsignedLongLong(BlockDst.address);
+
+		// Check exception
+		if (status)
+			return retaddr;
+
+		// Check breakpoint
+		if (PyDict_Contains(breakpoints, retaddr))
+			return retaddr;
+	}
+}
+
+
+
+static PyObject *GccError;
+
+
+static PyMethodDef GccMethods[] = {
+    {"gcc_exec_bloc",  gcc_exec_bloc, METH_VARARGS,
+     "gcc exec bloc"},
+    {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+PyMODINIT_FUNC
+initJitgcc(void)
+{
+    PyObject *m;
+
+    m = Py_InitModule("Jitgcc", GccMethods);
+    if (m == NULL)
+	    return;
+
+    GccError = PyErr_NewException("gcc.error", NULL, NULL);
+    Py_INCREF(GccError);
+    PyModule_AddObject(m, "error", GccError);
+}
+

--- a/miasm2/jitter/jitcore_gcc.py
+++ b/miasm2/jitter/jitcore_gcc.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+#-*- coding:utf-8 -*-
+
+import os
+import tempfile
+import ctypes
+from distutils.sysconfig import get_python_inc
+from subprocess import check_call
+from hashlib import md5
+
+from miasm2.ir.ir2C import irblocs2C
+from miasm2.jitter import jitcore, Jitgcc
+from miasm2.core.utils import keydefaultdict
+
+
+def gen_core(arch, attrib):
+    lib_dir = os.path.dirname(os.path.realpath(__file__))
+
+    txt = ""
+    txt += '#include "%s/queue.h"\n' % lib_dir
+    txt += '#include "%s/vm_mngr.h"\n' % lib_dir
+    txt += '#include "%s/vm_mngr_py.h"\n' % lib_dir
+    txt += '#include "%s/JitCore.h"\n' % lib_dir
+    txt += '#include "%s/arch/JitCore_%s.h"\n' % (lib_dir, arch.name)
+    txt += r'''
+#define RAISE(errtype, msg) {PyObject* p; p = PyErr_Format( errtype, msg ); return p;}
+'''
+    return txt
+
+
+def gen_C_source(ir_arch, func_code):
+    c_source = ""
+    c_source += "\n".join(func_code)
+
+    c_source = gen_core(ir_arch.arch, ir_arch.attrib) + c_source
+    c_source = "#include <Python.h>\n" + c_source
+
+    return c_source
+
+
+class myresolver(object):
+
+    def __init__(self, offset):
+        self.offset = offset
+
+    def ret(self):
+        return "return PyLong_FromUnsignedLongLong(0x%X);" % self.offset
+
+
+class resolver(object):
+
+    def __init__(self):
+        self.resolvers = keydefaultdict(myresolver)
+
+    def get_resolver(self, offset):
+        return self.resolvers[offset]
+
+
+class JitCore_Gcc(jitcore.JitCore):
+
+    "JiT management, using GCC as backend"
+
+    def __init__(self, ir_arch, bs=None):
+        self.jitted_block_delete_cb = self.deleteCB
+        super(JitCore_Gcc, self).__init__(ir_arch, bs)
+        self.resolver = resolver()
+        self.gcc_states = {}
+        self.ir_arch = ir_arch
+        self.tempdir = os.path.join(tempfile.gettempdir(), "miasm_gcc_cache")
+        try:
+            os.mkdir(self.tempdir, 0755)
+        except OSError:
+            pass
+        if not os.access(self.tempdir, os.R_OK | os.W_OK):
+            raise RuntimeError(
+                'Cannot access gcc cache directory %s ' % self.tempdir)
+        self.exec_wrapper = Jitgcc.gcc_exec_bloc
+        self.libs = None
+        self.include_files = None
+
+    def deleteCB(self, offset):
+        pass
+
+    def load(self):
+        lib_dir = os.path.dirname(os.path.realpath(__file__))
+        libs = [os.path.join(lib_dir, 'VmMngr.so'),
+                os.path.join(lib_dir,
+                             'arch/JitCore_%s.so' % (self.ir_arch.arch.name))]
+
+        include_files = [os.path.dirname(__file__),
+                         get_python_inc()]
+        self.include_files = include_files
+        self.libs = libs
+
+    def jit_gcc_compil(self, f_name, func_code):
+        func_hash = md5(func_code).hexdigest()
+        fname_out = os.path.join(self.tempdir, "%s.so" % func_hash)
+        if not os.access(fname_out, os.R_OK | os.X_OK):
+            # Create unique C file
+            fdesc, fname_in = tempfile.mkstemp(suffix=".c")
+            os.write(fdesc, func_code)
+            os.close(fdesc)
+
+            # Create unique SO file
+            _, fname_tmp = tempfile.mkstemp(suffix=".so")
+
+            inc_dir = ["-I%s" % inc for inc in self.include_files]
+            libs = ["%s" % lib for lib in self.libs]
+            args = ["gcc"] + ["-O3"] + [
+                "-shared", "-fPIC", fname_in, '-o', fname_tmp] + inc_dir + libs
+            check_call(args)
+            # Move temporary file to final file
+            os.rename(fname_tmp, fname_out)
+
+        lib = ctypes.cdll.LoadLibrary(fname_out)
+        func = getattr(lib, f_name)
+        addr = ctypes.cast(func, ctypes.c_void_p).value
+        return None, addr
+
+    def jitirblocs(self, label, irblocs):
+        f_name = "bloc_%s" % label.name
+        f_declaration = 'int %s(block_id * BlockDst, JitCpu* jitcpu)' % f_name
+        out = irblocs2C(self.ir_arch, self.resolver, label, irblocs,
+                        gen_exception_code=True,
+                        log_mn=self.log_mn,
+                        log_regs=self.log_regs)
+        out = [f_declaration + '{'] + out + ['}\n']
+        c_code = out
+
+        func_code = gen_C_source(self.ir_arch, c_code)
+
+        # open('tmp_%.4d.c'%self.jitcount, "w").write(func_code)
+        self.jitcount += 1
+        gcc_state, mcode = self.jit_gcc_compil(f_name, func_code)
+        self.lbl2jitbloc[label.offset] = mcode
+        self.gcc_states[label.offset] = gcc_state

--- a/miasm2/jitter/jitload.py
+++ b/miasm2/jitter/jitload.py
@@ -37,6 +37,11 @@ except ImportError:
     log.error('cannot import jit python')
 
 try:
+    from miasm2.jitter.jitcore_gcc import JitCore_Gcc
+except ImportError:
+    log.error('cannot import jit gcc')
+
+try:
     from miasm2.jitter import VmMngr
 except ImportError:
     log.error('cannot import VmMngr')
@@ -217,6 +222,8 @@ class jitter:
             self.jit = JitCore_LLVM(self.ir_arch, self.bs)
         elif jit_type == "python":
             self.jit = JitCore_Python(self.ir_arch, self.bs)
+        elif jit_type == "gcc":
+            self.jit = JitCore_Gcc(self.ir_arch, self.bs)
         else:
             raise Exception("Unkown JiT Backend")
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ def buil_all():
                   ["miasm2/jitter/JitCore.c",
                    "miasm2/jitter/vm_mngr.c",
                    "miasm2/jitter/arch/JitCore_mips32.c"]),
+        Extension("miasm2.jitter.Jitgcc",
+                  ["miasm2/jitter/Jitgcc.c"]),
         Extension("miasm2.jitter.Jitllvm",
                   ["miasm2/jitter/Jitllvm.c"]),
         ]
@@ -78,6 +80,8 @@ def buil_all():
                    "miasm2/jitter/arch/JitCore_mips32.c"]),
         Extension("miasm2.jitter.Jitllvm",
                   ["miasm2/jitter/Jitllvm.c"]),
+        Extension("miasm2.jitter.Jitgcc",
+                  ["miasm2/jitter/Jitgcc.c"]),
         Extension("miasm2.jitter.Jittcc",
                   ["miasm2/jitter/Jittcc.c"],
                   libraries=["tcc"])

--- a/test/arch/aarch64/unit/asm_test.py
+++ b/test/arch/aarch64/unit/asm_test.py
@@ -21,8 +21,8 @@ if filename and os.path.isfile(filename):
 reg_and_id = dict(mn_aarch64.regs.all_regs_ids_byname)
 
 class Asm_Test(object):
-    def __init__(self):
-        self.myjit = Machine("aarch64l").jitter()
+    def __init__(self, jitter):
+        self.myjit = Machine("aarch64l").jitter(jitter)
         self.myjit.init_stack()
 
         self.myjit.jit.log_regs = False

--- a/test/arch/aarch64/unit/mn_ubfm.py
+++ b/test/arch/aarch64/unit/mn_ubfm.py
@@ -1,4 +1,6 @@
 #! /usr/bin/env python
+import sys
+
 from asm_test import Asm_Test
 from pdb import pm
 
@@ -27,4 +29,4 @@ main:
 
 
 if __name__ == "__main__":
-    [test()() for test in [Test_UBFM1, Test_UBFM2 ]]
+    [test(*sys.argv[1:])() for test in [Test_UBFM1, Test_UBFM2 ]]

--- a/test/arch/mips32/unit/asm_test.py
+++ b/test/arch/mips32/unit/asm_test.py
@@ -23,8 +23,8 @@ reg_and_id = dict(mn_mips32.regs.all_regs_ids_byname)
 
 class Asm_Test(object):
 
-    def __init__(self):
-        self.myjit = Machine("mips32l").jitter()
+    def __init__(self, jitter):
+        self.myjit = Machine("mips32l").jitter(jitter)
         self.myjit.init_stack()
 
         self.myjit.jit.log_regs = False

--- a/test/arch/mips32/unit/mn_bcc.py
+++ b/test/arch/mips32/unit/mn_bcc.py
@@ -1,4 +1,6 @@
 #! /usr/bin/env python
+import sys
+
 from asm_test import Asm_Test
 
 
@@ -29,4 +31,4 @@ SKIP:
 
 
 if __name__ == "__main__":
-    [test()() for test in [Test_BCC]]
+    [test(*sys.argv[1:])() for test in [Test_BCC]]

--- a/test/arch/x86/unit/asm_test.py
+++ b/test/arch/x86/unit/asm_test.py
@@ -23,8 +23,8 @@ reg_and_id = dict(mn_x86.regs.all_regs_ids_byname)
 class Asm_Test(object):
     run_addr = 0x0
 
-    def __init__(self):
-        self.myjit = Machine(self.arch_name).jitter()
+    def __init__(self, jitter_engine):
+        self.myjit = Machine(self.arch_name).jitter(jitter_engine)
         self.myjit.init_stack()
 
         self.myjit.jit.log_regs = False
@@ -84,8 +84,8 @@ class Asm_Test_16(Asm_Test):
     arch_attrib = 16
     ret_addr = 0x1337
 
-    def __init__(self):
-        self.myjit = Machine(self.arch_name).jitter()
+    def __init__(self, jitter_engine):
+        self.myjit = Machine(self.arch_name).jitter(jitter_engine)
         self.myjit.stack_base = 0x1000
         self.myjit.stack_size = 0x1000
         self.myjit.init_stack()

--- a/test/arch/x86/unit/mn_daa.py
+++ b/test/arch/x86/unit/mn_daa.py
@@ -1,4 +1,6 @@
 #! /usr/bin/env python
+import sys
+
 from asm_test import Asm_Test_32
 
 
@@ -73,4 +75,4 @@ array_al_end:
 
 
 if __name__ == "__main__":
-    [test()() for test in [Test_DAA]]
+    [test(*sys.argv[1:])() for test in [Test_DAA]]

--- a/test/arch/x86/unit/mn_das.py
+++ b/test/arch/x86/unit/mn_das.py
@@ -1,4 +1,6 @@
 #! /usr/bin/env python
+import sys
+
 from asm_test import Asm_Test_32
 
 
@@ -103,4 +105,4 @@ array_al_end:
 
 
 if __name__ == "__main__":
-    [test()() for test in [Test_DAS]]
+    [test(*sys.argv[1:])() for test in [Test_DAS]]

--- a/test/arch/x86/unit/mn_float.py
+++ b/test/arch/x86/unit/mn_float.py
@@ -1,4 +1,6 @@
 #! /usr/bin/env python
+import sys
+
 from asm_test import Asm_Test_32
 
 
@@ -19,4 +21,4 @@ class Test_FADD(Asm_Test_32):
 
 
 if __name__ == "__main__":
-    [test()() for test in [Test_FADD]]
+    [test(*sys.argv[1:])() for test in [Test_FADD]]

--- a/test/arch/x86/unit/mn_int.py
+++ b/test/arch/x86/unit/mn_int.py
@@ -1,4 +1,6 @@
 #! /usr/bin/env python
+import sys
+
 from miasm2.jitter.csts import EXCEPT_INT_XX
 from asm_test import Asm_Test_32
 
@@ -15,8 +17,8 @@ class Test_INT(Asm_Test_32):
         jitter.cpu.set_exception(0)
         return True
 
-    def __init__(self):
-        super(Test_INT, self).__init__()
+    def __init__(self, jitter):
+        super(Test_INT, self).__init__(jitter)
         self.int_num = 0
         self.myjit.add_exception_handler(EXCEPT_INT_XX,
                                          self.set_int_num)
@@ -28,4 +30,4 @@ class Test_INT(Asm_Test_32):
 
 
 if __name__ == "__main__":
-    [test()() for test in [Test_INT]]
+    [test(*sys.argv[1:])() for test in [Test_INT]]

--- a/test/arch/x86/unit/mn_pcmpeq.py
+++ b/test/arch/x86/unit/mn_pcmpeq.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
-from asm_test import Asm_Test_32
 import sys
+
+from asm_test import Asm_Test_32
 
 class Test_PCMPEQB(Asm_Test_32):
     TXT = '''
@@ -61,4 +62,4 @@ class Test_PCMPEQD(Asm_Test_32):
 
 
 if __name__ == "__main__":
-    [test()() for test in [Test_PCMPEQB, Test_PCMPEQW, Test_PCMPEQD]]
+    [test(*sys.argv[1:])() for test in [Test_PCMPEQB, Test_PCMPEQW, Test_PCMPEQD]]

--- a/test/arch/x86/unit/mn_pextr.py
+++ b/test/arch/x86/unit/mn_pextr.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
-from asm_test import Asm_Test_32
 import sys
+
+from asm_test import Asm_Test_32
 
 class Test_PEXTRB(Asm_Test_32):
     TXT = '''
@@ -22,4 +23,4 @@ class Test_PEXTRB(Asm_Test_32):
 
 
 if __name__ == "__main__":
-    [test()() for test in [Test_PEXTRB]]
+    [test(*sys.argv[1:])() for test in [Test_PEXTRB]]

--- a/test/arch/x86/unit/mn_pinsr.py
+++ b/test/arch/x86/unit/mn_pinsr.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
-from asm_test import Asm_Test_32
 import sys
+
+from asm_test import Asm_Test_32
 
 class Test_PINSRB(Asm_Test_32):
     TXT = '''
@@ -22,4 +23,4 @@ class Test_PINSRB(Asm_Test_32):
 
 
 if __name__ == "__main__":
-    [test()() for test in [Test_PINSRB]]
+    [test(*sys.argv[1:])() for test in [Test_PINSRB]]

--- a/test/arch/x86/unit/mn_pmaxu.py
+++ b/test/arch/x86/unit/mn_pmaxu.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
-from asm_test import Asm_Test_32
 import sys
+
+from asm_test import Asm_Test_32
 
 class Test_PMAXU(Asm_Test_32):
     TXT = '''
@@ -22,4 +23,4 @@ class Test_PMAXU(Asm_Test_32):
 
 
 if __name__ == "__main__":
-    [test()() for test in [Test_PMAXU]]
+    [test(*sys.argv[1:])() for test in [Test_PMAXU]]

--- a/test/arch/x86/unit/mn_pminu.py
+++ b/test/arch/x86/unit/mn_pminu.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
-from asm_test import Asm_Test_32
 import sys
+
+from asm_test import Asm_Test_32
 
 class Test_PMINU(Asm_Test_32):
     TXT = '''
@@ -22,4 +23,4 @@ class Test_PMINU(Asm_Test_32):
 
 
 if __name__ == "__main__":
-    [test()() for test in [Test_PMINU]]
+    [test(*sys.argv[1:])() for test in [Test_PMINU]]

--- a/test/arch/x86/unit/mn_pmovmskb.py
+++ b/test/arch/x86/unit/mn_pmovmskb.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
-from asm_test import Asm_Test_32
 import sys
+
+from asm_test import Asm_Test_32
 
 class Test_PMOVMSKB(Asm_Test_32):
     TXT = '''
@@ -23,4 +24,4 @@ class Test_PMOVMSKB(Asm_Test_32):
         assert self.myjit.cpu.EAX == 0x00000015
 
 if __name__ == "__main__":
-    [test()() for test in [Test_PMOVMSKB,]]
+    [test(*sys.argv[1:])() for test in [Test_PMOVMSKB,]]

--- a/test/arch/x86/unit/mn_pshufb.py
+++ b/test/arch/x86/unit/mn_pshufb.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
-from asm_test import Asm_Test_32
 import sys
+
+from asm_test import Asm_Test_32
 
 class Test_PSHUFB(Asm_Test_32):
     TXT = '''
@@ -22,4 +23,4 @@ class Test_PSHUFB(Asm_Test_32):
 
 
 if __name__ == "__main__":
-    [test()() for test in [Test_PSHUFB]]
+    [test(*sys.argv[1:])() for test in [Test_PSHUFB]]

--- a/test/arch/x86/unit/mn_psrl_psll.py
+++ b/test/arch/x86/unit/mn_psrl_psll.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
-from asm_test import Asm_Test_32
 import sys
+
+from asm_test import Asm_Test_32
 
 class Test_PSRL(Asm_Test_32):
     TXT = '''
@@ -52,4 +53,4 @@ class Test_PSLL(Asm_Test_32):
 
 
 if __name__ == "__main__":
-    [test()() for test in [Test_PSRL, Test_PSLL]]
+    [test(*sys.argv[1:])() for test in [Test_PSRL, Test_PSLL]]

--- a/test/arch/x86/unit/mn_punpck.py
+++ b/test/arch/x86/unit/mn_punpck.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
-from asm_test import Asm_Test_32
 import sys
+
+from asm_test import Asm_Test_32
 
 class Test_PUNPCKHBW(Asm_Test_32):
     TXT = '''
@@ -120,5 +121,5 @@ class Test_PUNPCKLDQ(Asm_Test_32):
         assert self.myjit.cpu.MM1 == 0xEEFF020155667788
 
 if __name__ == "__main__":
-    [test()() for test in [Test_PUNPCKHBW, Test_PUNPCKHWD, Test_PUNPCKHDQ,
-                           Test_PUNPCKLBW, Test_PUNPCKLWD, Test_PUNPCKLDQ,]]
+    [test(*sys.argv[1:])() for test in [Test_PUNPCKHBW, Test_PUNPCKHWD, Test_PUNPCKHDQ,
+                                        Test_PUNPCKLBW, Test_PUNPCKLWD, Test_PUNPCKLDQ,]]

--- a/test/arch/x86/unit/mn_pushpop.py
+++ b/test/arch/x86/unit/mn_pushpop.py
@@ -1,4 +1,6 @@
 #! /usr/bin/env python
+import sys
+
 from asm_test import Asm_Test_16, Asm_Test_32
 from miasm2.core.utils import pck16, pck32
 
@@ -119,7 +121,7 @@ class Test_PUSHAD_16(Asm_Test_16):
 
 
 if __name__ == "__main__":
-    [test()() for test in [Test_PUSHA_16, Test_PUSHA_32,
-                           Test_PUSHAD_16, Test_PUSHAD_32
-                           ]
-     ]
+    [test(*sys.argv[1:])() for test in [Test_PUSHA_16, Test_PUSHA_32,
+                                        Test_PUSHAD_16, Test_PUSHAD_32
+                                        ]
+    ]

--- a/test/arch/x86/unit/mn_stack.py
+++ b/test/arch/x86/unit/mn_stack.py
@@ -1,4 +1,6 @@
 #! /usr/bin/env python
+import sys
+
 from asm_test import Asm_Test_32
 
 
@@ -57,4 +59,4 @@ BAD:
 
 
 if __name__ == "__main__":
-    [test()() for test in [Test_PUSHPOP]]
+    [test(*sys.argv[1:])() for test in [Test_PUSHPOP]]

--- a/test/arch/x86/unit/mn_strings.py
+++ b/test/arch/x86/unit/mn_strings.py
@@ -1,4 +1,6 @@
 #! /usr/bin/env python
+import sys
+
 from asm_test import Asm_Test_32
 
 class Test_SCAS(Asm_Test_32):
@@ -45,4 +47,4 @@ class Test_MOVS(Asm_Test_32):
 
 
 if __name__ == "__main__":
-    [test()() for test in [Test_SCAS, Test_MOVS]]
+    [test(*sys.argv[1:])() for test in [Test_SCAS, Test_MOVS]]

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -97,42 +97,42 @@ class QEMUTest(RegressionTest):
 # Test name -> supported jitter engines
 QEMU_TESTS = {
     # Operations
-    "btr": ("tcc", "python"),
-    "bts": ("tcc", "python"),
-    "bt": ("tcc", "python"),
-    "shrd": ("tcc", "python"),
-    "shld": ("tcc", "python"),
-    "rcl": ("tcc", "python"),
-    "rcr": ("tcc", "python"),
-    "ror": ("tcc", "python"),
-    "rol": ("tcc", "python"),
-    "sar": ("tcc", "python"),
-    "shr": ("tcc", "python"),
-    "shl": ("tcc", "python"),
-    "not": ("tcc", "python"),
-    "neg": ("tcc", "python"),
-    "dec": ("tcc", "python"),
-    "inc": ("tcc", "python"),
-    "sbb": ("tcc", "python"),
-    "adc": ("tcc", "python"),
-    "cmp": ("tcc", "python"),
-    "or": ("tcc", "python"),
-    "and": ("tcc", "python"),
-    "xor": ("tcc", "python"),
-    "sub": ("tcc", "python"),
-    "add": ("tcc", "python"),
+    "btr": ("tcc", "python", "gcc"),
+    "bts": ("tcc", "python", "gcc"),
+    "bt": ("tcc", "python", "gcc"),
+    "shrd": ("tcc", "python", "gcc"),
+    "shld": ("tcc", "python", "gcc"),
+    "rcl": ("tcc", "python", "gcc"),
+    "rcr": ("tcc", "python", "gcc"),
+    "ror": ("tcc", "python", "gcc"),
+    "rol": ("tcc", "python", "gcc"),
+    "sar": ("tcc", "python", "gcc"),
+    "shr": ("tcc", "python", "gcc"),
+    "shl": ("tcc", "python", "gcc"),
+    "not": ("tcc", "python", "gcc"),
+    "neg": ("tcc", "python", "gcc"),
+    "dec": ("tcc", "python", "gcc"),
+    "inc": ("tcc", "python", "gcc"),
+    "sbb": ("tcc", "python", "gcc"),
+    "adc": ("tcc", "python", "gcc"),
+    "cmp": ("tcc", "python", "gcc"),
+    "or": ("tcc", "python", "gcc"),
+    "and": ("tcc", "python", "gcc"),
+    "xor": ("tcc", "python", "gcc"),
+    "sub": ("tcc", "python", "gcc"),
+    "add": ("tcc", "python", "gcc"),
     # Specifics
-    "bsx": ("tcc", "python"),
-    "mul": ("tcc", "python"),
-    "jcc": ("tcc", "python"),
-    "loop": ("tcc", "python"),
-    "lea": ("tcc", "python"),
-    "self_modifying_code": ("tcc", "python"),
-    "conv": ("tcc", "python"),
-    "bcd": ("tcc", "python"),
-    "xchg": ("tcc", "python"),
-    "string": ("tcc", "python"),
-    "misc": ("tcc", "python"),
+    "bsx": ("tcc", "python", "gcc"),
+    "mul": ("tcc", "python", "gcc"),
+    "jcc": ("tcc", "python", "gcc"),
+    "loop": ("tcc", "python", "gcc"),
+    "lea": ("tcc", "python", "gcc"),
+    "self_modifying_code": ("tcc", "python", "gcc"),
+    "conv": ("tcc", "python", "gcc"),
+    "bcd": ("tcc", "python", "gcc"),
+    "xchg": ("tcc", "python", "gcc"),
+    "string": ("tcc", "python", "gcc"),
+    "misc": ("tcc", "python", "gcc"),
     # Unsupported
     # "floats", "segs", "code16", "exceptions", "single_step"
 }
@@ -535,7 +535,7 @@ class ExampleJitter(Example):
     - script path begins with "jitter/"
     """
     example_dir = "jitter"
-    jitter_engines = ["tcc", "llvm", "python"]
+    jitter_engines = ["tcc", "llvm", "python", "gcc"]
 
 
 for jitter in ExampleJitter.jitter_engines:


### PR DESCRIPTION
This PR introduces a new JIT module based on (and only on) `GCC`. This will have many consequences:
* `TCC` is no more needed to JIT code
* This may easier Miasm installation on platform like `Windows` or `OSX`


A `TCC` tag is added; Regression tests are done based on installed features.