### PR TITLE
Regression test for apply_expr/apply_change/eval_ir

### DIFF
--- a/test/ir/symbexec.py
+++ b/test/ir/symbexec.py
@@ -11,6 +11,7 @@ class TestSymbExec(unittest.TestCase):
             ExprCompose, ExprAff
         from miasm2.arch.x86.sem import ir_x86_32
         from miasm2.ir.symbexec import symbexec
+        from miasm2.ir.ir import AssignBlock
 
         addrX = ExprInt32(-1)
         addr0 = ExprInt32(0)
@@ -58,6 +59,22 @@ class TestSymbExec(unittest.TestCase):
         self.assertEqual(e.apply_expr(id_eax), addr0)
         self.assertEqual(e.apply_expr(ExprAff(id_eax, addr9)), addr9)
         self.assertEqual(e.apply_expr(id_eax), addr9)
+
+        # apply_change / eval_ir / apply_expr
+
+        ## x = a (with a = 0x0)
+        assignblk = AssignBlock()
+        assignblk[id_x] = id_a
+        e.eval_ir(assignblk)
+        self.assertEqual(e.apply_expr(id_x), addr0)
+
+        ## x = a (without replacing 'a' with 0x0)
+        e.apply_change(id_x, id_a)
+        self.assertEqual(e.apply_expr(id_x), id_a)
+
+        ## x = a (with a = 0x0)
+        self.assertEqual(e.apply_expr(assignblk.dst2ExprAff(id_x)), addr0)
+        self.assertEqual(e.apply_expr(id_x), addr0)
 
 if __name__ == '__main__':
     testsuite = unittest.TestLoader().loadTestsFromTestCase(TestSymbExec)


### PR DESCRIPTION
Add a way to insert "a knowledge" in a symbol execution context.

If the current context is:
```
a = 0
```
Then, on `b = a`:
* `apply_expr`, `eval_ir` will end with (applying the side effect of an instruction):
```
a = 0
b = 0
```
* `apply_change` will end with (injecting a statement):
```
a = 0
b = a
```

In the last example, the value of `b` is the initial value of `a` (`_init` are no longer needed since #445)