### PR TITLE
Explicitly compare z3 expression to None.

### DIFF
--- a/miasm2/ir/translators/z3_ir.py
+++ b/miasm2/ir/translators/z3_ir.py
@@ -141,7 +141,7 @@ class TranslatorZ3(Translator):
         for subexpr, start, stop in args:
             sube = self.from_expr(subexpr)
             e = z3.Extract(stop-start-1, 0, sube)
-            if res:
+            if res != None:
                 res = z3.Concat(e, res)
             else:
                 res = e


### PR DESCRIPTION
Implicit boolean comparisons broken by recent commit a2eb824 in Z3Prover/z3 causing translator to break.

Callstack of failure.

/usr/local/lib/python2.7/dist-packages/miasm2/ir/translators/z3_ir.pyc in from_ExprCompose(self, expr)
    142             sube = self.from_expr(subexpr)
    143             e = z3.Extract(stop-start-1, 0, sube)
--> 144             if res:
    145                 res = z3.Concat(e, res)
    146             else:

/usr/lib/python2.7/dist-packages/z3.py in __nonzero__(self)
    294
    295     def __nonzero__(self):
--> 296         return self.__bool__()
    297
    298     def __bool__(self):

/usr/lib/python2.7/dist-packages/z3.py in __bool__(self)
    304            return self.arg(0).eq(self.arg(1))
    305         else:
--> 306             raise Z3Exception("Symbolic expressions cannot be cast to concrete Boolean values.")
    307
    308     def sexpr(self):

Z3Exception: Symbolic expressions cannot be cast to concrete Boolean values.