### PR TITLE
Handle Elfesteem ValueError on 'get'

### DIFF
--- a/miasm2/core/bin_stream.py
+++ b/miasm2/core/bin_stream.py
@@ -187,7 +187,10 @@ class bin_stream_container(bin_stream):
         return self.bin.get(self.offset - l, self.offset)
 
     def _getbytes(self, start, l=1):
-        return self.bin.get(start, start + l)
+        try:
+            return self.bin.get(start, start + l)
+        except ValueError:
+            raise IOError("cannot get bytes")
 
     def __str__(self):
         out = self.bin.get(self.offset, self.offset + self.l)


### PR DESCRIPTION
Elfesteem may raise a `ValueError` while getting bytes (for instance, in elfesteem/elf_init.py, line 624, in get_rvaitem: `raise ValueError('unknown rva address! %x' % start)`) . Miasm disassembly engine handle read issues through `IOError`.