### PR TITLE
Jitter: fix post instr exception

### DIFF
--- a/miasm2/jitter/codegen.py
+++ b/miasm2/jitter/codegen.py
@@ -65,7 +65,7 @@ class CGen(object):
 
     CODE_CPU_EXCEPTION_POST_INSTR = r"""
     if (CPU_exception_flag) {
-        %s = %s;
+        %s = DST_value;
         BlockDst->address = DST_value;
         return JIT_RET_EXCEPTION;
     }
@@ -75,7 +75,7 @@ class CGen(object):
     check_memory_breakpoint(&(jitcpu->pyvm->vm_mngr));
     check_invalid_code_blocs(&(jitcpu->pyvm->vm_mngr));
     if (VM_exception_flag) {
-        %s = %s;
+        %s = DST_value;
         BlockDst->address = DST_value;
         return JIT_RET_EXCEPTION;
     }
@@ -296,13 +296,12 @@ class CGen(object):
                 '%s' % ret,
                 '%s' % retb], dst2index
 
-    def gen_post_instr_checks(self, attrib, dst):
+    def gen_post_instr_checks(self, attrib):
         out = []
-        dst = self.dst_to_c(dst)
         if attrib.mem_read | attrib.mem_write:
-            out += (self.CODE_VM_EXCEPTION_POST_INSTR % (self.C_PC, dst)).split('\n')
+            out += (self.CODE_VM_EXCEPTION_POST_INSTR % (self.C_PC)).split('\n')
         if attrib.set_exception or attrib.op_set_exception:
-            out += (self.CODE_CPU_EXCEPTION_POST_INSTR % (self.C_PC, dst)).split('\n')
+            out += (self.CODE_CPU_EXCEPTION_POST_INSTR % (self.C_PC)).split('\n')
 
         if attrib.mem_read | attrib.mem_write:
             out.append("reset_memory_access(&(jitcpu->pyvm->vm_mngr));")
@@ -340,12 +339,12 @@ class CGen(object):
             # (consecutive instructions)
             lbl = self.ir_arch.symbol_pool.getby_offset_create(dst)
             out += self.gen_post_code(attrib)
-            out += self.gen_post_instr_checks(attrib, dst)
+            out += self.gen_post_instr_checks(attrib)
             out.append('goto %s;' % lbl.name)
         else:
             out += self.gen_post_code(attrib)
             out.append('BlockDst->address = DST_value;')
-            out += self.gen_post_instr_checks(attrib, dst)
+            out += self.gen_post_instr_checks(attrib)
             out.append('\t\treturn JIT_RET_NO_EXCEPTION;')
         return out
 

--- a/test/jitter/test_post_instr.py
+++ b/test/jitter/test_post_instr.py
@@ -1,0 +1,46 @@
+from miasm2.analysis.machine import Machine
+from miasm2.jitter.csts import PAGE_READ, PAGE_WRITE, EXCEPT_BREAKPOINT_INTERN, EXCEPT_ACCESS_VIOL
+import sys
+
+machine = Machine("x86_32")
+jitter = machine.jitter(sys.argv[1])
+
+# Prepare stack and reset memory accesses to avoid an exception
+jitter.vm.add_memory_page(0x10000, PAGE_READ|PAGE_WRITE, "\x00"*0x1000, "stack")
+print jitter.vm
+
+jitter.cpu.ESP = 0x10000 + 0x1000
+jitter.push_uint32_t(0x0)
+jitter.push_uint32_t(0x1337beef)
+
+jitter.vm.reset_memory_access()
+print hex(jitter.vm.get_exception())
+
+# Add code, and keep memory write pending
+jitter.vm.add_memory_page(0x1000, PAGE_READ|PAGE_WRITE, "\x00"*0x1000, "code page")
+
+# MOV EAX, 0x11223344
+# RET
+jitter.vm.set_mem(0x1000, "B844332211C3".decode('hex'))
+
+jitter.jit.log_mn = True
+jitter.jit.log_regs = True
+
+def do_not_raise_me(jitter):
+    raise ValueError("Should not be here")
+
+jitter.exceptions_handler.callbacks[EXCEPT_BREAKPOINT_INTERN] = []
+jitter.add_exception_handler(EXCEPT_BREAKPOINT_INTERN,
+                             do_not_raise_me)
+jitter.vm.add_memory_breakpoint(0x11000-4, 4, 7)
+
+# The memory write pending will raise automod execption
+# The RET should not re evalueate PC @ [ESP+4]
+jitter.init_run(0x1000)
+try:
+    jitter.continue_run()
+except AssertionError:
+    assert jitter.vm.get_exception() == EXCEPT_ACCESS_VIOL
+except RuntimeError:
+    assert sys.argv[1] == 'python'
+    assert jitter.vm.get_exception() == EXCEPT_ACCESS_VIOL

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -341,6 +341,7 @@ for i, test_args in enumerate(test_args):
 for script in ["jitload.py",
                "vm_mngr.py",
                "jit_options.py",
+               "test_post_instr.py",
                ]:
     for engine in ArchUnitTest.jitter_engines:
         testset += RegressionTest([script, engine], base_dir="jitter",


### PR DESCRIPTION
PC must not be reevaluated on post instruction error.
(llvm backend not affected)


Bug raised and corrected with @commial 
Thanks @commial !
