### PR TITLE
Fix/division

### DIFF
--- a/miasm2/expression/modint.py
+++ b/miasm2/expression/modint.py
@@ -41,11 +41,15 @@ class moduint(object):
             return self.__class__(self.arg & y)
 
     def __div__(self, y):
+        # Python: 8 / -7 == -2 (C-like: -1)
+        # int(float) trick cannot be used, due to information loss
+        den = int(y)
+        num = int(self)
+        result_sign = 1 if (den * num) >= 0 else -1
+        cls = self.__class__
         if isinstance(y, moduint):
             cls = self.maxcast(y)
-            return cls(int(float(self.arg) / y.arg))
-        else:
-            return self.__class__(int(float(self.arg) / y))
+        return ((abs(num) / abs(den)) * result_sign)
 
     def __int__(self):
         return int(self.arg)
@@ -64,11 +68,11 @@ class moduint(object):
             return self.__class__(self.arg << y)
 
     def __mod__(self, y):
+        # See __div__ for implementation choice
+        cls = self.__class__
         if isinstance(y, moduint):
             cls = self.maxcast(y)
-            return cls(self.arg - (y.arg * int(float(self.arg)/y.arg)))
-        else:
-            return self.__class__(self.arg - (y * int(float(self.arg)/y)))
+        return cls(self.arg - (y * (self / y)))
 
     def __mul__(self, y):
         if isinstance(y, moduint):

--- a/test/expression/modint.py
+++ b/test/expression/modint.py
@@ -61,3 +61,12 @@ assert(c % -3 == 1)
 print e + c, c + e, c - e, e - c
 print 1000 * a
 print hex(a)
+
+define_int(128)
+define_uint(128)
+h = uint128(0x11223344556677889900AABBCCDDEEFF)
+i = int128(-0x9900AABBCCDDEEFF1122334455667788)
+
+assert(i / h == 6)
+assert(i % h == 0x3221aa32bb43cd58d9cc54dd65ee7e)
+

--- a/test/expression/modint.py
+++ b/test/expression/modint.py
@@ -8,7 +8,7 @@ d = uint1(0)
 e = uint1(1)
 
 f = uint8(0x1)
-
+g = int8(-3)
 
 print a, b, c
 print a + b, a + c, b + c
@@ -53,6 +53,10 @@ assert(f ^ f == 0)
 assert(f ^ 0 == f)
 assert(0 ^ f == f)
 assert(1 ^ f == 0)
+assert(c / g == -1)
+assert(c / -3 == -1)
+assert(c % g == 1)
+assert(c % -3 == 1)
 
 print e + c, c + e, c - e, e - c
 print 1000 * a


### PR DESCRIPTION
Fix division and modulo operation for moduint.

For the record, Python uses the Floor Division (`8 / -7 == -2`), instead of C-like and expected IR behavior (`8 / -7 == -1`).
The float trick is not usable here, because on big integer, there is a loss of information.