### PR TITLE
Jitter: fix symb cache name

### DIFF
--- a/miasm2/arch/mips32/jit.py
+++ b/miasm2/arch/mips32/jit.py
@@ -63,7 +63,7 @@ class mipsCGen(CGen):
         """
 
         lbl = self.get_block_post_label(block)
-        out = (self.CODE_RETURN_NO_EXCEPTION % (lbl.name,
+        out = (self.CODE_RETURN_NO_EXCEPTION % (self.label_to_jitlabel(lbl),
                                                 self.C_PC,
                                                 m2_expr.ExprId('branch_dst_irdst'),
                                                 m2_expr.ExprId('branch_dst_irdst'),

--- a/miasm2/jitter/jitcore_cc_base.py
+++ b/miasm2/jitter/jitcore_cc_base.py
@@ -90,7 +90,7 @@ class JitCore_Cc_Base(JitCore):
         Generate function name from @label
         @label: AsmLabel instance
         """
-        return "block_%s" % label.name
+        return "block_%s" % self.codegen.label_to_jitlabel(label)
 
     def gen_c_code(self, label, block):
         """

--- a/miasm2/jitter/jitcore_llvm.py
+++ b/miasm2/jitter/jitcore_llvm.py
@@ -82,7 +82,7 @@ class JitCore_LLVM(jitcore.JitCore):
 
         if not os.access(fname_out, os.R_OK):
             # Build a function in the context
-            func = LLVMFunction(self.context, block.label.name)
+            func = LLVMFunction(self.context, LLVMFunction.canonize_label_name(block.label))
 
             # Set log level
             func.log_regs = self.log_regs
@@ -113,7 +113,7 @@ class JitCore_LLVM(jitcore.JitCore):
 
         else:
             # The cache file exists: function can be loaded from cache
-            ptr = self.context.get_ptr_from_cache(fname_out, block.label.name)
+            ptr = self.context.get_ptr_from_cache(fname_out, LLVMFunction.canonize_label_name(block.label))
 
         # Store a pointer on the function jitted code
         self.lbl2jitbloc[block.label.offset] = ptr

--- a/miasm2/jitter/llvmconvert.py
+++ b/miasm2/jitter/llvmconvert.py
@@ -503,15 +503,19 @@ class LLVMFunction():
             var_casted = var
         self.builder.ret(var_casted)
 
-    def canonize_label_name(self, label):
+    @staticmethod
+    def canonize_label_name(label):
         """Canonize @label names to a common form.
         @label: str or asmlabel instance"""
         if isinstance(label, str):
             return label
-        elif isinstance(label, m2_asmblock.AsmLabel):
-            return "label_%s" % label.name
-        elif m2_asmblock.expr_is_label(label):
-            return "label_%s" % label.name.name
+        if m2_asmblock.expr_is_label(label):
+            label = label.name
+        if isinstance(label, m2_asmblock.AsmLabel):
+            if label.offset is None:
+                return "label_%s" % label.name
+            else:
+                return "label_%X" % label.offset
         else:
             raise ValueError("label must either be str or asmlabel")
 


### PR DESCRIPTION
Support different symbool names in identical jitter block
:warning: the `log_mn` keeps displaying old symbols
