### PR TITLE
Jitter: fix function cast

### DIFF
--- a/miasm2/jitter/Jitgcc.c
+++ b/miasm2/jitter/Jitgcc.c
@@ -35,7 +35,7 @@ PyObject* gcc_exec_bloc(PyObject* self, PyObject* args)
 		// Get the expected jitted function address
 		func_py = PyDict_GetItem(lbl2ptr, retaddr);
 		if (func_py)
-			func = (jitted_func) PyInt_AsLong((PyObject*) func_py);
+			func = (jitted_func) PyLong_AsVoidPtr((PyObject*) func_py);
 		else {
 			if (BlockDst.is_local == 1) {
 				fprintf(stderr, "return on local label!\n");
@@ -44,7 +44,6 @@ PyObject* gcc_exec_bloc(PyObject* self, PyObject* args)
 			// retaddr is not jitted yet
 			return retaddr;
 		}
-
 		// Execute it
 		status = func(&BlockDst, jitcpu);
 		Py_DECREF(retaddr);

--- a/miasm2/jitter/Jittcc.c
+++ b/miasm2/jitter/Jittcc.c
@@ -154,7 +154,7 @@ PyObject* tcc_exec_bloc(PyObject* self, PyObject* args)
 		// Get the expected jitted function address
 		func_py = PyDict_GetItem(lbl2ptr, retaddr);
 		if (func_py)
-			func = (jitted_func) PyInt_AsLong((PyObject*) func_py);
+			func = (jitted_func) PyLong_AsVoidPtr((PyObject*) func_py);
 		else {
 			if (BlockDst.is_local == 1) {
 				fprintf(stderr, "return on local label!\n");


### PR DESCRIPTION
Fix bad function casting in [gcc/tcc] jitter.

Fix issue #371 

