### PR TITLE
Feature/int expr int

### DIFF
--- a/miasm2/analysis/disasm_cb.py
+++ b/miasm2/analysis/disasm_cb.py
@@ -55,11 +55,11 @@ def arm_guess_subcall(
         if lr_val.arg != l.offset + l.l:
             continue
         # print 'IS CALL!'
-        l = symbol_pool.getby_offset_create(int(lr_val.arg))
+        l = symbol_pool.getby_offset_create(int(lr_val))
         c = asm_constraint_next(l)
 
         to_add.add(c)
-        offsets_to_dis.add(int(lr_val.arg))
+        offsets_to_dis.add(int(lr_val))
 
     # if to_add:
     #    print 'R'*70
@@ -106,7 +106,7 @@ def arm_guess_jump_table(
         print res
         if not isinstance(res[jrb], ExprInt):
             raise NotImplementedError('not fully functional')
-        base_ad = int(res[jrb].arg)
+        base_ad = int(res[jrb])
         print base_ad
         addrs = set()
         i = -1

--- a/miasm2/arch/aarch64/arch.py
+++ b/miasm2/arch/aarch64/arch.py
@@ -807,11 +807,11 @@ def set_imm_to_size(size, expr):
     if size == expr.size:
         return expr
     if size > expr.size:
-        expr = m2_expr.ExprInt(int(expr.arg), size)
+        expr = m2_expr.ExprInt(int(expr), size)
     else:
         if expr.arg > (1 << size) - 1:
             return None
-        expr = m2_expr.ExprInt(int(expr.arg), size)
+        expr = m2_expr.ExprInt(int(expr), size)
     return expr
 
 
@@ -838,7 +838,7 @@ class aarch64_imm_sf(imm_noarg):
             return False
         if not test_set_sf(self.parent, self.expr.size):
             return False
-        value = int(self.expr.arg)
+        value = int(self.expr)
         if value >= 1 << self.l:
             return False
         self.value = value
@@ -857,7 +857,7 @@ class aarch64_imm_sft(aarch64_imm_sf, m_arg):
             return False
         if not test_set_sf(self.parent, self.expr.size):
             return False
-        value = int(self.expr.arg)
+        value = int(self.expr)
         if value < 1 << self.l:
             self.parent.shift.value = 0
         else:
@@ -902,7 +902,7 @@ class aarch64_gpreg_ext(reg_noarg, m_arg):
             if not test_set_sf(self.parent, self.expr.size):
                 return False
         self.parent.option.value = option
-        self.parent.imm.value = int(amount.arg)
+        self.parent.imm.value = int(amount)
         return True
 
     def decode(self, v):
@@ -1037,7 +1037,7 @@ class aarch64_gpreg_sftimm(reg_noarg, m_arg):
         if not isinstance(args[1], m2_expr.ExprInt):
             return False
         self.parent.shift.value = shift_expr.index(self.expr.op)
-        self.parent.imm.value = int(args[1].arg)
+        self.parent.imm.value = int(args[1])
         self.value = self.reg_info[size].expr.index(args[0])
         return True
 
@@ -1120,7 +1120,7 @@ class aarch64_immhip_page(aarch64_imm_32):
         return True
 
     def encode(self):
-        v = int(self.expr.arg)
+        v = int(self.expr)
         if v & (1 << 63):
             v &= (1 << 33) - 1
         if v & 0xfff:
@@ -1142,7 +1142,7 @@ class aarch64_immhi_page(aarch64_imm_32):
         return True
 
     def encode(self):
-        v = int(self.expr.arg)
+        v = int(self.expr)
         if v & (1 << 63):
             v &= (1 << 33) - 1
         self.parent.immlo.value = v & 3
@@ -1168,7 +1168,7 @@ class aarch64_imm_hw(m_arg):
         size = self.parent.args[0].expr.size
         if set_imm_to_size(size, self.expr) is None:
             return False
-        value = int(self.expr.arg)
+        value = int(self.expr)
         mask = (1 << size) - 1
         for i in xrange(size / 16):
             if ((0xffff << (i * 16)) ^ mask) & value:
@@ -1197,7 +1197,7 @@ class aarch64_imm_hw_sc(m_arg):
         if isinstance(self.expr, m2_expr.ExprInt):
             if self.expr.arg > 0xFFFF:
                 return False
-            self.value = int(self.expr.arg)
+            self.value = int(self.expr)
             self.parent.hw.value = 0
             return True
 
@@ -1211,7 +1211,7 @@ class aarch64_imm_hw_sc(m_arg):
             return False
         if set_imm_to_size(self.parent.args[0].expr.size, self.expr.args[1]) is None:
             return False
-        arg, amount = [int(arg.arg) for arg in self.expr.args]
+        arg, amount = [int(arg) for arg in self.expr.args]
         if arg > 0xFFFF:
             return False
         if amount % 16 or amount / 16 > 4:
@@ -1234,7 +1234,7 @@ class aarch64_offs(imm_noarg, m_arg):
     def encode(self):
         if not isinstance(self.expr, m2_expr.ExprInt):
             return False
-        v = int(self.expr.arg)
+        v = int(self.expr)
         if v & (1 << 63):
             v &= (1 << (self.l + 2)) - 1
         self.value = v >> 2
@@ -1310,7 +1310,7 @@ class aarch64_deref(m_arg):
             return False
         if not isinstance(off, m2_expr.ExprInt):
             return False
-        imm = int(off.arg)
+        imm = int(off)
         imm = self.encode_w_size(imm)
         if imm is False:
             return False
@@ -1425,7 +1425,7 @@ class aarch64_b40(m_arg):
         if not isinstance(self.expr, m2_expr.ExprInt):
             return False
         size = self.parent.args[0].expr.size
-        value = int(self.expr.arg)
+        value = int(self.expr)
         self.value = value & self.lmask
         if self.parent.sf.value is None:
             self.parent.sf.value = value >> self.l

--- a/miasm2/arch/aarch64/sem.py
+++ b/miasm2/arch/aarch64/sem.py
@@ -275,11 +275,11 @@ def movk(ir, instr, arg1, arg2):
         assert(arg2.op == 'slice_at' and
                isinstance(arg2.args[0], m2_expr.ExprInt) and
                isinstance(arg2.args[1], m2_expr.ExprInt))
-        value, shift = int(arg2.args[0].arg), int(arg2.args[1].arg)
+        value, shift = int(arg2.args[0].arg), int(arg2.args[1])
         e.append(
             m2_expr.ExprAff(arg1[shift:shift + 16], m2_expr.ExprInt16(value)))
     else:
-        e.append(m2_expr.ExprAff(arg1[:16], m2_expr.ExprInt16(int(arg2.arg))))
+        e.append(m2_expr.ExprAff(arg1[:16], m2_expr.ExprInt16(int(arg2))))
 
     return e, []
 
@@ -368,7 +368,7 @@ def get_mem_access(mem):
                 off = reg.zeroExtend(base.size) << shift.zeroExtend(base.size)
                 addr = base + off
             elif op == 'LSL':
-                if isinstance(shift, m2_expr.ExprInt) and int(shift.arg) == 0:
+                if isinstance(shift, m2_expr.ExprInt) and int(shift) == 0:
                     addr = base + reg.zeroExtend(base.size)
                 else:
                     addr = base + \
@@ -481,7 +481,7 @@ def ldrsw(ir, instr, arg1, arg2):
 
 def sbfm(ir, instr, arg1, arg2, arg3, arg4):
     e = []
-    rim, sim = int(arg3.arg), int(arg4.arg) + 1
+    rim, sim = int(arg3.arg), int(arg4) + 1
     if sim > rim:
         res = arg2[rim:sim].signExtend(arg1.size)
     else:
@@ -493,7 +493,7 @@ def sbfm(ir, instr, arg1, arg2, arg3, arg4):
 
 def ubfm(ir, instr, arg1, arg2, arg3, arg4):
     e = []
-    rim, sim = int(arg3.arg), int(arg4.arg) + 1
+    rim, sim = int(arg3.arg), int(arg4) + 1
     if sim > rim:
         res = arg2[rim:sim].zeroExtend(arg1.size)
     else:
@@ -504,7 +504,7 @@ def ubfm(ir, instr, arg1, arg2, arg3, arg4):
 
 def bfm(ir, instr, arg1, arg2, arg3, arg4):
     e = []
-    rim, sim = int(arg3.arg), int(arg4.arg) + 1
+    rim, sim = int(arg3.arg), int(arg4) + 1
     if sim > rim:
         res = arg2[rim:sim]
         e.append(m2_expr.ExprAff(arg1[:sim-rim], res))
@@ -674,7 +674,7 @@ def nop():
 def extr(arg1, arg2, arg3, arg4):
     compose = m2_expr.ExprCompose([(arg2, 0, arg2.size),
                                    (arg3, arg2.size, arg2.size+arg3.size)])
-    arg1 = compose[int(arg4.arg):int(arg4.arg)+arg1.size]
+    arg1 = compose[int(arg4.arg):int(arg4)+arg1.size]
 
 mnemo_func = sbuild.functions
 mnemo_func.update({

--- a/miasm2/arch/arm/arch.py
+++ b/miasm2/arch/arm/arch.py
@@ -836,7 +836,7 @@ class arm_offs(arm_imm):
     def encode(self):
         if not isinstance(self.expr, ExprInt):
             return False
-        v = int(self.expr.arg)
+        v = int(self.expr)
         if (1 << (self.l - 1)) & v:
             v = -((0xffffffff ^ v) + 1)
         v = self.encodeval(v)
@@ -888,7 +888,7 @@ class arm_imm8_12(m_arg):
         if not isinstance(e, ExprInt):
             log.debug('should be int %r', e)
             return False
-        v = int(e.arg)
+        v = int(e)
         if v < 0 or v & (1 << 31):
             self.parent.updown.value = 0
             v = -v & 0xFFFFFFFF
@@ -912,7 +912,7 @@ class arm_imm_4_12(m_arg):
     def encode(self):
         if not isinstance(self.expr, ExprInt):
             return False
-        v = int(self.expr.arg)
+        v = int(self.expr)
         if v > 0xffff:
             return False
         self.parent.imm4.value = v >> 12
@@ -932,7 +932,7 @@ class arm_imm_12_4(m_arg):
     def encode(self):
         if not isinstance(self.expr, ExprInt):
             return False
-        v = int(self.expr.arg)
+        v = int(self.expr)
         if v > 0xffff:
             return False
         self.parent.imm.value = (v >> 4) & 0xfff
@@ -995,7 +995,7 @@ class arm_op2(m_arg):
         e = self.expr
         # pure imm
         if isinstance(e, ExprInt):
-            val = self.str_to_imm_rot_form(int(e.arg))
+            val = self.str_to_imm_rot_form(int(e))
             if val is None:
                 return False
             self.parent.immop.value = 1
@@ -1024,7 +1024,7 @@ class arm_op2(m_arg):
             shift_type = 3
         elif isinstance(e.args[1], ExprInt):
             shift_kind = 0
-            amount = int(e.args[1].arg)
+            amount = int(e.args[1])
             # LSR/ASR of 32 => 0
             if amount == 32 and e.op in ['>>', 'a>>']:
                 amount = 0
@@ -1120,9 +1120,9 @@ class arm_op2imm(arm_imm8_12):
         # pure imm
         if isinstance(e.args[1], ExprInt):
             self.parent.immop.value = 0
-            val = self.str_to_imm_rot_form(int(e.args[1].arg))
+            val = self.str_to_imm_rot_form(int(e.args[1]))
             if val is None:
-                val = self.str_to_imm_rot_form(int(e.args[1].arg), True)
+                val = self.str_to_imm_rot_form(int(e.args[1]), True)
                 if val is None:
                     log.debug('cannot encode inm')
                     return False
@@ -1147,7 +1147,7 @@ class arm_op2imm(arm_imm8_12):
         shift_type = allshifts.index(e.op)
         if isinstance(e.args[1], ExprInt):
             shift_kind = 0
-            amount = int(e.args[1].arg)
+            amount = int(e.args[1])
         else:
             shift_kind = 1
             amount = gpregs.expr.index(e.args[1]) << 1
@@ -1406,7 +1406,7 @@ class arm_immed(m_arg):
             return True
         e = e.args[1]
         if isinstance(e, ExprInt):
-            v = int(e.arg)
+            v = int(e)
             if v < 0 or v & (1 << 31):
                 self.parent.updown.value = 0
                 v = (-v) & 0xFFFFFFFF
@@ -1487,7 +1487,7 @@ class arm_mem_rn_imm(m_arg):
             self.value = gpregs.expr.index(reg)
             if not isinstance(imm, ExprInt):
                 return False
-            value = int(imm.arg)
+            value = int(imm)
             if value & 0x80000000:
                 value = -value
                 self.parent.add_imm.value = 0
@@ -1634,7 +1634,7 @@ class arm_widthm1(arm_imm, m_arg):
     def encode(self):
         if not isinstance(self.expr, ExprInt):
             return False
-        v = int(self.expr.arg) +  -1
+        v = int(self.expr) +  -1
         self.value = v
         return True
 
@@ -1660,7 +1660,7 @@ class arm_rm_rot2(m_arg):
             self.value = gpregs.expr.index(reg)
             if not isinstance(value, ExprInt):
                 return False
-            value = int(value.arg)
+            value = int(value)
             if not value in [8, 16, 24]:
                 return False
             self.parent.rot2.value = value / 8
@@ -1739,7 +1739,7 @@ class arm_offreg(m_arg):
         if e.args[0] != self.off_reg:
             log.debug('cannot encode reg %r', e.args[0])
             return False
-        v = int(e.args[1].arg)
+        v = int(e.args[1])
         v = self.encodeval(v)
         self.value = v
         return True
@@ -1773,7 +1773,7 @@ class arm_offpc(arm_offreg):
         if e.args[0] != self.off_reg:
             log.debug('cannot encode reg %r', e.args[0])
             return False
-        v = int(e.args[1].arg)
+        v = int(e.args[1])
         v >>= 2
         self.value = v
         return True
@@ -1865,7 +1865,7 @@ class arm_offbw(imm_noarg):
     def encode(self):
         if not isinstance(self.expr, ExprInt):
             return False
-        v = int(self.expr.arg)
+        v = int(self.expr)
         if self.parent.trb.value == 0:
             if v & 3:
                 log.debug('off must be aligned %r', v)
@@ -1886,7 +1886,7 @@ class arm_offh(imm_noarg):
     def encode(self):
         if not isinstance(self.expr, ExprInt):
             return False
-        v = int(self.expr.arg)
+        v = int(self.expr)
         if v & 1:
             log.debug('off must be aligned %r', v)
             return False
@@ -2197,7 +2197,7 @@ class armt_gpreg_rm_shift_off(arm_reg):
         shift = e.op
         r = gpregs_nosppc.expr.index(e.args[0])
         self.value = r
-        i = int(e.args[1].arg)
+        i = int(e.args[1])
         if shift == 'rrx':
             if i != 1:
                 log.debug('rrx shift must be 1')
@@ -2248,7 +2248,7 @@ class armt2_imm12(arm_imm):
         return True
 
     def encode(self):
-        v = int(self.expr.arg)
+        v = int(self.expr)
         value = None
         # simple encoding
         if 0 <= v < 0x100:

--- a/miasm2/arch/arm/sem.py
+++ b/miasm2/arch/arm/sem.py
@@ -893,8 +893,8 @@ def sxth(ir, instr, a, b):
 
 def ubfx(ir, instr, a, b, c, d):
     e = []
-    c = int(c.arg)
-    d = int(d.arg)
+    c = int(c)
+    d = int(d)
     r = b[c:c+d].zeroExtend(32)
     e.append(ExprAff(a, r))
     dst = None
@@ -905,8 +905,8 @@ def ubfx(ir, instr, a, b, c, d):
 
 def bfc(ir, instr, a, b, c):
     e = []
-    start = int(b.arg)
-    stop = start + int(c.arg)
+    start = int(b)
+    stop = start + int(c)
     out = []
     last = 0
     if start:

--- a/miasm2/arch/mips32/arch.py
+++ b/miasm2/arch/mips32/arch.py
@@ -430,13 +430,13 @@ class mips32_esize(mips32_imm, cpu.m_arg):
 
 class mips32_eposh(mips32_imm, cpu.m_arg):
     def decode(self, v):
-        self.expr = ExprInt32(v-int(self.parent.epos.expr.arg)+1)
+        self.expr = ExprInt32(v-int(self.parent.epos.expr)+1)
         return True
 
     def encode(self):
         if not isinstance(self.expr, ExprInt):
             return False
-        v = int(self.expr.arg) + int(self.parent.epos.expr.arg) -1
+        v = int(self.expr.arg) + int(self.parent.epos.expr) -1
         self.value = v
         return True
 
@@ -446,7 +446,7 @@ class mips32_eposh(mips32_imm, cpu.m_arg):
 class mips32_cpr(cpu.m_arg):
     parser = regs.regs_cpr0_info.parser
     def decode(self, v):
-        index = int(self.parent.cpr0.expr.arg) << 3
+        index = int(self.parent.cpr0.expr) << 3
         index += v
         self.expr = regs.regs_cpr0_expr[index]
         return True

--- a/miasm2/arch/mips32/sem.py
+++ b/miasm2/arch/mips32/sem.py
@@ -131,8 +131,8 @@ def l_and(arg1, arg2, arg3):
 
 @sbuild.parse
 def ext(arg1, arg2, arg3, arg4):
-    pos = int(arg3.arg)
-    size = int(arg4.arg)
+    pos = int(arg3)
+    size = int(arg4)
     arg1 = arg2[pos:pos + size].zeroExtend(32)
 
 @sbuild.parse
@@ -311,8 +311,8 @@ def tlbp():
 
 def ins(ir, instr, a, b, c, d):
     e = []
-    pos = int(c.arg)
-    l = int(d.arg)
+    pos = int(c)
+    l = int(d)
 
     my_slices = []
     if pos != 0:

--- a/miasm2/arch/msp430/arch.py
+++ b/miasm2/arch/msp430/arch.py
@@ -193,7 +193,7 @@ class instruction_msp430(instruction):
         # Call argument is an absolute offset
         # Other offsets are relative to instruction offset
         if self.name != "call":
-            self.args[0] =  ExprInt(int(e.arg) - self.offset, 16)
+            self.args[0] =  ExprInt(int(e) - self.offset, 16)
 
     def get_info(self, c):
         pass
@@ -371,7 +371,7 @@ class msp430_sreg_arg(reg_noarg, m_arg):
             self.parent.a_s.value = 0
             self.value = self.reg_info.expr.index(e)
         elif isinstance(e, ExprInt):
-            v = int(e.arg)
+            v = int(e)
             if v == 0xffff and self.parent.size.value == 0:
                 self.parent.a_s.value = 0b11
                 self.value = 3
@@ -404,11 +404,11 @@ class msp430_sreg_arg(reg_noarg, m_arg):
             elif isinstance(e.arg, ExprInt):
                 self.parent.a_s.value = 0b01
                 self.value = self.reg_info.expr.index(SR)
-                self.parent.off_s.value = int(e.arg.arg)
+                self.parent.off_s.value = int(e.arg)
             elif isinstance(e.arg, ExprOp):
                 self.parent.a_s.value = 0b01
                 self.value = self.reg_info.expr.index(e.arg.args[0])
-                self.parent.off_s.value = int(e.arg.args[1].arg)
+                self.parent.off_s.value = int(e.arg.args[1])
             else:
                 raise NotImplementedError(
                     'unknown instance e.arg = %s' % type(e.arg))
@@ -464,7 +464,7 @@ class msp430_dreg_arg(msp430_sreg_arg):
                     'unknown instance e.arg = %s' % type(e.arg))
             self.parent.a_d.value = 1
             self.value = self.reg_info.expr.index(r)
-            self.parent.off_d.value = int(i.arg)
+            self.parent.off_d.value = int(i)
         else:
             raise NotImplementedError('unknown instance e = %s' % type(e))
         return True
@@ -550,7 +550,7 @@ class msp430_offs(imm_noarg, m_arg):
     def encode(self):
         if not isinstance(self.expr, ExprInt):
             return False
-        v = int(self.expr.arg)
+        v = int(self.expr)
         if (1 << (self.l - 1)) & v:
             v = -((0xffff ^ v) + 1)
         v = self.encodeval(v)

--- a/miasm2/arch/sh4/arch.py
+++ b/miasm2/arch/sh4/arch.py
@@ -247,7 +247,7 @@ class sh4_dgpreg_imm(sh4_dgpreg):
                 return False
             if not isinstance(res[jrb], ExprInt):
                 return False
-            d = int(res[jrb].arg)
+            d = int(res[jrb])
             p.disp.value = d / (s / 8)
             if not res[jra] in gpregs.expr:
                 return False
@@ -275,7 +275,7 @@ class sh4_simm(sh4_imm):
     def encode(self):
         if not isinstance(self.expr, ExprInt):
             return False
-        v = int(self.expr.arg)
+        v = int(self.expr)
         if (1 << (self.l - 1)) & v:
             v = -((0xffffffff ^ v) + 1)
         v = self.encodeval(v)
@@ -291,7 +291,7 @@ class sh4_dpc16imm(sh4_dgpreg):
         return True
 
     def calcdisp(self, v):
-        v = (int(v.arg) - 4) / 2
+        v = (int(v) - 4) / 2
         if not 0 < v <= 0xff:
             return None
         return v
@@ -328,7 +328,7 @@ class sh4_dgbrimm8(sh4_dgpreg):
             return False
         if not isinstance(res[jra], ExprInt):
             return False
-        self.value = int(res[jra].arg) / (s / 8)
+        self.value = int(res[jra]) / (s / 8)
         return True
 
 
@@ -341,7 +341,7 @@ class sh4_dpc32imm(sh4_dpc16imm):
         return True
 
     def calcdisp(self, v):
-        v = (int(v.arg) - 4) / 4
+        v = (int(v) - 4) / 4
         if not 0 < v <= 0xff:
             return None
         return v
@@ -373,7 +373,7 @@ class sh4_pc32imm(m_arg):
             return False
         if not isinstance(res[jra], ExprInt):
             return False
-        v = (int(res[jra].arg) - 4) / 4
+        v = (int(res[jra]) - 4) / 4
         if v is None:
             return False
         self.value = v

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -430,7 +430,7 @@ def l_test(ir, instr, a, b):
 def get_shift(a, b):
     # b.size must match a
     if isinstance(b, m2_expr.ExprInt):
-        b = m2_expr.ExprInt(int(b.arg), a.size)
+        b = m2_expr.ExprInt(int(b), a.size)
     else:
         b = b.zeroExtend(a.size)
     if a.size == 64:
@@ -472,7 +472,7 @@ def _rotate_tpl(ir, instr, a, b, op, left=False, include_cf=False):
 
     # Don't generate conditional shifter on constant
     if isinstance(shifter, m2_expr.ExprInt):
-        if int(shifter.arg) != 0:
+        if int(shifter) != 0:
             return e_do, []
         else:
             return [], []
@@ -569,7 +569,7 @@ def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None, left=False,
 
     # Don't generate conditional shifter on constant
     if isinstance(shifter, m2_expr.ExprInt):
-        if int(shifter.arg) != 0:
+        if int(shifter) != 0:
             return e_do, []
         else:
             return [], []
@@ -1172,7 +1172,7 @@ def ret(ir, instr, a=None):
         a = m2_expr.ExprInt(0, s)
         value = (myesp + (m2_expr.ExprInt((s / 8), s)))
     else:
-        a = m2_expr.ExprInt(int(a.arg), s)
+        a = m2_expr.ExprInt(int(a), s)
         value = (myesp + (m2_expr.ExprInt((s / 8), s) + a))
 
     e.append(m2_expr.ExprAff(myesp, value))
@@ -3624,7 +3624,7 @@ def ps_rl_ll(ir, instr, a, b, op, size):
                        i, i + size))
 
     if isinstance(test, m2_expr.ExprInt):
-        if int(test.arg) == 0:
+        if int(test) == 0:
             return [m2_expr.ExprAff(a[0:a.size], m2_expr.ExprCompose(slices))], []
         else:
             return [m2_expr.ExprAff(a, m2_expr.ExprInt(0, a.size))], []
@@ -3803,7 +3803,7 @@ def pinsr(ir, instr, a, b, c, size):
             32: 0x3,
             64: 0x1}[size]
 
-    sel = (int(c.arg) & mask) * size
+    sel = (int(c) & mask) * size
     e.append(m2_expr.ExprAff(a[sel:sel + size], b[:size]))
 
     return e, []
@@ -3833,7 +3833,7 @@ def pextr(ir, instr, a, b, c, size):
             32: 0x3,
             64: 0x1}[size]
 
-    sel = (int(c.arg) & mask) * size
+    sel = (int(c) & mask) * size
     e.append(m2_expr.ExprAff(a, b[sel:sel + size].zeroExtend(a.size)))
 
     return e, []

--- a/miasm2/core/cpu.py
+++ b/miasm2/core/cpu.py
@@ -1433,7 +1433,7 @@ class cls_mn(object):
         args = []
         for d in dst:
             if isinstance(d, m2_expr.ExprInt):
-                l = symbol_pool.getby_offset_create(int(d.arg))
+                l = symbol_pool.getby_offset_create(int(d))
 
                 a = m2_expr.ExprId(l.name, d.size)
             else:
@@ -1457,7 +1457,7 @@ class imm_noarg(object):
     def expr2int(self, e):
         if not isinstance(e, m2_expr.ExprInt):
             return None
-        v = int(e.arg)
+        v = int(e)
         if v & ~self.intmask != 0:
             return None
         return v
@@ -1542,7 +1542,7 @@ class int32_noarg(imm_noarg):
     def encode(self):
         if not isinstance(self.expr, m2_expr.ExprInt):
             return False
-        v = int(self.expr.arg)
+        v = int(self.expr)
         if sign_ext(v & self.lmask, self.l, self.intsize) != v:
             return False
         v = self.encodeval(v & self.lmask)

--- a/miasm2/expression/expression.py
+++ b/miasm2/expression/expression.py
@@ -411,6 +411,12 @@ class ExprInt(Expr):
     def graph_recursive(self, graph):
         graph.add_node(self)
 
+    def __int__(self):
+        return int(self.arg)
+
+    def __long__(self):
+        return long(self.arg)
+
 
 class ExprId(Expr):
 

--- a/miasm2/expression/expression_helper.py
+++ b/miasm2/expression/expression_helper.py
@@ -43,7 +43,7 @@ def merge_sliceto_slice(args):
             # sources_int[a.start] = a
             # copy ExprInt because we will inplace modify arg just below
             # /!\ TODO XXX never ever modify inplace args...
-            sources_int[a[1]] = (m2_expr.ExprInt(int(a[0].arg),
+            sources_int[a[1]] = (m2_expr.ExprInt(int(a[0]),
                                                  a[2] - a[1]),
                                  a[1],
                                  a[2])
@@ -80,12 +80,12 @@ def merge_sliceto_slice(args):
             s_start, s_stop = sorted_s[-1][1][1], sorted_s[-1][1][2]
             size += s_stop - s_start
             a = m2_expr.mod_size2uint[size](
-                (int(out[0].arg) << (out[1] - s_start)) +
-                 int(sorted_s[-1][1][0].arg))
+                (int(out[0]) << (out[1] - s_start)) +
+                 int(sorted_s[-1][1][0]))
             out[0] = m2_expr.ExprInt(a)
             sorted_s.pop()
             out[1] = s_start
-        out[0] = m2_expr.ExprInt(int(out[0].arg), size)
+        out[0] = m2_expr.ExprInt(int(out[0]), size)
         final_sources.append((start, out))
 
     final_sources_int = final_sources

--- a/miasm2/expression/simplifications_common.py
+++ b/miasm2/expression/simplifications_common.py
@@ -267,7 +267,7 @@ def simp_cst_propagation(e_s, e):
     # A << int with A ExprCompose => move index
     if op == "<<" and isinstance(args[0], ExprCompose) and isinstance(args[1], ExprInt):
         final_size = args[0].size
-        shift = int(args[1].arg)
+        shift = int(args[1])
         new_args = []
         # shift indexes
         for expr, start, stop in args[0].args:
@@ -291,7 +291,7 @@ def simp_cst_propagation(e_s, e):
     # A >> int with A ExprCompose => move index
     if op == ">>" and isinstance(args[0], ExprCompose) and isinstance(args[1], ExprInt):
         final_size = args[0].size
-        shift = int(args[1].arg)
+        shift = int(args[1])
         new_args = []
         # shift indexes
         for expr, start, stop in args[0].args:
@@ -335,14 +335,14 @@ def simp_cst_propagation(e_s, e):
         dest, rounds, cf = args
         # Skipped if rounds is 0
         if (isinstance(rounds, ExprInt) and
-            int(rounds.arg) == 0):
+            int(rounds) == 0):
             return dest
         elif all(map(lambda x: isinstance(x, ExprInt), args)):
             # The expression can be resolved
-            tmp = int(dest.arg)
-            cf = int(cf.arg)
+            tmp = int(dest)
+            cf = int(cf)
             size = dest.size
-            tmp_count = (int(rounds.arg) &
+            tmp_count = (int(rounds) &
                          (0x3f if size == 64 else 0x1f)) % (size + 1)
             if op == ">>>c_rez":
                 while (tmp_count != 0):
@@ -350,14 +350,14 @@ def simp_cst_propagation(e_s, e):
                     tmp = (tmp >> 1) + (cf << (size - 1))
                     cf = tmp_cf
                     tmp_count -= 1
-                    tmp &= int(dest.mask.arg)
+                    tmp &= int(dest.mask)
             elif op == "<<<c_rez":
                 while (tmp_count != 0):
                     tmp_cf = (tmp >> (size - 1)) & 1
                     tmp = (tmp << 1) + cf
                     cf = tmp_cf
                     tmp_count -= 1
-                    tmp &= int(dest.mask.arg)
+                    tmp &= int(dest.mask)
             else:
                 raise RuntimeError("Unknown operation: %s" % op)
             return ExprInt(tmp, size=dest.size)
@@ -518,7 +518,7 @@ def simp_slice(e_s, e):
     elif (isinstance(e.arg, ExprOp) and e.arg.op in [">>", "<<"] and
           isinstance(e.arg.args[1], ExprInt)):
         arg, shift = e.arg.args
-        shift = int(shift.arg)
+        shift = int(shift)
         if e.arg.op == ">>":
             if shift + e.stop <= arg.size:
                 return arg[e.start + shift:e.stop + shift]

--- a/miasm2/expression/simplifications_cond.py
+++ b/miasm2/expression/simplifications_cond.py
@@ -197,13 +197,13 @@ def __comp_signed(arg1, arg2):
     """Return ExprInt1(1) if arg1 <s arg2 else ExprInt1(0)
     @arg1, @arg2: ExprInt"""
 
-    val1 = int(arg1.arg)
+    val1 = int(arg1)
     if val1 >> (arg1.size - 1) == 1:
-        val1 = - ((int(arg1.mask.arg) ^ val1) + 1)
+        val1 = - ((int(arg1.mask) ^ val1) + 1)
 
-    val2 = int(arg2.arg)
+    val2 = int(arg2)
     if val2 >> (arg2.size - 1) == 1:
-        val2 = - ((int(arg2.mask.arg) ^ val2) + 1)
+        val2 = - ((int(arg2.mask) ^ val2) + 1)
 
     return m2_expr.ExprInt1(1) if (val1 < val2) else m2_expr.ExprInt1(0)
 

--- a/miasm2/expression/stp.py
+++ b/miasm2/expression/stp.py
@@ -8,7 +8,7 @@ TODO XXX: finish
 
 
 def ExprInt_strcst(self):
-    b = bin(int(self.arg))[2::][::-1]
+    b = bin(int(self))[2::][::-1]
     b += "0" * self.size
     b = b[:self.size][::-1]
     return "0bin" + b

--- a/miasm2/ir/ir.py
+++ b/miasm2/ir/ir.py
@@ -326,7 +326,7 @@ class ir(object):
                 isinstance(ad.name, asm_label)):
             ad = ad.name
         if isinstance(ad, m2_expr.ExprInt):
-            ad = int(ad.arg)
+            ad = int(ad)
         if type(ad) in [int, long]:
             ad = self.symbol_pool.getby_offset_create(ad)
         elif isinstance(ad, asm_label):
@@ -514,7 +514,7 @@ class ir(object):
             for d in dst:
                 if isinstance(d, m2_expr.ExprInt):
                     d = m2_expr.ExprId(
-                        self.symbol_pool.getby_offset_create(int(d.arg)))
+                        self.symbol_pool.getby_offset_create(int(d)))
                 if expr_is_label(d):
                     self._graph.add_edge(lbl, d.name)
 

--- a/miasm2/ir/symbexec.py
+++ b/miasm2/ir/symbexec.py
@@ -295,7 +295,7 @@ class symbexec(object):
         ex = self.expr_simp(self.eval_expr(ex, {}))
         if not isinstance(ex, m2_expr.ExprInt):
             return None
-        ptr_diff = int(int32(ex.arg))
+        ptr_diff = int(int32(ex))
         out = []
         if ptr_diff < 0:
             #    [a     ]

--- a/miasm2/ir/translators/miasm.py
+++ b/miasm2/ir/translators/miasm.py
@@ -10,7 +10,7 @@ class TranslatorMiasm(Translator):
         return "ExprId(%s, size=%d)" % (repr(expr.name), expr.size)
 
     def from_ExprInt(self, expr):
-        return "ExprInt(0x%x, %d)" % (int(expr.arg), expr.size)
+        return "ExprInt(0x%x, %d)" % (int(expr), expr.size)
 
     def from_ExprCond(self, expr):
         return "ExprCond(%s, %s, %s)" % (self.from_expr(expr.cond),

--- a/miasm2/jitter/codegen.py
+++ b/miasm2/jitter/codegen.py
@@ -291,7 +291,7 @@ class CGen(object):
             return ("((%s)?(%s):(%s))" % (cond, src1, src2),
                     "((%s)?(%s):(%s))" % (cond, src1b, src2b))
         elif isinstance(expr, m2_expr.ExprInt):
-            offset = int(expr.arg)
+            offset = int(expr)
             self.add_label_index(dst2index, offset)
             return ("%s" % dst2index[offset],
                     hex(offset))

--- a/miasm2/jitter/emulatedsymbexec.py
+++ b/miasm2/jitter/emulatedsymbexec.py
@@ -90,7 +90,7 @@ class EmulatedSymbExec(symbexec):
         """Handle 'segm' operation"""
         if expr.op != "segm":
             return expr
-        segm_nb = int(expr.args[0].arg)
+        segm_nb = int(expr.args[0])
         segmaddr = self.cpu.get_segm_base(segm_nb)
         return e_s(m2_expr.ExprOp("+",
                                   m2_expr.ExprInt(segmaddr, expr.size),

--- a/miasm2/jitter/llvmconvert.py
+++ b/miasm2/jitter/llvmconvert.py
@@ -43,7 +43,7 @@ class LLVMType(llvm_c.Type):
     def generic(cls, e):
         "Generic value for execution"
         if isinstance(e, m2_expr.ExprInt):
-            return llvm_e.GenericValue.int(LLVMType.int(e.size), int(e.arg))
+            return llvm_e.GenericValue.int(LLVMType.int(e.size), int(e))
         elif isinstance(e, llvm_e.GenericValue):
             return e
         else:
@@ -365,7 +365,7 @@ class LLVMFunction():
         builder = self.builder
 
         if isinstance(expr, m2_expr.ExprInt):
-            ret = llvm_c.Constant.int(LLVMType.int(expr.size), int(expr.arg))
+            ret = llvm_c.Constant.int(LLVMType.int(expr.size), int(expr))
             self.update_cache(expr, ret)
             return ret
 

--- a/test/analysis/depgraph.py
+++ b/test/analysis/depgraph.py
@@ -637,7 +637,7 @@ def flatNode(node):
         if isinstance(node.element, ExprId):
             element = node.element.name
         elif isinstance(node.element, ExprInt):
-            element = int(node.element.arg.arg)
+            element = int(node.element.arg)
         else:
             RuntimeError("Unsupported type '%s'" % type(enode.element))
         return (node.label.name,


### PR DESCRIPTION
Introduce a more intuitive (at least to me) way to get the value of a `ExprInt`.
Instead of `int(x.arg)` or `x.arg.arg`, `int(x)` is now available (and `long(x)` too)