### PR TITLE
Symb exec clean

### DIFF
--- a/example/expression/basic_simplification.py
+++ b/example/expression/basic_simplification.py
@@ -11,8 +11,7 @@ b = ExprId('ebx')
 
 exprs = [a + b - a,
          ExprInt32(0x12) + ExprInt32(0x30) - a,
-         ExprCompose([(a[:8], 0, 8),
-                      (a[8:16], 8, 16)])]
+         ExprCompose(a[:8], a[8:16])]
 
 for e in exprs:
     print '*' * 40

--- a/example/expression/expr_grapher.py
+++ b/example/expression/expr_grapher.py
@@ -8,7 +8,7 @@ c = ExprId("C")
 d = ExprId("D")
 m = ExprMem(a + b + c + a)
 
-e1 = ExprCompose([(a + b - (c * a) / m | b, 0, 32), (a + m, 32, 64)])
+e1 = ExprCompose(a + b - (c * a) / m | b, a + m)
 e2 = ExprInt64(15)
 e = ExprCond(d, e1, e2)[0:32]
 

--- a/example/expression/simplification_tools.py
+++ b/example/expression/simplification_tools.py
@@ -25,11 +25,9 @@ i1 = ExprInt(uint32(0x1))
 i2 = ExprInt(uint32(0x2))
 cc = ExprCond(a, b, c)
 
-o = ExprCompose([(a[:8], 8, 16),
-                 (a[8:16], 0, 8)])
+o = ExprCompose(a[8:16], a[:8])
 
-o2 = ExprCompose([(a[8:16], 0, 8),
-                 (a[:8], 8, 16)])
+o2 = ExprCompose(a[8:16], a[:8])
 
 l = [a[:8], b[:8], c[:8], m[:8], s, i1[:8], i2[:8], o[:8]]
 l2 = l[::-1]
@@ -56,7 +54,7 @@ print y == y.copy()
 print repr(y), repr(y.copy())
 
 
-z = ExprCompose([(a[5:5 + 8], 0, 8), (b[:16], 8, 24), (x[:8], 24, 32)])
+z = ExprCompose(a[5:5 + 8], b[:16], x[:8])
 print z
 print z.copy()
 print z[:31].copy().visit(replace_expr)

--- a/example/ida/symbol_exec.py
+++ b/example/ida/symbol_exec.py
@@ -94,7 +94,7 @@ def symbolic_exec():
 
     print "Run symbolic execution..."
     sb = symbexec(ira, machine.mn.regs.regs_init)
-    sb.emul_ir_blocs(ira, start)
+    sb.emul_ir_blocks(start)
 
     modified = {}
     for ident in sb.symbols.symbols_id:

--- a/example/symbol_exec/single_instr.py
+++ b/example/symbol_exec/single_instr.py
@@ -26,8 +26,8 @@ symbols_init = ira.arch.regs.regs_init
 symb = symbexec(ira, symbols_init)
 
 # Emulate one IR basic block
-## Emulation of several basic blocks can be done through .emul_ir_blocs
-cur_addr = symb.emul_ir_bloc(ira, START_ADDR)
+## Emulation of several basic blocks can be done through .emul_ir_blocks
+cur_addr = symb.emul_ir_block(START_ADDR)
 
 # Modified elements
 print 'Modified registers:'

--- a/miasm2/analysis/data_analysis.py
+++ b/miasm2/analysis/data_analysis.py
@@ -75,12 +75,7 @@ def intra_bloc_flow_symbexec(ir_arch, flow_graph, irb):
     out_nodes = {}
     current_nodes = {}
 
-    symbols_init = {}
-    for r in ir_arch.arch.regs.all_regs_ids:
-        # symbols_init[r] = ir_arch.arch.regs.all_regs_ids_init[i]
-        x = ExprId(r.name, r.size)
-        x.is_term = True
-        symbols_init[r] = x
+    symbols_init = dict(ir_arch.arch.regs.all_regs_ids_init)
 
     sb = symbexec(ir_arch, dict(symbols_init))
     sb.emulbloc(irb)

--- a/miasm2/arch/aarch64/sem.py
+++ b/miasm2/arch/aarch64/sem.py
@@ -672,8 +672,7 @@ def nop():
 
 @sbuild.parse
 def extr(arg1, arg2, arg3, arg4):
-    compose = m2_expr.ExprCompose([(arg2, 0, arg2.size),
-                                   (arg3, arg2.size, arg2.size+arg3.size)])
+    compose = m2_expr.ExprCompose(arg2, arg3)
     arg1 = compose[int(arg4.arg):int(arg4)+arg1.size]
 
 mnemo_func = sbuild.functions

--- a/miasm2/arch/mips32/sem.py
+++ b/miasm2/arch/mips32/sem.py
@@ -99,7 +99,7 @@ def bne(arg1, arg2, arg3):
 def lui(arg1, arg2):
     """The immediate value @arg2 is shifted left 16 bits and stored in the
     register @arg1. The lower 16 bits are zeroes."""
-    arg1 = ExprCompose([(i16(0), 0, 16), (arg2[:16], 16, 32)])
+    arg1 = ExprCompose(i16(0), arg2[:16])
 
 @sbuild.parse
 def nop():
@@ -251,10 +251,7 @@ def bgtz(arg1, arg2):
 
 @sbuild.parse
 def wsbh(arg1, arg2):
-    arg1 = ExprCompose([(arg2[8:16],  0, 8),
-                        (arg2[0:8]  , 8, 16),
-                        (arg2[24:32], 16, 24),
-                        (arg2[16:24], 24, 32)])
+    arg1 = ExprCompose(arg2[8:16], arg2[0:8], arg2[24:32], arg2[16:24])
 
 @sbuild.parse
 def rotr(arg1, arg2, arg3):

--- a/miasm2/arch/msp430/sem.py
+++ b/miasm2/arch/msp430/sem.py
@@ -250,8 +250,7 @@ def call(ir, instr, a):
 def swpb(ir, instr, a):
     e = []
     x, y = a[:8], a[8:16]
-    e.append(ExprAff(a, ExprCompose([(y, 0, 8),
-                                     (x, 8, 16)])))
+    e.append(ExprAff(a, ExprCompose(y, x)))
     return e, []
 
 
@@ -330,8 +329,7 @@ def jmp(ir, instr, a):
 
 def rrc_w(ir, instr, a):
     e = []
-    c = ExprCompose([(a[1:16], 0, 15),
-                   (cf, 15, 16)])
+    c = ExprCompose(a[1:16], cf)
     e.append(ExprAff(a, c))
     e.append(ExprAff(cf, a[:1]))
     # e += update_flag_zn_r(c)
@@ -347,8 +345,7 @@ def rrc_w(ir, instr, a):
 
 def rra_w(ir, instr, a):
     e = []
-    c = ExprCompose([(a[1:16], 0, 15),
-                   (a[15:16], 15, 16)])
+    c = ExprCompose(a[1:16], a[15:16])
     e.append(ExprAff(a, c))
     # TODO: error in disasm microcorruption?
     # e.append(ExprAff(cf, a[:1]))
@@ -406,18 +403,7 @@ mnemo_func = {
 }
 
 
-composed_sr = ExprCompose([
-    (cf,   0,  1),
-    (zf,   1,  2),
-    (nf,   2,  3),
-    (gie,  3,  4),
-    (cpuoff,  4,  5),
-    (osc,  5,  6),
-    (scg0, 6,  7),
-    (scg1, 7,  8),
-    (of, 8,  9),
-    (res, 9, 16),
-])
+composed_sr = ExprCompose(cf, zf, nf, gie, cpuoff, osc, scg0, scg1, of, res)
 
 
 def ComposeExprAff(dst, src):

--- a/miasm2/arch/sh4/regs.py
+++ b/miasm2/arch/sh4/regs.py
@@ -78,7 +78,6 @@ all_regs_ids_init = [ExprId("%s_init" % x.name, x.size) for x in all_regs_ids]
 
 regs_init = {}
 for i, r in enumerate(all_regs_ids):
-    all_regs_ids_init[i].is_term = True
     regs_init[r] = all_regs_ids_init[i]
 
 regs_flt_expr = []

--- a/miasm2/arch/x86/regs.py
+++ b/miasm2/arch/x86/regs.py
@@ -430,7 +430,6 @@ all_regs_ids_init = [ExprId("%s_init" % x.name, x.size) for x in all_regs_ids]
 
 regs_init = {}
 for i, r in enumerate(all_regs_ids):
-    all_regs_ids_init[i].is_term = True
     regs_init[r] = all_regs_ids_init[i]
 
 regs_flt_expr = [float_st0, float_st1, float_st2, float_st3,

--- a/miasm2/core/sembuilder.py
+++ b/miasm2/core/sembuilder.py
@@ -16,7 +16,7 @@ class MiasmTransformer(ast.NodeTransformer):
     X if Y else Z -> ExprCond(Y, X, Z)
     'X'(Y)        -> ExprOp('X', Y)
     ('X' % Y)(Z)  -> ExprOp('X' % Y, Z)
-    {a, b}        -> ExprCompose([a, 0, a.size], [b, a.size, a.size + b.size])
+    {a, b}        -> ExprCompose([(a, 0, a.size), (b, a.size, a.size + b.size)])
     """
 
     # Parsers
@@ -95,7 +95,7 @@ class MiasmTransformer(ast.NodeTransformer):
         return call
 
     def visit_Set(self, node):
-        "{a, b} -> ExprCompose([a, 0, a.size], [b, a.size, a.size + b.size])"
+        "{a, b} -> ExprCompose([(a, 0, a.size)], (b, a.size, a.size + b.size)])"
         if len(node.elts) == 0:
             return node
 
@@ -109,7 +109,7 @@ class MiasmTransformer(ast.NodeTransformer):
                                   right=ast.Attribute(value=elt,
                                                       attr='size',
                                                       ctx=ast.Load()))
-            new_elts.append(ast.List(elts=[elt, index, new_index],
+            new_elts.append(ast.Tuple(elts=[elt, index, new_index],
                                      ctx=ast.Load()))
             index = new_index
         return ast.Call(func=ast.Name(id='ExprCompose',

--- a/miasm2/core/sembuilder.py
+++ b/miasm2/core/sembuilder.py
@@ -95,27 +95,16 @@ class MiasmTransformer(ast.NodeTransformer):
         return call
 
     def visit_Set(self, node):
-        "{a, b} -> ExprCompose([(a, 0, a.size)], (b, a.size, a.size + b.size)])"
+        "{a, b} -> ExprCompose(a, b)"
         if len(node.elts) == 0:
             return node
 
         # Recursive visit
         node = self.generic_visit(node)
 
-        new_elts = []
-        index = ast.Num(n=0)
-        for elt in node.elts:
-            new_index = ast.BinOp(op=ast.Add(), left=index,
-                                  right=ast.Attribute(value=elt,
-                                                      attr='size',
-                                                      ctx=ast.Load()))
-            new_elts.append(ast.Tuple(elts=[elt, index, new_index],
-                                     ctx=ast.Load()))
-            index = new_index
         return ast.Call(func=ast.Name(id='ExprCompose',
                                       ctx=ast.Load()),
-                               args=[ast.List(elts=new_elts,
-                                              ctx=ast.Load())],
+                               args=node.elts,
                                keywords=[],
                                starargs=None,
                                kwargs=None)

--- a/miasm2/core/sembuilder.py
+++ b/miasm2/core/sembuilder.py
@@ -16,7 +16,7 @@ class MiasmTransformer(ast.NodeTransformer):
     X if Y else Z -> ExprCond(Y, X, Z)
     'X'(Y)        -> ExprOp('X', Y)
     ('X' % Y)(Z)  -> ExprOp('X' % Y, Z)
-    {a, b}        -> ExprCompose([(a, 0, a.size), (b, a.size, a.size + b.size)])
+    {a, b}        -> ExprCompose(((a, 0, a.size), (b, a.size, a.size + b.size)))
     """
 
     # Parsers

--- a/miasm2/expression/expression.py
+++ b/miasm2/expression/expression.py
@@ -118,7 +118,6 @@ class Expr(object):
 
     all_exprs = set()
     args2expr = {}
-    simp_exprs = set()
     canon_exprs = set()
     use_singleton = True
 
@@ -146,15 +145,6 @@ class Expr(object):
     def __new__(cls, *args, **kwargs):
         expr = object.__new__(cls, *args, **kwargs)
         return expr
-
-    def get_is_simp(self):
-        return self in Expr.simp_exprs
-
-    def set_is_simp(self, value):
-        assert(value is True)
-        Expr.simp_exprs.add(self)
-
-    is_simp = property(get_is_simp, set_is_simp)
 
     def get_is_canon(self):
         return self in Expr.canon_exprs

--- a/miasm2/expression/expression.py
+++ b/miasm2/expression/expression.py
@@ -389,6 +389,12 @@ class ExprInt(Expr):
     size = property(lambda self: self.__size)
     arg = property(lambda self: self.__arg)
 
+    def __getstate__(self):
+        return int(self.__arg), self.__size
+
+    def __setstate__(self, state):
+        self.__init__(*state)
+
     def __new__(cls, arg, size=None):
         if size is None:
             size = arg.size
@@ -466,6 +472,12 @@ class ExprId(Expr):
     size = property(lambda self: self.__size)
     name = property(lambda self: self.__name)
 
+    def __getstate__(self):
+        return self.__name, self.__size
+
+    def __setstate__(self, state):
+        self.__init__(*state)
+
     def __new__(cls, name, size=32):
         return Expr.get_object(cls, (name, size))
 
@@ -542,6 +554,12 @@ class ExprAff(Expr):
     size = property(lambda self: self.__size)
     dst = property(lambda self: self.__dst)
     src = property(lambda self: self.__src)
+
+    def __getstate__(self):
+        return self.__dst, self.__src
+
+    def __setstate__(self, state):
+        self.__init__(*state)
 
     def __new__(cls, dst, src):
         return Expr.get_object(cls, (dst, src))
@@ -641,6 +659,12 @@ class ExprCond(Expr):
     src1 = property(lambda self: self.__src1)
     src2 = property(lambda self: self.__src2)
 
+    def __getstate__(self):
+        return self.__cond, self.__src1, self.__src2
+
+    def __setstate__(self, state):
+        self.__init__(*state)
+
     def __new__(cls, cond, src1, src2):
         return Expr.get_object(cls, (cond, src1, src2))
 
@@ -725,6 +749,12 @@ class ExprMem(Expr):
 
     size = property(lambda self: self.__size)
     arg = property(lambda self: self.__arg)
+
+    def __getstate__(self):
+        return self.__arg, self.__size
+
+    def __setstate__(self, state):
+        self.__init__(*state)
 
     def __new__(cls, arg, size=32):
         return Expr.get_object(cls, (arg, size))
@@ -857,6 +887,13 @@ class ExprOp(Expr):
     op = property(lambda self: self.__op)
     args = property(lambda self: self.__args)
 
+    def __getstate__(self):
+        return self.__op, self.__args
+
+    def __setstate__(self, state):
+        op, args = state
+        self.__init__(op, *args)
+
     def __new__(cls, op, *args):
         return Expr.get_object(cls, (op, args))
 
@@ -948,6 +985,12 @@ class ExprSlice(Expr):
     arg = property(lambda self: self.__arg)
     start = property(lambda self: self.__start)
     stop = property(lambda self: self.__stop)
+
+    def __getstate__(self):
+        return self.__arg, self.__start, self.__stop
+
+    def __setstate__(self, state):
+        self.__init__(*state)
 
     def __new__(cls, arg, start, stop):
         return Expr.get_object(cls, (arg, start, stop))
@@ -1056,6 +1099,12 @@ class ExprCompose(Expr):
 
     size = property(lambda self: self.__size)
     args = property(lambda self: self.__args)
+
+    def __getstate__(self):
+        return self.__args
+
+    def __setstate__(self, state):
+        self.__init__(state)
 
     def __new__(cls, args):
         return Expr.get_object(cls, tuple(args))

--- a/miasm2/expression/expression.py
+++ b/miasm2/expression/expression.py
@@ -114,6 +114,8 @@ class Expr(object):
 
     "Parent class for Miasm Expressions"
 
+    __slots__ = ["__hash", "__repr", "__size"]
+
     all_exprs = set()
     args2expr = {}
     simp_exprs = set()
@@ -373,6 +375,8 @@ class ExprInt(Expr):
      - Constant 0x12345678 on 32bits
      """
 
+    __slots__ = Expr.__slots__ + ["__arg"]
+
 
     def __init__(self, num, size=None):
         """Create an ExprInt from a modint or num/size
@@ -458,6 +462,7 @@ class ExprId(Expr):
      - variable v1
      """
 
+    __slots__ = Expr.__slots__ + ["__name"]
 
     def __init__(self, name, size=32):
         """Create an identifier
@@ -515,6 +520,7 @@ class ExprAff(Expr):
      - var1 <- 2
     """
 
+    __slots__ = Expr.__slots__ + ["__dst", "__src"]
 
     def __init__(self, dst, src):
         """Create an ExprAff for dst <- src
@@ -625,6 +631,7 @@ class ExprCond(Expr):
      - if (cond) then ... else ...
     """
 
+    __slots__ = Expr.__slots__ + ["__cond", "__src1", "__src2"]
 
     def __init__(self, cond, src1, src2):
         """Create an ExprCond
@@ -710,6 +717,7 @@ class ExprMem(Expr):
      - Memory write
     """
 
+    __slots__ = Expr.__slots__ + ["__arg"]
 
     def __init__(self, arg, size=32):
         """Create an ExprMem
@@ -786,6 +794,7 @@ class ExprOp(Expr):
      - parity bit(var1)
     """
 
+    __slots__ = Expr.__slots__ + ["__op", "__args"]
 
     def __init__(self, op, *args):
         """Create an ExprOp
@@ -936,6 +945,7 @@ class ExprOp(Expr):
 
 class ExprSlice(Expr):
 
+    __slots__ = Expr.__slots__ + ["__arg", "__start", "__stop"]
 
     def __init__(self, arg, start, stop):
         super(ExprSlice, self).__init__()
@@ -1022,6 +1032,7 @@ class ExprCompose(Expr):
     In the example, salad.size == 3.
     """
 
+    __slots__ = Expr.__slots__ + ["__args"]
 
     def __init__(self, args):
         """Create an ExprCompose

--- a/miasm2/expression/expression_helper.py
+++ b/miasm2/expression/expression_helper.py
@@ -210,9 +210,6 @@ class Variables_Identifier(object):
     - original expression with variables translated
     """
 
-    # Attribute used to distinguish created variables from original ones
-    is_var_ident = "is_var_ident"
-
     def __init__(self, expr, var_prefix="v"):
         """Set the expression @expr to handle and launch variable identification
         process
@@ -287,13 +284,11 @@ class Variables_Identifier(object):
             for element_done in done:
                 todo.remove(element_done)
 
-    @classmethod
-    def is_var_identifier(cls, expr):
+    def is_var_identifier(self, expr):
         "Return True iff @expr is a variable identifier"
         if not isinstance(expr, m2_expr.ExprId):
             return False
-
-        return expr.is_var_ident
+        return expr in self._vars
 
     def find_variables_rec(self, expr):
         """Recursive method called by find_variable to expand @expr.
@@ -310,7 +305,6 @@ class Variables_Identifier(object):
                 identifier = m2_expr.ExprId("%s%s" % (self.var_prefix,
                                                       self.var_indice.next()),
                                             size = expr.size)
-                identifier.is_var_ident = True
                 self._vars[identifier] = expr
 
             # Recursion stop case

--- a/miasm2/expression/expression_helper.py
+++ b/miasm2/expression/expression_helper.py
@@ -86,7 +86,7 @@ def merge_sliceto_slice(args):
             sorted_s.pop()
             out[1] = s_start
         out[0] = m2_expr.ExprInt(int(out[0]), size)
-        final_sources.append((start, out))
+        final_sources.append((start, tuple(out)))
 
     final_sources_int = final_sources
     # check if same sources have corresponding start/stop

--- a/miasm2/expression/expression_helper.py
+++ b/miasm2/expression/expression_helper.py
@@ -34,103 +34,76 @@ def parity(a):
     return cpt
 
 
-def merge_sliceto_slice(args):
-    sources = {}
-    non_slice = {}
-    sources_int = {}
-    for a in args:
-        if isinstance(a[0], m2_expr.ExprInt):
-            # sources_int[a.start] = a
-            # copy ExprInt because we will inplace modify arg just below
-            # /!\ TODO XXX never ever modify inplace args...
-            sources_int[a[1]] = (m2_expr.ExprInt(int(a[0]),
-                                                 a[2] - a[1]),
-                                 a[1],
-                                 a[2])
-        elif isinstance(a[0], m2_expr.ExprSlice):
-            if not a[0].arg in sources:
-                sources[a[0].arg] = []
-            sources[a[0].arg].append(a)
+def merge_sliceto_slice(expr):
+    """
+    Apply basic factorisation on ExprCompose sub compoenents
+    @expr: ExprCompose
+    """
+
+    slices_raw = []
+    other_raw = []
+    integers_raw = []
+    for index, arg in expr.iter_args():
+        if isinstance(arg, m2_expr.ExprInt):
+            integers_raw.append((index, arg))
+        elif isinstance(arg, m2_expr.ExprSlice):
+            slices_raw.append((index, arg))
         else:
-            non_slice[a[1]] = a
-    # find max stop to determine size
-    max_size = None
-    for a in args:
-        if max_size is None or max_size < a[2]:
-            max_size = a[2]
+            other_raw.append((index, arg))
 
-    # first simplify all num slices
-    final_sources = []
-    sorted_s = []
-    for x in sources_int.values():
-        x = list(x)
-        # mask int
-        v = x[0].arg & ((1 << (x[2] - x[1])) - 1)
-        x[0] = m2_expr.ExprInt_from(x[0], v)
-        x = tuple(x)
-        sorted_s.append((x[1], x))
-    sorted_s.sort()
-    while sorted_s:
-        start, v = sorted_s.pop()
-        out = [m2_expr.ExprInt(v[0].arg), v[1], v[2]]
-        size = v[2] - v[1]
-        while sorted_s:
-            if sorted_s[-1][1][2] != start:
+    # Find max stop to determine size
+    max_size = sum([arg.size for arg in expr.args])
+
+    integers_merged = []
+    # Merge consecutive integers
+    while integers_raw:
+        index, arg = integers_raw.pop()
+        new_size = arg.size
+        value = int(arg)
+        while integers_raw:
+            prev_index, prev_value = integers_raw[-1]
+            # Check if intergers are consecutive
+            if prev_index + prev_value.size != index:
                 break
-            s_start, s_stop = sorted_s[-1][1][1], sorted_s[-1][1][2]
-            size += s_stop - s_start
-            a = m2_expr.mod_size2uint[size](
-                (int(out[0]) << (out[1] - s_start)) +
-                 int(sorted_s[-1][1][0]))
-            out[0] = m2_expr.ExprInt(a)
-            sorted_s.pop()
-            out[1] = s_start
-        out[0] = m2_expr.ExprInt(int(out[0]), size)
-        final_sources.append((start, tuple(out)))
+            # Merge integers
+            index = prev_index
+            new_size += prev_value.size
+            value = value << prev_value.size
+            value |= int(prev_value)
+            integers_raw.pop()
+        integers_merged.append((index, m2_expr.ExprInt(value, new_size)))
 
-    final_sources_int = final_sources
-    # check if same sources have corresponding start/stop
-    # is slice AND is sliceto
-    simp_sources = []
-    for args in sources.values():
-        final_sources = []
-        sorted_s = []
-        for x in args:
-            sorted_s.append((x[1], x))
-        sorted_s.sort()
-        while sorted_s:
-            start, v = sorted_s.pop()
-            ee = v[0].arg[v[0].start:v[0].stop]
-            out = ee, v[1], v[2]
-            while sorted_s:
-                if sorted_s[-1][1][2] != start:
-                    break
-                if sorted_s[-1][1][0].stop != out[0].start:
-                    break
 
-                start = sorted_s[-1][1][1]
-                # out[0].start = sorted_s[-1][1][0].start
-                o_e, _, o_stop = out
-                o1, o2 = sorted_s[-1][1][0].start, o_e.stop
-                o_e = o_e.arg[o1:o2]
-                out = o_e, start, o_stop
-                # update _size
-                # out[0]._size = out[0].stop-out[0].start
-                sorted_s.pop()
-            out = out[0], start, out[2]
+    slices_merged = []
+    # Merge consecutive slices
+    while slices_raw:
+        index, arg = slices_raw.pop()
+        value, slice_start, slice_stop = arg.arg, arg.start, arg.stop
+        while slices_raw:
+            prev_index, prev_value = slices_raw[-1]
+            # Check if slices are consecutive
+            if prev_index + prev_value.size != index:
+                break
+            # Check if slices can ben merged
+            if prev_value.arg != value:
+                break
+            if prev_value.stop != slice_start:
+                break
+            # Merge slices
+            index = prev_index
+            slice_start = prev_value.start
+            slices_raw.pop()
+        slices_merged.append((index, value[slice_start:slice_stop]))
 
-            final_sources.append((start, out))
 
-        simp_sources += final_sources
+    new_args = slices_merged + integers_merged + other_raw
+    new_args.sort()
+    for i, (index, arg) in enumerate(new_args[:-1]):
+        assert index + arg.size == new_args[i+1][0]
+    ret = [arg[1] for arg in new_args]
 
-    simp_sources += final_sources_int
+    return ret
 
-    for i, v in non_slice.items():
-        simp_sources.append((i, v))
-
-    simp_sources.sort()
-    simp_sources = [x[1] for x in simp_sources]
-    return simp_sources
 
 
 op_propag_cst = ['+', '*', '^', '&', '|', '>>',
@@ -327,8 +300,8 @@ class Variables_Identifier(object):
             self.find_variables_rec(expr.arg)
 
         elif isinstance(expr, m2_expr.ExprCompose):
-            for a in expr.args:
-                self.find_variables_rec(list(a)[0])
+            for arg in expr.args:
+                self.find_variables_rec(arg)
 
         elif isinstance(expr, m2_expr.ExprSlice):
             self.find_variables_rec(expr.arg)
@@ -646,15 +619,14 @@ def possible_values(expr):
     elif isinstance(expr, m2_expr.ExprCompose):
         # Generate each possibility for sub-argument, associated with the start
         # and stop bit
-        consvals_args = [map(lambda x: (x, arg[1], arg[2]),
-                             possible_values(arg[0]))
+        consvals_args = [map(lambda x: x, possible_values(arg))
                          for arg in expr.args]
         for consvals_possibility in itertools.product(*consvals_args):
             # Merge constraint of each sub-element
-            args_constraint = itertools.chain(*[consval[0].constraints
+            args_constraint = itertools.chain(*[consval.constraints
                                                 for consval in consvals_possibility])
             # Gen the corresponding constraints / ExprCompose
-            args = [consval[0].value for consval in consvals_possibility]
+            args = [consval.value for consval in consvals_possibility]
             consvals.add(
                 ConstrainedValue(frozenset(args_constraint),
                                  m2_expr.ExprCompose(*args)))

--- a/miasm2/expression/expression_helper.py
+++ b/miasm2/expression/expression_helper.py
@@ -449,21 +449,19 @@ class ExprRandom(object):
         """
         # First layer
         upper_bound = random.randint(1, size)
-        args = [(cls._gen(size=upper_bound, depth=depth - 1), 0, upper_bound)]
+        args = [cls._gen(size=upper_bound, depth=depth - 1)]
 
         # Next layers
         while (upper_bound < size):
             if len(args) == (cls.compose_max_layer - 1):
                 # We reach the maximum size
-                upper_bound = size
+                new_upper_bound = size
             else:
-                upper_bound = random.randint(args[-1][-1] + 1, size)
+                new_upper_bound = random.randint(upper_bound + 1, size)
 
-            args.append((cls._gen(size=upper_bound - args[-1][-1]),
-                         args[-1][-1],
-                         upper_bound))
-
-        return m2_expr.ExprCompose(args)
+            args.append(cls._gen(size=new_upper_bound - upper_bound))
+            upper_bound = new_upper_bound
+        return m2_expr.ExprCompose(*args)
 
     @classmethod
     def memory(cls, size=32, depth=1):
@@ -656,14 +654,10 @@ def possible_values(expr):
             args_constraint = itertools.chain(*[consval[0].constraints
                                                 for consval in consvals_possibility])
             # Gen the corresponding constraints / ExprCompose
+            args = [consval[0].value for consval in consvals_possibility]
             consvals.add(
                 ConstrainedValue(frozenset(args_constraint),
-                                 m2_expr.ExprCompose(
-                                     [(consval[0].value,
-                                       consval[1],
-                                       consval[2])
-                                      for consval in consvals_possibility]
-                )))
+                                 m2_expr.ExprCompose(*args)))
     else:
         raise RuntimeError("Unsupported type for expr: %s" % type(expr))
 

--- a/miasm2/expression/simplifications.py
+++ b/miasm2/expression/simplifications.py
@@ -48,6 +48,7 @@ class ExpressionSimplifier(object):
 
     def __init__(self):
         self.expr_simp_cb = {}
+        self.simplified_exprs = set()
 
     def enable_passes(self, passes):
         """Add passes from @passes
@@ -80,7 +81,7 @@ class ExpressionSimplifier(object):
         @expression: Expr instance
         Return an Expr instance"""
 
-        if expression.is_simp:
+        if expression in self.simplified_exprs:
             return expression
 
         # Find a stable state
@@ -92,10 +93,9 @@ class ExpressionSimplifier(object):
 
             # Launch recursivity
             expression = self.expr_simp_wrapper(e_new)
-            expression.is_simp = True
-
+            self.simplified_exprs.add(expression)
         # Mark expression as simplified
-        e_new.is_simp = True
+        self.simplified_exprs.add(e_new)
         return e_new
 
     def expr_simp_wrapper(self, expression, callback=None):
@@ -104,13 +104,13 @@ class ExpressionSimplifier(object):
         @manual_callback: If set, call this function instead of normal one
         Return an Expr instance"""
 
-        if expression.is_simp:
+        if expression in self.simplified_exprs:
             return expression
 
         if callback is None:
             callback = self.expr_simp
 
-        return expression.visit(callback, lambda e: not(e.is_simp))
+        return expression.visit(callback, lambda e: e not in self.simplified_exprs)
 
     def __call__(self, expression, callback=None):
         "Wrapper on expr_simp_wrapper"

--- a/miasm2/expression/simplifications.py
+++ b/miasm2/expression/simplifications.py
@@ -96,6 +96,7 @@ class ExpressionSimplifier(object):
             self.simplified_exprs.add(expression)
         # Mark expression as simplified
         self.simplified_exprs.add(e_new)
+
         return e_new
 
     def expr_simp_wrapper(self, expression, callback=None):

--- a/miasm2/ir/analysis.py
+++ b/miasm2/ir/analysis.py
@@ -283,11 +283,8 @@ class ira(ir):
 
     def gen_equations(self):
         for irb in self.blocs.values():
-            symbols_init = {}
-            for r in self.arch.regs.all_regs_ids:
-                x = ExprId(r.name, r.size)
-                x.is_term = True
-                symbols_init[r] = x
+            symbols_init = dict(self.arch.regs.all_regs_ids_init)
+
             sb = symbexec(self, dict(symbols_init))
             sb.emulbloc(irb)
             eqs = []

--- a/miasm2/ir/ir.py
+++ b/miasm2/ir/ir.py
@@ -46,7 +46,6 @@ class AssignBlock(dict):
         * if dst is an ExprSlice, expand it to affect the full Expression
         * if dst already known, sources are merged
         """
-
         if dst.size != src.size:
             raise RuntimeError(
                 "sanitycheck: args must have same size! %s" %
@@ -75,6 +74,7 @@ class AssignBlock(dict):
             expr_list = [(new_dst, new_src),
                          (new_dst, self[new_dst])]
             # Find collision
+            print 'FIND COLISION'
             e_colision = reduce(lambda x, y: x.union(y),
                                 (self.get_modified_slice(dst, src)
                                  for (dst, src) in expr_list),
@@ -109,17 +109,16 @@ class AssignBlock(dict):
     def get_modified_slice(dst, src):
         """Return an Expr list of extra expressions needed during the
         object instanciation"""
-
         if not isinstance(src, m2_expr.ExprCompose):
             raise ValueError("Get mod slice not on expraff slice", str(self))
         modified_s = []
-        for arg in src.args:
-            if (not isinstance(arg[0], m2_expr.ExprSlice) or
-                    arg[0].arg != dst or
-                    arg[1] != arg[0].start or
-                    arg[2] != arg[0].stop):
+        for index, arg in src.iter_args():
+            if not (isinstance(arg, m2_expr.ExprSlice) and
+                    arg.arg == dst and
+                    index == arg.start and
+                    index+arg.size == arg.stop):
                 # If x is not the initial expression
-                modified_s.append(arg)
+                modified_s.append((arg, index, index+arg.size))
         return modified_s
 
     def get_w(self):

--- a/miasm2/ir/ir.py
+++ b/miasm2/ir/ir.py
@@ -59,7 +59,8 @@ class AssignBlock(dict):
                     for r in dst.slice_rest()]
             all_a = [(src, dst.start, dst.stop)] + rest
             all_a.sort(key=lambda x: x[1])
-            new_src = m2_expr.ExprCompose(all_a)
+            args = [expr for (expr, _, _) in all_a]
+            new_src = m2_expr.ExprCompose(*args)
         else:
             new_dst, new_src = dst, src
 
@@ -95,7 +96,12 @@ class AssignBlock(dict):
                          for interval in missing_i)
 
             # Build the merging expression
-            new_src = m2_expr.ExprCompose(e_colision.union(remaining))
+            args = list(e_colision.union(remaining))
+            args.sort(key=lambda x:x[1])
+            starts = [start for (_, start, _) in args]
+            assert len(set(starts)) == len(starts)
+            args = [expr for (expr, _, _) in args]
+            new_src = m2_expr.ExprCompose(*args)
 
         super(AssignBlock, self).__setitem__(new_dst, new_src)
 

--- a/miasm2/ir/symbexec.py
+++ b/miasm2/ir/symbexec.py
@@ -4,6 +4,8 @@ from miasm2.expression.simplifications import expr_simp
 from miasm2.core import asmbloc
 from miasm2.ir.ir import AssignBlock
 from miasm2.core.interval import interval
+from miasm2.core.utils import get_caller_name
+import warnings
 
 import logging
 
@@ -434,14 +436,22 @@ class symbexec(object):
         return self.eval_expr(self.ir_arch.IRDst)
 
     def emul_ir_bloc(self, myir, addr, step=False):
-        irblock = myir.get_bloc(addr)
+        warnings.warn('DEPRECATION WARNING: use "emul_ir_block(self, addr, step=False)" instead of emul_ir_bloc')
+        return self.emul_ir_block(addr, step)
+
+    def emul_ir_block(self, addr, step=False):
+        irblock = self.ir_arch.get_bloc(addr)
         if irblock is not None:
             addr = self.emulbloc(irblock, step=step)
         return addr
 
     def emul_ir_blocs(self, myir, addr, lbl_stop=None, step=False):
+        warnings.warn('DEPRECATION WARNING: use "emul_ir_blocks(self, addr, lbl_stop=None, step=False):" instead of emul_ir_blocs')
+        return self.emul_ir_blocks(addr, lbl_stop, step)
+
+    def emul_ir_blocks(self, addr, lbl_stop=None, step=False):
         while True:
-            irblock = myir.get_bloc(addr)
+            irblock = self.ir_arch.get_bloc(addr)
             if irblock is None:
                 break
             if irblock.label == lbl_stop:

--- a/miasm2/ir/symbexec.py
+++ b/miasm2/ir/symbexec.py
@@ -148,7 +148,8 @@ class symbexec(object):
                     mem = m2_expr.ExprMem(ptr, slice_stop - slice_start)
                     out.append((mem, slice_start, slice_stop))
                 out.sort(key=lambda x: x[1])
-                tmp = m2_expr.ExprSlice(m2_expr.ExprCompose(out), 0, size)
+                args = [expr for (expr, _, _) in out]
+                tmp = m2_expr.ExprSlice(m2_expr.ExprCompose(*args), 0, size)
                 tmp = self.expr_simp(tmp)
                 return tmp
 
@@ -179,7 +180,9 @@ class symbexec(object):
                 ptr_index += diff_size
                 rest -= diff_size
                 ptr = self.expr_simp(ptr + m2_expr.ExprInt(mem.size / 8, ptr.size))
-            ret = self.expr_simp(m2_expr.ExprCompose(out))
+            out.sort(key=lambda x: x[1])
+            args = [expr for (expr, _, _) in out]
+            ret = self.expr_simp(m2_expr.ExprCompose(*args))
             return ret
         # part lookup
         ret = self.expr_simp(self.symbols[ret][:size])
@@ -228,8 +231,8 @@ class symbexec(object):
             args = []
             for (arg, start, stop) in expr.args:
                 arg = self.apply_expr_on_state_visit_cache(arg, state, cache, level+1)
-                args.append((arg, start, stop))
-            ret = m2_expr.ExprCompose(args)
+                args.append(arg)
+            ret = m2_expr.ExprCompose(*args)
         else:
             raise TypeError("Unknown expr type")
         #print '\t'*level, "Result", ret

--- a/miasm2/ir/symbexec.py
+++ b/miasm2/ir/symbexec.py
@@ -229,9 +229,8 @@ class symbexec(object):
             ret = m2_expr.ExprOp(expr.op, *args)
         elif isinstance(expr, m2_expr.ExprCompose):
             args = []
-            for (arg, start, stop) in expr.args:
-                arg = self.apply_expr_on_state_visit_cache(arg, state, cache, level+1)
-                args.append(arg)
+            for arg in expr.args:
+                args.append(self.apply_expr_on_state_visit_cache(arg, state, cache, level+1))
             ret = m2_expr.ExprCompose(*args)
         else:
             raise TypeError("Unknown expr type")
@@ -378,7 +377,6 @@ class symbexec(object):
         """
         pool_out = {}
         eval_cache = {}
-
         for dst, src in assignblk.iteritems():
             src = self.eval_expr(src, eval_cache)
             if isinstance(dst, m2_expr.ExprMem):

--- a/miasm2/ir/translators/C.py
+++ b/miasm2/ir/translators/C.py
@@ -145,11 +145,11 @@ class TranslatorC(Translator):
         out = []
         # XXX check mask for 64 bit & 32 bit compat
         dst_cast = "uint%d_t" % expr.size
-        for x in expr.args:
+        for index, arg in expr.iter_args():
             out.append("(((%s)(%s & 0x%X)) << %d)" % (dst_cast,
-                                                      self.from_expr(x[0]),
-                                                      (1 << (x[2] - x[1])) - 1,
-                                                      x[1]))
+                                                      self.from_expr(arg),
+                                                      (1 << arg.size) - 1,
+                                                      index))
         out = ' | '.join(out)
         return '(' + out + ')'
 

--- a/miasm2/ir/translators/miasm.py
+++ b/miasm2/ir/translators/miasm.py
@@ -27,8 +27,7 @@ class TranslatorMiasm(Translator):
                                    ", ".join(map(self.from_expr, expr.args)))
 
     def from_ExprCompose(self, expr):
-        args = ["%s" % self.from_expr(arg)
-                for arg, _, _ in expr.args]
+        args = ["%s" % self.from_expr(arg) for arg in expr.args]
         return "ExprCompose(%s)" % ", ".join(args)
 
     def from_ExprAff(self, expr):

--- a/miasm2/ir/translators/miasm.py
+++ b/miasm2/ir/translators/miasm.py
@@ -27,9 +27,9 @@ class TranslatorMiasm(Translator):
                                    ", ".join(map(self.from_expr, expr.args)))
 
     def from_ExprCompose(self, expr):
-        args = ["(%s, %d, %d)" % (self.from_expr(arg), start, stop)
-                for arg, start, stop in expr.args]
-        return "ExprCompose([%s])" % ", ".join(args)
+        args = ["%s" % self.from_expr(arg)
+                for arg, _, _ in expr.args]
+        return "ExprCompose(%s)" % ", ".join(args)
 
     def from_ExprAff(self, expr):
         return "ExprAff(%s, %s)" % (self.from_expr(expr.dst),

--- a/miasm2/ir/translators/python.py
+++ b/miasm2/ir/translators/python.py
@@ -31,10 +31,10 @@ class TranslatorPython(Translator):
 
     def from_ExprCompose(self, expr):
         out = []
-        for subexpr, start, stop in expr.args:
-            out.append("((%s & 0x%x) << %d)" % (self.from_expr(subexpr),
-                                                 (1 << (stop - start)) - 1,
-                                                 start))
+        for index, arg in expr.iter_args():
+            out.append("((%s & 0x%x) << %d)" % (self.from_expr(arg),
+                                                 (1 << arg.size) - 1,
+                                                 index))
         return "(%s)" % ' | '.join(out)
 
     def from_ExprCond(self, expr):

--- a/miasm2/ir/translators/smt2.py
+++ b/miasm2/ir/translators/smt2.py
@@ -163,10 +163,8 @@ class TranslatorSMT2(Translator):
 
     def from_ExprCompose(self, expr):
         res = None
-        args = sorted(expr.args, key=operator.itemgetter(2))  # sort by start off
-        for subexpr, start, stop in args:
-            sube = self.from_expr(subexpr)
-            e = bv_extract(stop-start-1, 0, sube)
+        for arg in expr.args:
+            e = bv_extract(arg.size-1, 0, self.from_expr(arg))
             if res:
                 res = bv_concat(e, res)
             else:

--- a/miasm2/ir/translators/z3_ir.py
+++ b/miasm2/ir/translators/z3_ir.py
@@ -137,10 +137,8 @@ class TranslatorZ3(Translator):
 
     def from_ExprCompose(self, expr):
         res = None
-        args = sorted(expr.args, key=operator.itemgetter(2)) # sort by start off
-        for subexpr, start, stop in args:
-            sube = self.from_expr(subexpr)
-            e = z3.Extract(stop-start-1, 0, sube)
+        for arg in expr.args:
+            e = z3.Extract(arg.size-1, 0, self.from_expr(arg))
             if res != None:
                 res = z3.Concat(e, res)
             else:

--- a/test/arch/arm/sem.py
+++ b/test/arch/arm/sem.py
@@ -285,7 +285,7 @@ class TestARMSemantic(unittest.TestCase):
         self.assertEqual(compute('AND                R4,    R4,   R5    LSR 2 ',  {R4: 0xFFFFFFFF, R5: 0x80000041, }), {R4: 0x20000010, R5: 0x80000041, })
         self.assertEqual(compute('AND                R4,    R4,   R5    ASR 3 ',  {R4: 0xF00000FF, R5: 0x80000081, }), {R4: 0xF0000010, R5: 0x80000081, })
         self.assertEqual(compute('AND                R4,    R4,   R5    ROR 4 ',  {R4: 0xFFFFFFFF, R5: 0x000000FF, }), {R4: 0xF000000F, R5: 0x000000FF, })
-        self.assertEqual(compute('AND                R4,    R4,   R5    RRX   ',  {R4: 0xFFFFFFFF, R5: 0x00000101, }), {R4: ExprCompose([(ExprInt(0x80, 31),0,31), (cf_init,31,32)]), R5: 0x00000101, })
+        self.assertEqual(compute('AND                R4,    R4,   R5    RRX   ',  {R4: 0xFFFFFFFF, R5: 0x00000101, }), {R4: ExprCompose(ExprInt(0x80, 31), cf_init), R5: 0x00000101, })
 
         # §A8.8.15:                AND{S}{<c>}{<q>} {<Rd>,} <Rn>, <Rm>, <type> <Rs>
         self.assertEqual(compute('AND                R4,    R6,   R4    LSL R5',  {R4: 0x00000001, R5: 0x00000004, R6: -1, }), {R4: 0x00000010, R5: 0x00000004, R6: 0xFFFFFFFF, })

--- a/test/arch/arm/sem.py
+++ b/test/arch/arm/sem.py
@@ -29,7 +29,7 @@ def compute(asm, inputstate={}, debug=False):
     instr = mn.dis(code, "l")
     instr.offset = inputstate.get(PC, 0)
     interm.add_instr(instr)
-    symexec.emul_ir_blocs(interm, instr.offset)
+    symexec.emul_ir_blocks(instr.offset)
     if debug:
         for k, v in symexec.symbols.items():
             if regs_init.get(k, None) != v:

--- a/test/arch/msp430/sem.py
+++ b/test/arch/msp430/sem.py
@@ -27,7 +27,7 @@ def compute(asm, inputstate={}, debug=False):
     instr = mn.dis(code, mode)
     instr.offset = inputstate.get(PC, 0)
     interm.add_instr(instr)
-    symexec.emul_ir_blocs(interm, instr.offset)
+    symexec.emul_ir_blocks(instr.offset)
     if debug:
         for k, v in symexec.symbols.items():
             if regs_init.get(k, None) != v:

--- a/test/arch/x86/sem.py
+++ b/test/arch/x86/sem.py
@@ -26,7 +26,7 @@ def symb_exec(interm, inputstate, debug):
     sympool = dict(regs_init)
     sympool.update(inputstate)
     symexec = symbexec(interm, sympool)
-    symexec.emul_ir_blocs(interm, 0)
+    symexec.emul_ir_blocks(0)
     if debug:
         for k, v in symexec.symbols.items():
             if regs_init.get(k, None) != v:

--- a/test/expression/expression.py
+++ b/test/expression/expression.py
@@ -30,10 +30,10 @@ for expr in [
         A + cst1,
         A + ExprCond(cond1, cst1, cst2),
         ExprCond(cond1, cst1, cst2) + ExprCond(cond2, cst3, cst4),
-        ExprCompose([(A, 0, 32), (cst1, 32, 64)]),
-        ExprCompose([(ExprCond(cond1, cst1, cst2), 0, 32), (A, 32, 64)]),
-        ExprCompose([(ExprCond(cond1, cst1, cst2), 0, 32),
-                     (ExprCond(cond2, cst3, cst4), 32, 64)]),
+        ExprCompose(A, cst1),
+        ExprCompose(ExprCond(cond1, cst1, cst2), A),
+        ExprCompose(ExprCond(cond1, cst1, cst2),
+                    ExprCond(cond2, cst3, cst4)),
         ExprCond(ExprCond(cond1, cst1, cst2), cst3, cst4),
 ]:
     print "*" * 80

--- a/test/expression/expression_helper.py
+++ b/test/expression/expression_helper.py
@@ -16,11 +16,10 @@ class TestExpressionExpressionHelper(unittest.TestCase):
         ebx = m2_expr.ExprId("EBX")
         ax = eax[0:16]
         expr = eax + ebx
-        expr = m2_expr.ExprCompose([(ax, 0, 16), (expr[16:32], 16, 32)])
+        expr = m2_expr.ExprCompose(ax, expr[16:32])
         expr2 = m2_expr.ExprMem((eax + ebx) ^ (eax), size=16)
         expr2 = expr2 | ax | expr2 | cst
-        exprf = expr - expr + m2_expr.ExprCompose([(expr2, 0, 16),
-                                                   (cst, 16, 32)])
+        exprf = expr - expr + m2_expr.ExprCompose(expr2, cst)
 
         # Identify variables
         vi = Variables_Identifier(exprf)

--- a/test/ir/symbexec.py
+++ b/test/ir/symbexec.py
@@ -43,12 +43,12 @@ class TestSymbExec(unittest.TestCase):
         self.assertEqual(e.eval_expr(ExprMem(addr1 - addr1)), id_x)
         self.assertEqual(e.eval_expr(ExprMem(addr1, 8)), id_y)
         self.assertEqual(e.eval_expr(ExprMem(addr1 + addr1)), ExprCompose(
-            [(id_x[16:32], 0, 16), (ExprMem(ExprInt32(4), 16), 16, 32)]))
+            id_x[16:32], ExprMem(ExprInt32(4), 16)))
         self.assertEqual(e.eval_expr(mem8), ExprCompose(
-            [(id_x[0:24], 0, 24), (ExprMem(ExprInt32(11), 8), 24, 32)]))
+            id_x[0:24], ExprMem(ExprInt32(11), 8)))
         self.assertEqual(e.eval_expr(mem40v), id_x[:8])
         self.assertEqual(e.eval_expr(mem50w), ExprCompose(
-            [(id_y, 0, 8), (ExprMem(ExprInt32(51), 8), 8, 16)]))
+            id_y, ExprMem(ExprInt32(51), 8)))
         self.assertEqual(e.eval_expr(mem20), mem20)
         e.func_read = lambda x: x
         self.assertEqual(e.eval_expr(mem20), mem20)

--- a/test/ir/symbexec.py
+++ b/test/ir/symbexec.py
@@ -21,7 +21,7 @@ class TestSymbExec(unittest.TestCase):
         addr40 = ExprInt32(40)
         addr50 = ExprInt32(50)
         mem0 = ExprMem(addr0)
-        mem1 = ExprMem(addr1)
+        mem1 = ExprMem(addr1, 8)
         mem8 = ExprMem(addr8)
         mem9 = ExprMem(addr9)
         mem20 = ExprMem(addr20)
@@ -34,22 +34,24 @@ class TestSymbExec(unittest.TestCase):
         id_a = ExprId('a')
         id_eax = ExprId('eax_init')
 
-        e = symbexec(
-            ir_x86_32(), {mem0: id_x, mem1: id_y, mem9: id_x, mem40w: id_x, mem50v: id_y, id_a: addr0, id_eax: addr0})
+        e = symbexec(ir_x86_32(),
+                     {mem0: id_x, mem1: id_y, mem9: id_x,
+                      mem40w: id_x[:16], mem50v: id_y,
+                      id_a: addr0, id_eax: addr0})
         self.assertEqual(e.find_mem_by_addr(addr0), mem0)
         self.assertEqual(e.find_mem_by_addr(addrX), None)
-        self.assertEqual(e.eval_ExprMem(ExprMem(addr1 - addr1)), id_x)
-        self.assertEqual(e.eval_ExprMem(ExprMem(addr1,  8)),     id_y)
-        self.assertEqual(e.eval_ExprMem(ExprMem(addr1 + addr1)), ExprCompose(
+        self.assertEqual(e.eval_expr(ExprMem(addr1 - addr1)), id_x)
+        self.assertEqual(e.eval_expr(ExprMem(addr1, 8)), id_y)
+        self.assertEqual(e.eval_expr(ExprMem(addr1 + addr1)), ExprCompose(
             [(id_x[16:32], 0, 16), (ExprMem(ExprInt32(4), 16), 16, 32)]))
-        self.assertEqual(e.eval_ExprMem(mem8),                   ExprCompose(
+        self.assertEqual(e.eval_expr(mem8), ExprCompose(
             [(id_x[0:24], 0, 24), (ExprMem(ExprInt32(11), 8), 24, 32)]))
-        self.assertEqual(e.eval_ExprMem(mem40v),                 id_x[:8])
-        self.assertEqual(e.eval_ExprMem(mem50w),                 ExprCompose(
+        self.assertEqual(e.eval_expr(mem40v), id_x[:8])
+        self.assertEqual(e.eval_expr(mem50w), ExprCompose(
             [(id_y, 0, 8), (ExprMem(ExprInt32(51), 8), 8, 16)]))
-        self.assertEqual(e.eval_ExprMem(mem20), mem20)
+        self.assertEqual(e.eval_expr(mem20), mem20)
         e.func_read = lambda x: x
-        self.assertEqual(e.eval_ExprMem(mem20), mem20)
+        self.assertEqual(e.eval_expr(mem20), mem20)
         self.assertEqual(set(e.modified()), set(e.symbols))
         self.assertRaises(
             KeyError, e.symbols.__getitem__, ExprMem(ExprInt32(100)))

--- a/test/ir/translators/z3_ir.py
+++ b/test/ir/translators/z3_ir.py
@@ -114,7 +114,7 @@ check_interp(model[memb.get_mem_array(32)],
              [(0xdeadbeef, 0), (0xdeadbeef + 3, 2)])
 
 # --------------------------------------------------------------------------
-e5 = ExprSlice(ExprCompose(((e, 0, 32), (four, 32, 64))), 0, 32) * five
+e5 = ExprSlice(ExprCompose(e, four), 0, 32) * five
 ez3 = Translator.to_language('z3').from_expr(e5)
 
 z3_e5 = z3.Extract(31, 0, z3.Concat(z3_four, z3_e)) * z3_five


### PR DESCRIPTION
Many changes here, and some API update :warning: :
* Expressions are now fully immutable
* singleton pattern is used by default (can be deactivated)
* `symbol_exec`: use `emul_ir_block` instead of `emul_ir_bloc` (change in arguments)
* `ExprCompose([(a, 0, 16), (b, 16, 32)])` becomes `ExprCompose(a, b)`

Old apis are still supported, but will display a deprecation warning.
Those apis will be removed in the future.
