### PR TITLE
Remove PYTHONSTARTUP in end-user scripts

### DIFF
--- a/example/disasm/full.py
+++ b/example/disasm/full.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from argparse import ArgumentParser
 from pdb import pm
@@ -16,10 +15,6 @@ console_handler = logging.StreamHandler()
 console_handler.setFormatter(logging.Formatter("%(levelname)-5s: %(message)s"))
 log.addHandler(console_handler)
 log.setLevel(logging.INFO)
-
-filename = os.environ.get('PYTHONSTARTUP')
-if filename and os.path.isfile(filename):
-    execfile(filename)
 
 
 parser = ArgumentParser("Disassemble a binary")

--- a/example/expression/simplification_add.py
+++ b/example/expression/simplification_add.py
@@ -1,11 +1,6 @@
 import miasm2.expression.expression as m2_expr
 from miasm2.expression.simplifications import expr_simp
 from pdb import pm
-import os
-
-filename = os.environ.get('PYTHONSTARTUP')
-if filename and os.path.isfile(filename):
-    execfile(filename)
 
 print """
 Expression simplification demo: Adding a simplification:

--- a/example/expression/simplification_tools.py
+++ b/example/expression/simplification_tools.py
@@ -1,10 +1,5 @@
 from miasm2.expression.expression import *
 from pdb import pm
-import os
-
-filename = os.environ.get('PYTHONSTARTUP')
-if filename and os.path.isfile(filename):
-    execfile(filename)
 
 print """
 Expression simplification demo.

--- a/example/expression/solve_condition_stp.py
+++ b/example/expression/solve_condition_stp.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import subprocess
 from collections import defaultdict
@@ -17,11 +16,6 @@ from miasm2.expression.simplifications import expr_simp
 from miasm2.expression import stp
 from miasm2.core import parse_asm
 from miasm2.arch.x86.disasm import dis_x86_32 as dis_engine
-
-
-filename = os.environ.get('PYTHONSTARTUP')
-if filename and os.path.isfile(filename):
-    execfile(filename)
 
 
 mn = mn_x86

--- a/example/jitter/sandbox_elf_aarch64l.py
+++ b/example/jitter/sandbox_elf_aarch64l.py
@@ -1,14 +1,7 @@
-import os
+import logging
 from pdb import pm
 from miasm2.analysis.sandbox import Sandbox_Linux_aarch64l
 from miasm2.jitter.jitload import log_func
-import logging
-
-
-# Python auto completion
-filename = os.environ.get('PYTHONSTARTUP')
-if filename and os.path.isfile(filename):
-    execfile(filename)
 
 # Insert here user defined methods
 

--- a/example/jitter/sandbox_pe_x86_32.py
+++ b/example/jitter/sandbox_pe_x86_32.py
@@ -1,11 +1,5 @@
-import os
 from pdb import pm
 from miasm2.analysis.sandbox import Sandbox_Win_x86_32
-
-# Python auto completion
-filename = os.environ.get('PYTHONSTARTUP')
-if filename and os.path.isfile(filename):
-    execfile(filename)
 
 # Insert here user defined methods
 

--- a/example/jitter/sandbox_pe_x86_64.py
+++ b/example/jitter/sandbox_pe_x86_64.py
@@ -1,11 +1,5 @@
-import os
 from pdb import pm
 from miasm2.analysis.sandbox import Sandbox_Win_x86_64
-
-# Python auto completion
-filename = os.environ.get('PYTHONSTARTUP')
-if filename and os.path.isfile(filename):
-    execfile(filename)
 
 # Insert here user defined methods
 

--- a/example/jitter/unpack_upx.py
+++ b/example/jitter/unpack_upx.py
@@ -4,12 +4,6 @@ from pdb import pm
 from elfesteem import pe
 from miasm2.analysis.sandbox import Sandbox_Win_x86_32
 
-
-filename = os.environ.get('PYTHONSTARTUP')
-if filename and os.path.isfile(filename):
-    execfile(filename)
-
-
 # User defined methods
 
 def kernel32_GetProcAddress(jitter):

--- a/example/jitter/x86_32.py
+++ b/example/jitter/x86_32.py
@@ -1,14 +1,8 @@
-import os
 from argparse import ArgumentParser
 from miasm2.jitter.csts import PAGE_READ, PAGE_WRITE
 from miasm2.analysis.machine import Machine
 
 from pdb import pm
-
-
-filename = os.environ.get('PYTHONSTARTUP')
-if filename and os.path.isfile(filename):
-    execfile(filename)
 
 parser = ArgumentParser(description="x86 32 basic Jitter")
 parser.add_argument("filename", help="x86 32 shellcode filename")

--- a/test/arch/aarch64/arch.py
+++ b/test/arch/aarch64/arch.py
@@ -1,11 +1,6 @@
-import os, sys
+import sys
 import time
 from miasm2.arch.aarch64.arch import *
-
-filename = os.environ.get('PYTHONSTARTUP')
-if filename and os.path.isfile(filename):
-    execfile(filename)
-
 
 reg_tests_aarch64 = [
     ("XXXXXXXX    MOV        W1, WZR",

--- a/test/arch/arm/arch.py
+++ b/test/arch/arm/arch.py
@@ -1,10 +1,5 @@
-import os
 import time
 from miasm2.arch.arm.arch import *
-
-filename = os.environ.get('PYTHONSTARTUP')
-if filename and os.path.isfile(filename):
-    execfile(filename)
 
 if 0:
     a = bs('00')

--- a/test/arch/mips32/arch.py
+++ b/test/arch/mips32/arch.py
@@ -1,10 +1,7 @@
-import sys
 import time
 from pdb import pm
 
-sys.path.append('/home/serpilliere/projet/m2_devel')
 from miasm2.arch.mips32.arch import *
-
 
 reg_tests_mips32 = [
     ("004496D8    ADDU       GP, GP, T9",

--- a/test/arch/mips32/arch.py
+++ b/test/arch/mips32/arch.py
@@ -1,16 +1,9 @@
-import os, sys
+import sys
 import time
 from pdb import pm
 
 sys.path.append('/home/serpilliere/projet/m2_devel')
 from miasm2.arch.mips32.arch import *
-
-import sys
-
-
-filename = os.environ.get('PYTHONSTARTUP')
-if filename and os.path.isfile(filename):
-    execfile(filename)
 
 
 reg_tests_mips32 = [

--- a/test/arch/msp430/arch.py
+++ b/test/arch/msp430/arch.py
@@ -1,11 +1,5 @@
-
-import os
 import time
 from miasm2.arch.msp430.arch import *
-
-filename = os.environ.get('PYTHONSTARTUP')
-if filename and os.path.isfile(filename):
-    execfile(filename)
 
 
 def h2i(s):

--- a/test/arch/sh4/arch.py
+++ b/test/arch/sh4/arch.py
@@ -1,12 +1,6 @@
-import os
 import time
 from sys import stderr
 from miasm2.arch.sh4.arch import *
-
-filename = os.environ.get('PYTHONSTARTUP')
-if filename and os.path.isfile(filename):
-    execfile(filename)
-
 
 def h2i(s):
     return s.replace(' ', '').decode('hex')

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -1,4 +1,3 @@
-import os
 import time
 import miasm2.expression.expression as m2_expr
 from miasm2.arch.x86.arch import mn_x86, deref_mem_ad, ParseAst, ast_int2expr, \
@@ -6,9 +5,6 @@ from miasm2.arch.x86.arch import mn_x86, deref_mem_ad, ParseAst, ast_int2expr, \
 from miasm2.arch.x86.sem import ir_x86_16, ir_x86_32, ir_x86_64
 from miasm2.core.bin_stream import bin_stream_str
 
-filename = os.environ.get('PYTHONSTARTUP')
-if filename and os.path.isfile(filename):
-    execfile(filename)
 for s in ["[EAX]",
           "[0x10]",
           "[EBX + 0x10]",


### PR DESCRIPTION
Remove 'PYTHONSTARTUP' auto-completion trick in example and tests:
* this is related to the environment of the user, not to Miasm
* it brings unnecessary imports
* it had complexity to example for no reasons