### PR TITLE
Feature llvm jitter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,19 @@ python:
 - "2.7"
 addons:
     apt:
+        sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test']
         packages:
             - make
             - gcc
             - python-virtualenv
             - unzip
+            - llvm-3.8
+            - llvm-3.8-dev
+            - g++-5
 before_script:
 - "cd .."
+- "export LLVM_CONFIG=$(which llvm-config-3.8)"
+- "export CXX=$(which g++-5)"
 # make virtual env
 - "python /usr/lib/python2.7/dist-packages/virtualenv.py virtualenv;"
 - "cd virtualenv;"
@@ -21,6 +27,11 @@ before_script:
 - "make && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd);cd ..;"
 - "cp tinycc/libtcc.h include"
 - "cp tinycc/libtcc.so.1.0 tinycc/libtcc.so"
+# install llvmlite, using the system libdtc++ instead of statically linking it
+- "pip install enum34"
+- "git clone https://github.com/numba/llvmlite llvmlite && cd llvmlite"
+- "sed -i 's/-static-libstdc++ //' ffi/Makefile.linux"
+- "python setup.py install && cd .."
 # install elfesteem
 - "git clone https://github.com/serpilliere/elfesteem elfesteem && cd elfesteem && python setup.py install && cd ..;"
 # install pyparsing

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Miasm uses:
 To enable code JIT, one of the following module is mandatory:
 * GCC
 * Clang
-* LLVM v3.2 with python-llvm, see below
+* LLVM with Numba llvmlite, see below
 * LibTCC [tinycc (ONLY version 0.9.26)](http://repo.or.cz/w/tinycc.git)
 
 'optional' Miasm can also use:
@@ -483,9 +483,9 @@ To use the jitter, GCC, TCC or LLVM is recommended
   * `sudo make install`
   * There may be an error on documentation generation
 * LLVM
-  * Debian (testing/unstable): install python-llvm
-  * Debian stable/Ubuntu/Kali/whatever: install from [llvmpy](http://www.llvmpy.org/)
-  * Windows: python-llvm is not supported :/
+  * Debian (testing/unstable): Not tested
+  * Debian stable/Ubuntu/Kali/whatever: `pip install llvmlite` or install from [llvmlite](https://github.com/numba/llvmlite)
+  * Windows: Not tested
 * Build and install Miasm:
 ```
 $ cd miasm_directory

--- a/miasm2/ir/translators/C.py
+++ b/miasm2/ir/translators/C.py
@@ -47,9 +47,9 @@ class TranslatorC(Translator):
                 return "parity(%s&0x%x)" % (self.from_expr(expr.args[0]),
                                             size2mask(expr.args[0].size))
             elif expr.op in ['bsr', 'bsf']:
-                return "x86_%s(%s, 0x%x)" % (expr.op,
-                                             self.from_expr(expr.args[0]),
-                                             expr.args[0].size)
+                return "x86_%s(0x%x, %s)" % (expr.op,
+                                             expr.args[0].size,
+                                             self.from_expr(expr.args[0]))
             elif expr.op in ['clz']:
                 return "%s(%s)" % (expr.op,
                                    self.from_expr(expr.args[0]))

--- a/miasm2/jitter/Jitllvm.c
+++ b/miasm2/jitter/Jitllvm.c
@@ -13,16 +13,17 @@
 PyObject* llvm_exec_bloc(PyObject* self, PyObject* args)
 {
 	uint64_t func_addr;
-	uint64_t (*func)(void*, void*, void*);
+	uint64_t (*func)(void*, void*, void*, uint8_t*);
 	uint64_t vm;
 	uint64_t ret;
 	JitCpu* jitcpu;
-
+	uint8_t status;
+	
 	if (!PyArg_ParseTuple(args, "KOK", &func_addr, &jitcpu, &vm))
 		return NULL;
 	vm_cpu_t* cpu = jitcpu->cpu;
 	func = (void *) (intptr_t) func_addr;
-	ret = func((void*) jitcpu, (void*)(intptr_t) cpu, (void*)(intptr_t) vm);
+	ret = func((void*) jitcpu, (void*)(intptr_t) cpu, (void*)(intptr_t) vm, &status);
 	return PyLong_FromUnsignedLongLong(ret);
 }
 

--- a/miasm2/jitter/Jitllvm.c
+++ b/miasm2/jitter/Jitllvm.c
@@ -3,17 +3,24 @@
 #include <inttypes.h>
 
 #include <stdint.h>
+#include "queue.h"
+#include "vm_mngr.h"
+#include "vm_mngr_py.h"
+#include "JitCore.h"
+// Needed to get the JitCpu.cpu offset, arch independent
+#include "arch/JitCore_x86.h"
 
 PyObject* llvm_exec_bloc(PyObject* self, PyObject* args)
 {
 	uint64_t func_addr;
 	uint64_t (*func)(void*, void*);
 	uint64_t vm;
-	uint64_t cpu;
 	uint64_t ret;
+	JitCpu* jitcpu;
 
-	if (!PyArg_ParseTuple(args, "KKK", &func_addr, &cpu, &vm))
+	if (!PyArg_ParseTuple(args, "KOK", &func_addr, &jitcpu, &vm))
 		return NULL;
+	vm_cpu_t* cpu = jitcpu->cpu;
 	func = (void *) (intptr_t) func_addr;
 	ret = func((void*)(intptr_t) cpu, (void*)(intptr_t) vm);
 	return PyLong_FromUnsignedLongLong(ret);

--- a/miasm2/jitter/Jitllvm.c
+++ b/miasm2/jitter/Jitllvm.c
@@ -13,7 +13,7 @@
 PyObject* llvm_exec_bloc(PyObject* self, PyObject* args)
 {
 	uint64_t func_addr;
-	uint64_t (*func)(void*, void*);
+	uint64_t (*func)(void*, void*, void*);
 	uint64_t vm;
 	uint64_t ret;
 	JitCpu* jitcpu;
@@ -22,7 +22,7 @@ PyObject* llvm_exec_bloc(PyObject* self, PyObject* args)
 		return NULL;
 	vm_cpu_t* cpu = jitcpu->cpu;
 	func = (void *) (intptr_t) func_addr;
-	ret = func((void*)(intptr_t) cpu, (void*)(intptr_t) vm);
+	ret = func((void*) jitcpu, (void*)(intptr_t) cpu, (void*)(intptr_t) vm);
 	return PyLong_FromUnsignedLongLong(ret);
 }
 

--- a/miasm2/jitter/arch/JitCore_x86.c
+++ b/miasm2/jitter/arch/JitCore_x86.c
@@ -599,6 +599,11 @@ PyObject* get_gpreg_offset_all(void)
     get_reg_off(tsc1);
     get_reg_off(tsc2);
 
+    get_reg_off(interrupt_num);
+    get_reg_off(exception_flags);
+
+    get_reg_off(float_stack_ptr);
+
     return dict;
 }
 

--- a/miasm2/jitter/jitcore_llvm.py
+++ b/miasm2/jitter/jitcore_llvm.py
@@ -14,7 +14,9 @@ class JitCore_LLVM(jitcore.JitCore):
     arch_dependent_libs = {"x86": "JitCore_x86.so",
                            "arm": "JitCore_arm.so",
                            "msp430": "JitCore_msp430.so",
-                           "mips32": "JitCore_mips32.so"}
+                           "mips32": "JitCore_mips32.so",
+                           "aarch64": "JitCore_aarch64.so",
+    }
 
     def __init__(self, ir_arch, bs=None):
         super(JitCore_LLVM, self).__init__(ir_arch, bs)

--- a/miasm2/jitter/jitcore_llvm.py
+++ b/miasm2/jitter/jitcore_llvm.py
@@ -21,8 +21,8 @@ class JitCore_LLVM(jitcore.JitCore):
     def __init__(self, ir_arch, bs=None):
         super(JitCore_LLVM, self).__init__(ir_arch, bs)
 
-        self.options.update({"safe_mode": False,   # Verify each function
-                             "optimise": False,     # Optimise functions
+        self.options.update({"safe_mode": True,   # Verify each function
+                             "optimise": True,     # Optimise functions
                              "log_func": False,    # Print LLVM functions
                              "log_assembly": False,  # Print assembly executed
                              })
@@ -59,12 +59,6 @@ class JitCore_LLVM(jitcore.JitCore):
         mod_name = "miasm2.jitter.arch.JitCore_%s" % (self.ir_arch.arch.name)
         mod = importlib.import_module(mod_name)
         self.context.set_vmcpu(mod.get_gpreg_offset_all())
-
-        # Save module base
-        self.mod_base_str = str(self.context.mod)
-
-        # Set IRs transformation to apply
-        self.context.set_IR_transformation(self.ir_arch.expr_fix_regs_for_mode)
 
     def add_bloc(self, block):
         """Add a block to JiT and JiT it.

--- a/miasm2/jitter/jitcore_llvm.py
+++ b/miasm2/jitter/jitcore_llvm.py
@@ -68,7 +68,7 @@ class JitCore_LLVM(jitcore.JitCore):
     def add_bloc(self, bloc):
 
         # Search in IR cache
-        if self.options["cache_ir"] is not None:
+        if False and self.options["cache_ir"] is not None:
 
             # /!\ This part is under development
             # Use it at your own risk
@@ -153,3 +153,11 @@ class JitCore_LLVM(jitcore.JitCore):
 
         # Store a pointer on the function jitted code
         self.lbl2jitbloc[label.offset] = func.get_function_pointer()
+
+    def jit_call(self, label, cpu, _vmmngr, breakpoints):
+        """Call the function label with cpu and vmmngr states
+        @label: function's label
+        @cpu: JitCpu instance
+        @breakpoints: Dict instance of used breakpoints
+        """
+        return self.exec_wrapper(self.lbl2jitbloc[label], cpu, cpu.vmmngr.vmmngr)

--- a/miasm2/jitter/llvmconvert.py
+++ b/miasm2/jitter/llvmconvert.py
@@ -572,8 +572,9 @@ class LLVMFunction():
                 return ret
 
             if op == "-":
-                zero = llvm_ir.Constant(LLVMType.IntType(expr.size),
-                                        0)
+                # Unsupported op '-' with more than 1 arg
+                assert len(expr.args) == 1
+                zero = LLVMType.IntType(expr.size)(0)
                 ret = builder.sub(zero, self.add_ir(expr.args[0]))
                 self.update_cache(expr, ret)
                 return ret

--- a/miasm2/jitter/llvmconvert.py
+++ b/miasm2/jitter/llvmconvert.py
@@ -258,6 +258,14 @@ class LLVMContext_JIT(LLVMContext):
                                         "args": [p8,
                                                  LLVMType.IntType(k),
                                                  LLVMType.IntType(k)]}})
+            self.add_fc({"umod%s" % k: {"ret": LLVMType.IntType(k),
+                                        "args": [p8,
+                                                 LLVMType.IntType(k),
+                                                 LLVMType.IntType(k)]}})
+            self.add_fc({"udiv%s" % k: {"ret": LLVMType.IntType(k),
+                                        "args": [p8,
+                                                 LLVMType.IntType(k),
+                                                 LLVMType.IntType(k)]}})
 
     def add_log_functions(self):
         "Add functions for state logging"
@@ -592,7 +600,7 @@ class LLVMFunction():
                 self.update_cache(expr, ret)
                 return ret
 
-            if op in ["imod", "idiv"]:
+            if op in ["imod", "idiv", "umod", "udiv"]:
                 fc_ptr = self.mod.get_global(
                     "%s%s" % (op, expr.args[0].size))
                 args_casted = [self.add_ir(arg) for arg in expr.args]
@@ -619,10 +627,10 @@ class LLVMFunction():
                     callback = builder.shl
                 elif op == "a>>":
                     callback = builder.ashr
-                elif op == "udiv":
-                    callback = builder.udiv
-                elif op == "umod":
+                elif op == "%":
                     callback = builder.urem
+                elif op == "/":
+                    callback = builder.udiv
                 else:
                     raise NotImplementedError('Unknown op: %s' % op)
 

--- a/miasm2/jitter/llvmconvert.py
+++ b/miasm2/jitter/llvmconvert.py
@@ -312,7 +312,7 @@ class LLVMFunction():
         "Create an alloca instruction at the beginning of the current fc"
         builder = self.builder
         current_bbl = builder.basic_block
-        builder.position_at_end(self.entry_bbl)
+        builder.position_at_start(self.entry_bbl)
 
         ret = builder.alloca(var_type)
         builder.position_at_end(current_bbl)

--- a/miasm2/jitter/llvmconvert.py
+++ b/miasm2/jitter/llvmconvert.py
@@ -5,7 +5,7 @@
 # - JiT                                                                        #
 #
 # Requires:                                                                    #
-# - llvmpy (tested on v0.11.2)                                                 #
+# - llvmlite (tested on v0.15)                                                 #
 #
 # Authors : Fabrice DESCLAUX (CEA/DAM), Camille MOUGEY (CEA/DAM)               #
 #

--- a/miasm2/jitter/llvmconvert.py
+++ b/miasm2/jitter/llvmconvert.py
@@ -230,6 +230,12 @@ class LLVMContext_JIT(LLVMContext):
                                              itype,
                                              itype,
                                              itype]}})
+        self.add_fc({"x86_bsr": {"ret": itype,
+                                 "args": [itype,
+                                          itype]}})
+        self.add_fc({"x86_bsf": {"ret": itype,
+                                 "args": [itype,
+                                          itype]}})
         self.add_fc({"segm2addr": {"ret": itype,
                                    "args": [p8,
                                             itype,
@@ -333,6 +339,8 @@ class LLVMFunction():
                               '>>>': 'rot_right',
                               '<<<c_rez': 'rcl_rez_op',
                               '>>>c_rez': 'rcr_rez_op',
+                              'bsr': 'x86_bsr',
+                              'bsf': 'x86_bsf',
     }
     ## Add the size as suffix
     op_translate_with_suffix_size = {'bcdadd': 'bcdadd',

--- a/miasm2/jitter/vm_mngr.c
+++ b/miasm2/jitter/vm_mngr.c
@@ -76,6 +76,11 @@ const uint8_t parity_table[256] = {
     0, CC_P, CC_P, 0, CC_P, 0, 0, CC_P,
 };
 
+uint8_t parity(uint64_t a) {
+	return parity_table[(a) & 0xFF];
+}
+
+
 // #define DEBUG_MIASM_AUTOMOD_CODE
 
 void memory_access_list_init(struct memory_access_list * access)

--- a/miasm2/jitter/vm_mngr.c
+++ b/miasm2/jitter/vm_mngr.c
@@ -921,7 +921,7 @@ unsigned int rcr_rez_op(unsigned int size, unsigned int a, unsigned int b, unsig
     return tmp;
 }
 
-unsigned int x86_bsr(uint64_t src, unsigned int size)
+unsigned int x86_bsr(unsigned int size, uint64_t src)
 {
 	int i;
 
@@ -933,7 +933,7 @@ unsigned int x86_bsr(uint64_t src, unsigned int size)
 	exit(0);
 }
 
-unsigned int x86_bsf(uint64_t src, unsigned int size)
+unsigned int x86_bsf(unsigned int size, uint64_t src)
 {
 	int i;
 

--- a/miasm2/jitter/vm_mngr.h
+++ b/miasm2/jitter/vm_mngr.h
@@ -194,7 +194,7 @@ int vm_write_mem(vm_mngr_t* vm_mngr, uint64_t addr, char *buffer, uint64_t size)
 
 extern const uint8_t parity_table[256];
 
-#define parity(a) (parity_table[(a) & 0xFF])
+uint8_t parity(uint64_t a);
 
 unsigned int my_imul08(unsigned int a, unsigned int b);
 

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -55,7 +55,7 @@ class ArchUnitTest(RegressionTest):
 
 # script -> blacklisted jitter
 blacklist = {
-    "x86/unit/mn_float.py": ["python"],
+    "x86/unit/mn_float.py": ["python", "llvm"],
 }
 for script in ["x86/sem.py",
                "x86/unit/mn_strings.py",
@@ -684,7 +684,7 @@ By default, no tag is omitted." % ", ".join(TAGS.keys()), default="")
     # Handle llvm modularity
     llvm = True
     try:
-        import llvm
+        import llvmlite
     except ImportError:
         llvm = False
 
@@ -694,9 +694,6 @@ By default, no tag is omitted." % ", ".join(TAGS.keys()), default="")
         from miasm2.jitter import Jittcc
     except ImportError:
         tcc = False
-
-    # TODO XXX: fix llvm jitter (deactivated for the moment)
-    llvm = False
 
     if llvm is False:
         print "%(red)s[LLVM]%(end)s Python" % cosmetics.colors + \

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -697,7 +697,7 @@ By default, no tag is omitted." % ", ".join(TAGS.keys()), default="")
 
     if llvm is False:
         print "%(red)s[LLVM]%(end)s Python" % cosmetics.colors + \
-            "'py-llvm 3.2' module is required for llvm tests"
+            "'llvmlite' module is required for llvm tests"
 
         # Remove llvm tests
         if TAGS["llvm"] not in exclude_tags:


### PR DESCRIPTION
As stated in #5, the current support of LLVM is broken.
In this work, the Numba [llvmlite](https://github.com/numba/llvmlite) backend is used instead of pyllvm.
One of its main advantage is that the IR module is entirely built in Python, and the LLVM backend is only called at the end (avoiding wasting time in the wrapper, as before). In addition, it is more up to date.

As a lot of internal API have changed since the first use of LLVM (`IRDst`, `vm_MEM*`, breakpoints, code generation optimisations as `codegen`, JiT loop while code is already Jitted with an optional maximum number of iteration, `VmMngr` move to `JitCpu` attribute, specific `dump_gpregs` for certain architecture, ...), the current code base needs a big update (perhaps a merge with `codegen`).

Here is a TODO list of what is needed, and what is done for now:

- [x] Adapt to `IRDst`
- [x] Modify API to call `vm_MEM*` wrappers
- [x] Modify API to handle architecture specific `dump_gpregs` wrappers
- [x] Expose specific operation code (as `parity`)
- [x] Merge modules between them (may with `ModuleRef.link_in`) to avoid cumulative construction :arrow_forward: finally not done, because it does not avoid cumulative construction. Then, functions are independent modules, handled within a common `ExecEngine`
- [x] Update doc
- [x] Pass `md5_arm` test with a correct MD5
- [x] Pass `unpack_upx` test with the same output
- [x] Pass all regression tests (77 / 77 LLVM only tests)
- [x] Update Travis CI
- [x] Handle compilation optimization
- [x] Clean up unused APIs

Others points could be considered as optimization, and will be handled in others PRs. With this in mind, it is not possible to conclude on performance for now.
For instance:

- Loop in the wrapper code while JiT blocks are already available
- Cache to disk already generated block (as string or LLVM bitcode)
- Separate code relative to JIT and code relative to IR translation
- `jit_maxline` option handling
- Support of floating point operations