### PR TITLE
Feature/sembuilder arm

### DIFF
--- a/miasm2/arch/arm/sem.py
+++ b/miasm2/arch/arm/sem.py
@@ -106,7 +106,7 @@ def update_flag(on=None, inv=False,
         def new_func(ir, instr, *args):
             cur_block = func(ir, instr, *args)
 
-            if on is not None and instr.name == on and args[0] != PC:
+            if (on is None or instr.name == on) and args[0] != PC:
                 result = (aff.src
                           for aff in cur_block
                           if aff.dst == args[0]).next()
@@ -190,12 +190,11 @@ def sub(ir, instr, a, b, c):
     e.append(ExprAff(a, r))
     return e
 
+@update_flag(arith=True, sub=True)
 @extend_sem
 def subs(ir, instr, a, b, c=None):
     e = []
     r = b - c
-    e += update_flag_arith(r)
-    e += update_flag_sub(b, c, r)
     e.append(ExprAff(a, r))
     return e
 

--- a/miasm2/arch/arm/sem.py
+++ b/miasm2/arch/arm/sem.py
@@ -293,7 +293,7 @@ def movt(arg1, arg2):
 @extend_sem
 @sbuild.parse
 def mvn(arg1, arg2):
-    arg1 = arg2 ^ i32(-1)
+    arg1 = ~arg2
 
 
 @extend_sem
@@ -311,7 +311,7 @@ def negs(ir, instr, a, b):
 @extend_sem
 @sbuild.parse
 def bic(arg1, arg2, arg3):
-    arg1 = arg2 & (arg3 ^ i32(-1))
+    arg1 = arg2 & ~arg3
 
 
 @update_flag(on="MLAS", zn=True)

--- a/miasm2/core/sembuilder.py
+++ b/miasm2/core/sembuilder.py
@@ -129,15 +129,21 @@ class SemBuilder(object):
     instanciation
     """
 
-    def __init__(self, ctx):
+    def __init__(self, ctx, no_extra_block=False):
         """Create a SemBuilder
         @ctx: context dictionary used during parsing
+        @no_extra_block: (optional) if set, build functions will not return extra
+        blocks
+
         """
         # Init
         self.transformer = MiasmTransformer()
         self._ctx = dict(m2_expr.__dict__)
         self._ctx["irbloc"] = irbloc
         self._functions = {}
+
+        # Option
+        self._no_extra_block = no_extra_block
 
         # Update context
         self._ctx.update(ctx)
@@ -308,11 +314,17 @@ class SemBuilder(object):
             ## Last block can be empty
             blocks.pop()
         other_blocks = blocks[1:]
-        body.append(ast.Return(value=ast.Tuple(elts=[ast.List(elts=cur_instr,
-                                                              ctx=ast.Load()),
-                                                     ast.List(elts=other_blocks,
-                                                              ctx=ast.Load())],
-                                               ctx=ast.Load())))
+
+        if self._no_extra_block:
+            to_ret = ast.List(elts=cur_instr,
+                              ctx=ast.Load())
+        else:
+            to_ret = ast.Tuple(elts=[ast.List(elts=cur_instr,
+                                              ctx=ast.Load()),
+                                     ast.List(elts=other_blocks,
+                                              ctx=ast.Load())],
+                               ctx=ast.Load())
+        body.append(ast.Return(value=to_ret))
 
         ret = ast.Module([ast.FunctionDef(name=fc_ast.name,
                                           args=fc_ast.args,

--- a/test/core/sembuilder.py
+++ b/test/core/sembuilder.py
@@ -63,3 +63,12 @@ for irb in res[1]:
         for expr in exprs:
             print expr
         print
+
+# Test options
+
+sb = SemBuilder({}, no_extra_block=True)
+@sb.parse
+def test(arg1, arg2):
+    arg1 = arg2
+
+assert test(ir, instr, a, b) == [m2_expr.ExprAff(a, b)]


### PR DESCRIPTION
Merge common subcode snippets in ARM semantic definition, such as:
* if `arg3` is `None`, `arg2` and `arg3` are modified to `arg1` and `arg2`
* update `IRDst` if the destination argument is `PC`
* flag update are now specified through a decorator

In addition, this PR introduce the use of sembuilder to describe ARM semantic.