### PR TITLE
Let x86 'pre_add_instr' be the default behavior

### DIFF
--- a/miasm2/arch/aarch64/ira.py
+++ b/miasm2/arch/aarch64/ira.py
@@ -34,34 +34,6 @@ class ir_a_aarch64l(ir_a_aarch64l_base):
         b.rw[-1][1].add(self.arch.regs.of)
         b.rw[-1][1].add(self.arch.regs.cf)
 
-    def post_add_bloc(self, bloc, ir_blocs):
-        ir.post_add_bloc(self, bloc, ir_blocs)
-        for irb in ir_blocs:
-            pc_val = None
-            lr_val = None
-            for assignblk in irb.irs:
-                pc_val = assignblk.get(PC, pc_val)
-                lr_val = assignblk.get(LR, lr_val)
-            if pc_val is None or lr_val is None:
-                continue
-            if not isinstance(lr_val, ExprInt):
-                continue
-
-            l = bloc.lines[-1]
-            if lr_val.arg != l.offset + l.l:
-                continue
-
-            # CALL
-            lbl = bloc.get_next()
-            new_lbl = self.gen_label()
-            irs = self.call_effects(pc_val, l)
-            irs.append(AssignBlock([ExprAff(self.IRDst,
-                                            ExprId(lbl, size=self.pc.size))]))
-            nbloc = irbloc(new_lbl, irs)
-            nbloc.lines = [l] * len(irs)
-            self.blocs[new_lbl] = nbloc
-            irb.dst = ExprId(new_lbl, size=self.pc.size)
-
     def get_out_regs(self, b):
         return set([self.ret_reg, self.sp])
 

--- a/miasm2/arch/arm/ira.py
+++ b/miasm2/arch/arm/ira.py
@@ -32,34 +32,6 @@ class ir_a_arml(ir_a_arml_base):
         b.rw[-1][1].add(self.arch.regs.of)
         b.rw[-1][1].add(self.arch.regs.cf)
 
-    def post_add_bloc(self, bloc, ir_blocs):
-        ir.post_add_bloc(self, bloc, ir_blocs)
-        for irb in ir_blocs:
-            pc_val = None
-            lr_val = None
-            for assignblk in irb.irs:
-                pc_val = assignblk.get(PC, pc_val)
-                lr_val = assignblk.get(LR, lr_val)
-            if pc_val is None or lr_val is None:
-                continue
-            if not isinstance(lr_val, ExprInt):
-                continue
-
-            l = bloc.lines[-1]
-            if lr_val.arg != l.offset + l.l:
-                continue
-
-            # CALL
-            lbl = bloc.get_next()
-            new_lbl = self.gen_label()
-            irs = self.call_effects(pc_val, l)
-            irs.append(AssignBlock([ExprAff(self.IRDst,
-                                            ExprId(lbl, size=self.pc.size))]))
-            nbloc = irbloc(new_lbl, irs)
-            nbloc.lines = [l] * len(irs)
-            self.blocs[new_lbl] = nbloc
-            irb.dst = ExprId(new_lbl, size=self.pc.size)
-
     def get_out_regs(self, b):
         return set([self.ret_reg, self.sp])
 

--- a/miasm2/arch/mips32/ira.py
+++ b/miasm2/arch/mips32/ira.py
@@ -17,6 +17,10 @@ class ir_a_mips32l(ir_mips32l, ira):
     def set_dead_regs(self, b):
         pass
 
+    def pre_add_instr(self, block, instr, irb_cur, ir_blocks_all, gen_pc_updt):
+        # Avoid adding side effects, already done in post_add_bloc
+        return irb_cur
+
     def post_add_bloc(self, bloc, ir_blocs):
         ir.post_add_bloc(self, bloc, ir_blocs)
         for irb in ir_blocs:

--- a/miasm2/arch/msp430/ira.py
+++ b/miasm2/arch/msp430/ira.py
@@ -34,30 +34,6 @@ class ir_a_msp430(ir_a_msp430_base):
         b.rw[-1][1].add(self.arch.regs.cpuoff)
         b.rw[-1][1].add(self.arch.regs.gie)
 
-    def post_add_bloc(self, bloc, ir_blocs):
-        ir.post_add_bloc(self, bloc, ir_blocs)
-        l = bloc.lines[-1]
-        if not l.is_subcall():
-            return
-
-        for irb in ir_blocs:
-            pc_val = None
-            for assignblk in irb.irs:
-                pc_val = assignblk.get(PC, pc_val)
-            if pc_val is None:
-                continue
-
-            l = bloc.lines[-1]
-            lbl = bloc.get_next()
-            new_lbl = self.gen_label()
-            irs = self.call_effects(pc_val, l)
-            irs.append(AssignBlock([ExprAff(self.IRDst,
-                                            ExprId(lbl, size=self.pc.size))]))
-            nbloc = irbloc(new_lbl, irs)
-            nbloc.lines = [l] * len(irs)
-            self.blocs[new_lbl] = nbloc
-            irb.dst = ExprId(new_lbl, size=self.pc.size)
-
     def get_out_regs(self, b):
         return set([self.ret_reg, self.sp])
 

--- a/miasm2/arch/x86/ira.py
+++ b/miasm2/arch/x86/ira.py
@@ -31,15 +31,6 @@ class ir_a_x86_16(ir_x86_16, ira):
         for b in leaves:
             self.set_dead_regs(b)
 
-    def pre_add_instr(self, block, instr, irb_cur, ir_blocks_all, gen_pc_update):
-        if not instr.is_subcall():
-            return irb_cur
-        call_effects = self.call_effects(instr.args[0], instr)
-        for assignblk in call_effects:
-            irb_cur.irs.append(assignblk)
-            irb_cur.lines.append(instr)
-        return None
-
 class ir_a_x86_32(ir_x86_32, ir_a_x86_16):
 
     def __init__(self, symbol_pool=None):

--- a/miasm2/ir/analysis.py
+++ b/miasm2/ir/analysis.py
@@ -44,6 +44,17 @@ class ira(ir):
                  'call_func_stack', ad, self.sp)),
              ])]
 
+    def pre_add_instr(self, block, instr, irb_cur, ir_blocks_all, gen_pc_update):
+        """Replace function call with corresponding call effects,
+        inside the IR block"""
+        if not instr.is_subcall():
+            return irb_cur
+        call_effects = self.call_effects(instr.args[0], instr)
+        for assignblk in call_effects:
+            irb_cur.irs.append(assignblk)
+            irb_cur.lines.append(instr)
+        return None
+
     def remove_dead_instr(self, irb, useful):
         """Remove dead affectations using previous reaches analysis
         @irb: irbloc instance


### PR DESCRIPTION
Since #469, call effects are placed "inline" in IR blocks.
This PR applied this *wanted* behavior for all architectures (ie. by default), except for mips32 due to delayslot issues