### PR TITLE
Refactor/gcc default jitter

### DIFF
--- a/example/jitter/mips32.py
+++ b/example/jitter/mips32.py
@@ -20,8 +20,8 @@ parser.add_argument("-n", "--log-newbloc",
                     help="Log basic blocks processed by the Jitter",
                     action="store_true")
 parser.add_argument("-j", "--jitter",
-                    help="Jitter engine. Possible values are : tcc (default), llvm",
-                    default="tcc")
+                    help="Jitter engine (default is 'gcc')",
+                    default="gcc")
 parser.add_argument("-d", "--debugging",
                     help="Attach a CLI debugguer to the sandboxed programm",
                     action="store_true")

--- a/example/jitter/msp430.py
+++ b/example/jitter/msp430.py
@@ -18,8 +18,8 @@ parser.add_argument("-n", "--log-newbloc",
                     help="Log basic blocks processed by the Jitter",
                     action="store_true")
 parser.add_argument("-j", "--jitter",
-                    help="Jitter engine. Possible values are : tcc (default), llvm",
-                    default="tcc")
+                    help="Jitter engine (default is 'gcc')",
+                    default="gcc")
 parser.add_argument("-d", "--debugging",
                     help="Attach a CLI debugguer to the sandboxed programm",
                     action="store_true")

--- a/example/jitter/x86_32.py
+++ b/example/jitter/x86_32.py
@@ -13,8 +13,8 @@ if filename and os.path.isfile(filename):
 parser = ArgumentParser(description="x86 32 basic Jitter")
 parser.add_argument("filename", help="x86 32 shellcode filename")
 parser.add_argument("-j", "--jitter",
-                    help="Jitter engine. Possible values are : tcc (default), llvm",
-                    default="tcc")
+                    help="Jitter engine (default is 'gcc')",
+                    default="gcc")
 args = parser.parse_args()
 
 def code_sentinelle(jitter):

--- a/miasm2/analysis/sandbox.py
+++ b/miasm2/analysis/sandbox.py
@@ -88,8 +88,8 @@ class Sandbox(object):
         parser.add_argument('-g', "--gdbserver", type=int,
                             help="Listen on port @port")
         parser.add_argument("-j", "--jitter",
-                            help="Jitter engine. Possible values are: tcc (default), llvm, python",
-                            default="tcc")
+                            help="Jitter engine. Possible values are: gcc (default), tcc, llvm, python",
+                            default="gcc")
         parser.add_argument(
             '-q', "--quiet-function-calls", action="store_true",
                             help="Don't log function calls")

--- a/miasm2/jitter/jitload.py
+++ b/miasm2/jitter/jitload.py
@@ -163,12 +163,12 @@ class jitter:
 
     C_Gen = CGen
 
-    def __init__(self, ir_arch, jit_type="tcc"):
+    def __init__(self, ir_arch, jit_type="gcc"):
         """Init an instance of jitter.
         @ir_arch: ir instance for this architecture
         @jit_type: JiT backend to use. Available options are:
-            - "tcc"
             - "gcc"
+            - "tcc"
             - "llvm"
             - "python"
         """

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -16,6 +16,7 @@ TAGS = {"regression": "REGRESSION", # Regression tests
         "long": "LONG", # Very time consumming tests
         "llvm": "LLVM", # LLVM dependency is required
         "tcc": "TCC", # TCC dependency is required
+        "gcc": "GCC", # GCC based tests
         "z3": "Z3", # Z3 dependecy is needed
         "qemu": "QEMU", # QEMU tests (several tests)
         "cparser": "CPARSER", # pycparser is needed
@@ -209,7 +210,7 @@ class SemanticTestExec(RegressionTest):
                              input_filename,
                              "-a", hex(address)]
         self.products = []
-        self.tags.append(TAGS["tcc"])
+        self.tags.append(TAGS["gcc"])
 
 
 test_x86_64_mul_div = SemanticTestAsm("x86_64", "PE", ["mul_div"])
@@ -256,13 +257,13 @@ testset += RegressionTest(["smt2.py"], base_dir="ir/translators",
 ## OS_DEP
 for script in ["win_api_x86_32.py",
                ]:
-    testset += RegressionTest([script], base_dir="os_dep", tags=[TAGS['tcc']])
+    testset += RegressionTest([script], base_dir="os_dep", tags=[TAGS['gcc']])
 
 for arch in ["x86_32", "x86_64", "arml", "aarch64l"]:
     testset += RegressionTest(["test_env.py", arch, "test_env.%s" % arch, "-c",
                                "arg1", "-c", "arg2", "--environment-vars",
                                "TEST=TOTO", "--mimic-env"],
-                              base_dir="os_dep/linux", tags=[TAGS['tcc']])
+                              base_dir="os_dep/linux", tags=[TAGS['gcc']])
 
 ## Analysis
 testset += RegressionTest(["depgraph.py"], base_dir="analysis",
@@ -628,6 +629,7 @@ for jitter in ExampleJitter.jitter_engines:
     tags = {"python": [TAGS["long"]],
             "llvm": [TAGS["llvm"]],
             "tcc": [TAGS["tcc"]],
+            "gcc": [TAGS["gcc"]],
             }
     testset += ExampleJitter(["unpack_upx.py",
                               Example.get_sample("box_upx.exe")] +


### PR DESCRIPTION
Let *GCC* be the default jitter, as it is required to build Miasm (and *TCC* is not).