### PR TITLE
Duplicated WZR definition

### DIFF
--- a/miasm2/arch/aarch64/regs.py
+++ b/miasm2/arch/aarch64/regs.py
@@ -88,9 +88,9 @@ all_regs_ids = [
 
     exception_flags,
     PC,
-    WZR, WZR,
+    WZR,
     zf, nf, of, cf,
-    XZR, WZR,
+    XZR
 
 ]
 


### PR DESCRIPTION
The WZR register is defined three times.

Before the patch:
```
>>> from miasm2.arch.aarch64.regs import all_regs_ids
>>> len(all_regs_ids), len(set(all_regs_ids))
(234, 232)
```
After the patch:
```
>>> from miasm2.arch.aarch64.regs import all_regs_ids
>>> len(all_regs_ids), len(set(all_regs_ids))
>>> (232, 232)
```