### PR TITLE
Jitter: Error on reg set not int

### DIFF
--- a/miasm2/jitter/JitCore.h
+++ b/miasm2/jitter/JitCore.h
@@ -17,7 +17,7 @@
 	}								\
 
 
-#define PyGetInt_ret0(item, value)					\
+#define PyGetInt_retneg(item, value)					\
 	if (PyInt_Check(item)){						\
 		value = (uint64_t)PyInt_AsLong(item);			\
 	}								\
@@ -25,7 +25,8 @@
 		value = (uint64_t)PyLong_AsUnsignedLongLong(item);	\
 	}								\
 	else{								\
-		printf("error\n"); return 0;				\
+		PyErr_SetString(PyExc_TypeError, "Arg must be int");	\
+		return -1;						\
 	}								\
 
 
@@ -38,7 +39,7 @@
 	static int JitCpu_set_ ## regname  (JitCpu *self, PyObject *value, void *closure) \
 	{								\
 		uint64_t val;						\
-		PyGetInt_ret0(value, val);				\
+		PyGetInt_retneg(value, val);				\
 		((vm_cpu_t*)(self->cpu))->  regname   = val;		\
 		return 0;						\
 	}
@@ -51,7 +52,7 @@
 	static int JitCpu_set_ ## regname  (JitCpu *self, PyObject *value, void *closure) \
 	{								\
 		uint32_t val;						\
-		PyGetInt_ret0(value, val);				\
+		PyGetInt_retneg(value, val);				\
 		((vm_cpu_t*)(self->cpu))->  regname   = val;		\
 		return 0;						\
 	}
@@ -65,8 +66,8 @@
 	static int JitCpu_set_ ## regname  (JitCpu *self, PyObject *value, void *closure) \
 	{								\
 		uint16_t val;						\
-		PyGetInt_ret0(value, val);				\
-		((vm_cpu_t*)(self->cpu))->  regname   = val;				\
+		PyGetInt_retneg(value, val);				\
+		((vm_cpu_t*)(self->cpu))->  regname   = val;		\
 		return 0;						\
 	}
 

--- a/miasm2/jitter/arch/JitCore_x86.c
+++ b/miasm2/jitter/arch/JitCore_x86.c
@@ -428,7 +428,7 @@ JitCpu_init(JitCpu *self, PyObject *args, PyObject *kwds)
 	static int JitCpu_set_E ## regname  (JitCpu *self, PyObject *value, void *closure) \
 	{								\
 		uint64_t val;						\
-		PyGetInt_ret0(value, val);				\
+		PyGetInt_retneg(value, val);				\
 		val &= 0xFFFFFFFF;					\
 		val |= ((vm_cpu_t*)(self->cpu))->R ##regname & 0xFFFFFFFF00000000ULL; \
 		((vm_cpu_t*)(self->cpu))->R ## regname   = val;			\
@@ -445,7 +445,7 @@ JitCpu_init(JitCpu *self, PyObject *args, PyObject *kwds)
 	static int JitCpu_set_ ## regname  (JitCpu *self, PyObject *value, void *closure) \
 	{								\
 		uint64_t val;						\
-		PyGetInt_ret0(value, val);				\
+		PyGetInt_retneg(value, val);				\
 		val &= 0xFFFF;						\
 		val |= ((vm_cpu_t*)(self->cpu))->R ##regname & 0xFFFFFFFFFFFF0000ULL; \
 		((vm_cpu_t*)(self->cpu))->R ## regname   = val;			\


### PR DESCRIPTION
Raise error if setting a jitter register with something else than an integer (or long)