### PR TITLE
Feature/faster parity

### DIFF
--- a/miasm2/jitter/vm_mngr.c
+++ b/miasm2/jitter/vm_mngr.c
@@ -76,11 +76,6 @@ const uint8_t parity_table[256] = {
     0, CC_P, CC_P, 0, CC_P, 0, 0, CC_P,
 };
 
-uint8_t parity(uint64_t a) {
-	return parity_table[(a) & 0xFF];
-}
-
-
 // #define DEBUG_MIASM_AUTOMOD_CODE
 
 void memory_access_list_init(struct memory_access_list * access)

--- a/miasm2/jitter/vm_mngr.h
+++ b/miasm2/jitter/vm_mngr.h
@@ -193,8 +193,7 @@ int vm_write_mem(vm_mngr_t* vm_mngr, uint64_t addr, char *buffer, uint64_t size)
 #define CC_P 1
 
 extern const uint8_t parity_table[256];
-
-uint8_t parity(uint64_t a);
+#define parity(a) parity_table[(a) & 0xFF]
 
 unsigned int my_imul08(unsigned int a, unsigned int b);
 


### PR DESCRIPTION
As noticed by @serpilliere, the `parity` operation is widely used, and defining it as a C macro avoid a lot of function call in CC's JiTted code.
For the same reason, the LLVM [`ctpop`](http://llvm.org/docs/LangRef.html#llvm-ctpop-intrinsic) can be used to avoid a call to an external function, and then permit better optimisation and code generation.