### PR TITLE
Fix obj

### DIFF
--- a/example/expression/expr_c.py
+++ b/example/expression/expr_c.py
@@ -4,10 +4,9 @@ Parse C expression to access variables and retrieve information:
 * variable type
 """
 
-from miasm2.core.ctypesmngr import CTypesManagerNotPacked
+from miasm2.core.ctypesmngr import CTypeStruct, CAstTypes, CTypePtr
 from miasm2.arch.x86.ctype import CTypeAMD64_unk
-from miasm2.core.objc import CHandler
-from miasm2.core.objc import ObjCPtr
+from miasm2.core.objc import CTypesManagerNotPacked, CHandler
 from miasm2.expression.expression import ExprId
 
 
@@ -31,24 +30,21 @@ def test():
     """
 
     # Type manager for x86 64: structures not packed
-    my_types = CTypeAMD64_unk()
-    types_mngr = CTypesManagerNotPacked(my_types.types)
+    base_types = CTypeAMD64_unk()
+    types_ast = CAstTypes()
 
     # Add C types definition
-    types_mngr.add_c_decl(text)
+    types_ast.add_c_decl(text)
+
+    types_mngr = CTypesManagerNotPacked(types_ast, base_types)
 
     # Create the ptr variable with type "struct rectangle*"
-    void_ptr = types_mngr.void_ptr
-    rectangle = types_mngr.get_type(('rectangle',))
-    ptr_rectangle = ObjCPtr('noname', rectangle,
-                            void_ptr.align, void_ptr.size)
-
+    ptr_rectangle = types_mngr.get_objc(CTypePtr(CTypeStruct('rectangle')))
 
     ptr = ExprId('ptr', 64)
     expr_types = {ptr.name: ptr_rectangle}
 
     mychandler = CHandler(types_mngr, expr_types)
-
 
     # Parse some C accesses
     c_acceses = ["ptr->width",

--- a/example/expression/expr_c.py
+++ b/example/expression/expr_c.py
@@ -10,57 +10,53 @@ from miasm2.core.objc import CTypesManagerNotPacked, CHandler
 from miasm2.expression.expression import ExprId
 
 
-def test():
-    """
-    C manipulation example
-    """
+"""
+C manipulation example
+"""
 
-    # Digest C informations
-    text = """
-    struct line {
-            char color[20];
-            int size;
-    };
+# Digest C informations
+text = """
+struct line {
+        char color[20];
+        int size;
+};
 
-    struct rectangle {
-            unsigned int width;
-            unsigned int length;
-            struct line* line;
-    };
-    """
+struct rectangle {
+        unsigned int width;
+        unsigned int length;
+        struct line* line;
+};
+"""
 
-    # Type manager for x86 64: structures not packed
-    base_types = CTypeAMD64_unk()
-    types_ast = CAstTypes()
+# Type manager for x86 64: structures not packed
+base_types = CTypeAMD64_unk()
+types_ast = CAstTypes()
 
-    # Add C types definition
-    types_ast.add_c_decl(text)
+# Add C types definition
+types_ast.add_c_decl(text)
 
-    types_mngr = CTypesManagerNotPacked(types_ast, base_types)
+types_mngr = CTypesManagerNotPacked(types_ast, base_types)
 
-    # Create the ptr variable with type "struct rectangle*"
-    ptr_rectangle = types_mngr.get_objc(CTypePtr(CTypeStruct('rectangle')))
+# Create the ptr variable with type "struct rectangle*"
+ptr_rectangle = types_mngr.get_objc(CTypePtr(CTypeStruct('rectangle')))
 
-    ptr = ExprId('ptr', 64)
-    expr_types = {ptr.name: ptr_rectangle}
+ptr = ExprId('ptr', 64)
+expr_types = {ptr.name: ptr_rectangle}
 
-    mychandler = CHandler(types_mngr, expr_types)
+mychandler = CHandler(types_mngr, expr_types)
 
-    # Parse some C accesses
-    c_acceses = ["ptr->width",
-                 "ptr->length",
-                 "ptr->line",
-                 "ptr->line->color",
-                 "ptr->line->color[3]",
-                 "ptr->line->size"
-                ]
+# Parse some C accesses
+c_acceses = ["ptr->width",
+             "ptr->length",
+             "ptr->line",
+             "ptr->line->color",
+             "ptr->line->color[3]",
+             "ptr->line->size"
+            ]
 
-    for c_str in c_acceses:
-        expr = mychandler.c_to_expr(c_str)
-        c_type = mychandler.c_to_type(c_str)
-        print 'C access:', c_str
-        print '\tExpr:', expr
-        print '\tType:', c_type
-
-if __name__ == '__main__':
-    test()
+for c_str in c_acceses:
+    expr = mychandler.c_to_expr(c_str)
+    c_type = mychandler.c_to_type(c_str)
+    print 'C access:', c_str
+    print '\tExpr:', expr
+    print '\tType:', c_type

--- a/miasm2/arch/x86/ctype.py
+++ b/miasm2/arch/x86/ctype.py
@@ -62,3 +62,68 @@ class CTypeAMD64_unk(CLeafTypes):
             CTypeId('long', 'double'): self.obj_ldouble,
             CTypePtr(CTypeId('void')): self.obj_ulong,
         }
+
+
+
+
+
+class CTypeX86_unk(CLeafTypes):
+    """Define C types sizes/alignement for x86_64 architecture"""
+
+    obj_char = ObjCDecl("char", 1, 1)
+    obj_short = ObjCDecl("short", 2, 2)
+    obj_int = ObjCDecl("int", 4, 4)
+    obj_long = ObjCDecl("long", 4, 4)
+
+    obj_uchar = ObjCDecl("uchar", 1, 1)
+    obj_ushort = ObjCDecl("ushort", 2, 2)
+    obj_uint = ObjCDecl("uint", 4, 4)
+    obj_ulong = ObjCDecl("ulong", 4, 4)
+
+    obj_void = ObjCDecl("void", 1, 1)
+
+    obj_enum = ObjCDecl("enum", 4, 4)
+
+    obj_float = ObjCDecl("float", 4, 4)
+    obj_double = ObjCDecl("double", 8, 8)
+    obj_ldouble = ObjCDecl("ldouble", 16, 16)
+
+    def __init__(self):
+        self.types = {
+            CTypeId('char'): self.obj_char,
+            CTypeId('short'): self.obj_short,
+            CTypeId('int'): self.obj_int,
+            CTypeId('void'): self.obj_void,
+            CTypeId('long',): self.obj_long,
+            CTypeId('float'): self.obj_float,
+            CTypeId('double'): self.obj_double,
+
+            CTypeId('signed', 'char'): self.obj_char,
+            CTypeId('unsigned', 'char'): self.obj_uchar,
+
+            CTypeId('short', 'int'): self.obj_short,
+            CTypeId('signed', 'short'): self.obj_short,
+            CTypeId('signed', 'short', 'int'): self.obj_short,
+            CTypeId('unsigned', 'short'): self.obj_ushort,
+            CTypeId('unsigned', 'short', 'int'): self.obj_ushort,
+
+            CTypeId('unsigned', ): self.obj_uint,
+            CTypeId('unsigned', 'int'): self.obj_uint,
+            CTypeId('signed', 'int'): self.obj_int,
+
+            CTypeId('long', 'int'): self.obj_long,
+            CTypeId('long', 'long'): self.obj_long,
+            CTypeId('long', 'long', 'int'): self.obj_long,
+            CTypeId('signed', 'long', 'long'): self.obj_long,
+            CTypeId('unsigned', 'long', 'long'): self.obj_ulong,
+            CTypeId('signed', 'long', 'long', 'int'): self.obj_long,
+            CTypeId('unsigned', 'long', 'long', 'int'): self.obj_ulong,
+
+            CTypeId('signed', 'long'): self.obj_long,
+            CTypeId('unsigned', 'long'): self.obj_ulong,
+            CTypeId('signed', 'long', 'int'): self.obj_long,
+            CTypeId('unsigned', 'long', 'int'): self.obj_ulong,
+
+            CTypeId('long', 'double'): self.obj_ldouble,
+            CTypePtr(CTypeId('void')): self.obj_uint,
+        }

--- a/miasm2/arch/x86/ctype.py
+++ b/miasm2/arch/x86/ctype.py
@@ -1,7 +1,8 @@
-from miasm2.core.objc import CTypeTemplate, ObjCDecl
+from miasm2.core.objc import CLeafTypes, ObjCDecl
+from miasm2.core.ctypesmngr import CTypeId, CTypePtr
 
 
-class CTypeAMD64_unk(CTypeTemplate):
+class CTypeAMD64_unk(CLeafTypes):
     """Define C types sizes/alignement for x86_64 architecture"""
 
     obj_char = ObjCDecl("char", 1, 1)
@@ -13,38 +14,51 @@ class CTypeAMD64_unk(CTypeTemplate):
     obj_ushort = ObjCDecl("ushort", 2, 2)
     obj_uint = ObjCDecl("uint", 4, 4)
     obj_ulong = ObjCDecl("ulong", 8, 8)
+
     obj_void = ObjCDecl("void", 1, 1)
 
     obj_enum = ObjCDecl("enum", 4, 4)
 
+    obj_float = ObjCDecl("float", 4, 4)
+    obj_double = ObjCDecl("double", 8, 8)
+    obj_ldouble = ObjCDecl("ldouble", 16, 16)
 
     def __init__(self):
         self.types = {
-            ('char',): self.obj_char,
-            ('short',): self.obj_short,
-            ('int',): self.obj_int,
-            ('void',): self.obj_void,
-            ('enum',): self.obj_enum,
+            CTypeId('char'): self.obj_char,
+            CTypeId('short'): self.obj_short,
+            CTypeId('int'): self.obj_int,
+            CTypeId('void'): self.obj_void,
+            CTypeId('long',): self.obj_long,
+            CTypeId('float'): self.obj_float,
+            CTypeId('double'): self.obj_double,
 
-            ('signed', 'char'): self.obj_char,
-            ('unsigned', 'char'): self.obj_uchar,
-            ('signed', 'short', 'int'): self.obj_short,
-            ('short', 'int'): self.obj_short,
-            ('unsigned', 'short'): self.obj_ushort,
-            ('unsigned', 'short', 'int'): self.obj_ushort,
-            ('signed', 'int'): self.obj_int,
-            ('unsigned', 'int'): self.obj_uint,
-            ('long', 'int'): self.obj_long,
-            ('unsigned', 'long'): self.obj_ulong,
-            ('signed', 'long', 'int'): self.obj_long,
-            ('unsigned', 'long', 'int'): self.obj_ulong,
-            ('long',): self.obj_long,
-            ('unsigned', ): self.obj_uint,
+            CTypeId('signed', 'char'): self.obj_char,
+            CTypeId('unsigned', 'char'): self.obj_uchar,
 
-            ('signed', 'long', 'long', 'int'): self.obj_long,
-            ('long', 'unsigned', 'int'): self.obj_ulong,
-            ('unsigned', 'long', 'long'): self.obj_ulong,
-            ('long', 'long', 'int'): self.obj_long,
-            ('unsigned', 'long', 'long', 'int'): self.obj_ulong,
-            ('void*',): self.obj_ulong,
+            CTypeId('short', 'int'): self.obj_short,
+            CTypeId('signed', 'short'): self.obj_short,
+            CTypeId('signed', 'short', 'int'): self.obj_short,
+            CTypeId('unsigned', 'short'): self.obj_ushort,
+            CTypeId('unsigned', 'short', 'int'): self.obj_ushort,
+
+            CTypeId('unsigned', ): self.obj_uint,
+            CTypeId('unsigned', 'int'): self.obj_uint,
+            CTypeId('signed', 'int'): self.obj_int,
+
+            CTypeId('long', 'int'): self.obj_long,
+            CTypeId('long', 'long'): self.obj_long,
+            CTypeId('long', 'long', 'int'): self.obj_long,
+            CTypeId('signed', 'long', 'long'): self.obj_long,
+            CTypeId('unsigned', 'long', 'long'): self.obj_ulong,
+            CTypeId('signed', 'long', 'long', 'int'): self.obj_long,
+            CTypeId('unsigned', 'long', 'long', 'int'): self.obj_ulong,
+
+            CTypeId('signed', 'long'): self.obj_long,
+            CTypeId('unsigned', 'long'): self.obj_ulong,
+            CTypeId('signed', 'long', 'int'): self.obj_long,
+            CTypeId('unsigned', 'long', 'int'): self.obj_ulong,
+
+            CTypeId('long', 'double'): self.obj_ldouble,
+            CTypePtr(CTypeId('void')): self.obj_ulong,
         }

--- a/miasm2/core/ctypesmngr.py
+++ b/miasm2/core/ctypesmngr.py
@@ -1,66 +1,388 @@
-from pycparser import c_ast
-from miasm2.core.objc import ObjCStruct, ObjCUnion, ObjCDecl, ObjCPtr, \
-    ObjCArray, _ObjCRecurse, c_to_ast
+import re
+
+from pycparser import c_parser, c_ast
+
+RE_HASH_CMT = re.compile(r'^#\s*\d+.*$', flags=re.MULTILINE)
+
+# Ref: ISO/IEC 9899:TC2
+# http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1124.pdf
 
 
-def fix_recursive_objects(types_mngr, obj):
-    """Replace _ObjCRecurse objects by its parent"""
+def c_to_ast(c_str):
+    """Transform a @c_str into a C ast
+    Note: will ignore lines containing code refs ie:
+    # 23 "miasm.h"
+    """
 
-    void_type = types_mngr.void_ptr
-
-    if isinstance(obj, ObjCStruct):
-        for i, (name, fieldtype, offset, size) in enumerate(obj.fields):
-            fieldtype = fix_recursive_objects(types_mngr, fieldtype)
-            obj.fields[i] = (name, fieldtype, offset, size)
-    elif isinstance(obj, ObjCDecl):
-        return obj
-    elif isinstance(obj, ObjCPtr):
-        target_obj = fix_recursive_objects(types_mngr, obj.objtype)
-        obj = ObjCPtr(obj.name, target_obj, void_type.align, void_type.size)
-    elif isinstance(obj, ObjCArray):
-        target_obj = fix_recursive_objects(types_mngr, obj.objtype)
-        obj = ObjCArray(target_obj, obj.elems)
-    elif isinstance(obj, ObjCUnion):
-        for i, (name, fieldtype, offset, size) in enumerate(obj.fields):
-            fieldtype = fix_recursive_objects(types_mngr, fieldtype)
-            obj.fields[i] = (name, fieldtype, offset, size)
-    elif isinstance(obj, _ObjCRecurse):
-        obj = types_mngr.get_type((obj.name,))
-    else:
-        raise NotImplementedError("Unknown type")
-    return obj
+    new_str = re.sub(RE_HASH_CMT, "", c_str)
+    parser = c_parser.CParser()
+    return parser.parse(new_str, filename='<stdin>')
 
 
-class CTypesManager(object):
-    """Store all defined C types"""
+class CTypeBase(object):
+    """Object to represent the 3 forms of C type:
+    * object types
+    * function types
+    * incomplete types
+    """
 
-    def __init__(self, knowntypes):
+    def __init__(self):
+        self.__repr = str(self)
+        self.__hash = hash(self.__repr)
+
+    @property
+    def _typerepr(self):
+        return self.__repr
+
+    def eq_base(self, other):
+        """Trivial common equality test"""
+        return self.__class__ == other.__class__
+
+    def __hash__(self):
+        return self.__hash
+
+    def __repr__(self):
+        return self._typerepr
+
+
+class CTypeId(CTypeBase):
+    """C type id:
+    int
+    unsigned int
+    """
+
+    def __init__(self, *names):
+        # Type specifier order does not matter
+        # so the cannonical form is ordered
+        self.names = tuple(sorted(names))
+        super(CTypeId, self).__init__()
+
+    def __hash__(self):
+        return hash((self.__class__, self.names))
+
+    def __eq__(self, other):
+        return (self.eq_base(other) and
+                self.names == other.names)
+
+    def __str__(self):
+        return "<Id:%s>" % ', '.join(self.names)
+
+
+class CTypeArray(CTypeBase):
+    """C type for array:
+    typedef int XXX[4];
+    """
+
+    def __init__(self, target, size):
+        assert isinstance(target, CTypeBase)
+        self.target = target
+        self.size = size
+        super(CTypeArray, self).__init__()
+
+    def __hash__(self):
+        return hash((self.__class__, self.target, self.size))
+
+    def __eq__(self, other):
+        return (self.eq_base(other) and
+                self.target == other.target and
+                self.size == other.size)
+
+    def __str__(self):
+        return "<Array[%s]:%s>" % (self.size, str(self.target))
+
+
+class CTypePtr(CTypeBase):
+    """C type for pointer:
+    typedef int* XXX;
+    """
+
+    def __init__(self, target):
+        assert isinstance(target, CTypeBase)
+        self.target = target
+        super(CTypePtr, self).__init__()
+
+    def __hash__(self):
+        return hash((self.__class__, self.target))
+
+    def __eq__(self, other):
+        return (self.eq_base(other) and
+                self.target == other.target)
+
+    def __str__(self):
+        return "<Ptr:%s>" % str(self.target)
+
+
+class CTypeStruct(CTypeBase):
+    """C type for structure"""
+
+    def __init__(self, name, fields=None):
+        self.name = name
+        if fields is None:
+            fields = ()
+        for _, field in fields:
+            assert isinstance(field, CTypeBase)
+        self.fields = tuple(fields)
+        super(CTypeStruct, self).__init__()
+
+    def __hash__(self):
+        return hash((self.__class__, self.name, self.fields))
+
+    def __eq__(self, other):
+        return (self.eq_base(other) and
+                self.name == other.name and
+                self.fields == other.fields)
+
+    def __str__(self):
+        out = []
+        out.append("<Struct:%s>" % self.name)
+        for name, field in self.fields:
+            out.append("\t%-10s %s" % (name, field))
+        return '\n'.join(out)
+
+
+class CTypeUnion(CTypeBase):
+    """C type for union"""
+
+    def __init__(self, name, fields=None):
+        self.name = name
+        if fields is None:
+            fields = []
+        for _, field in fields:
+            assert isinstance(field, CTypeBase)
+        self.fields = tuple(fields)
+        super(CTypeUnion, self).__init__()
+
+    def __hash__(self):
+        return hash((self.__class__, self.name, self.fields))
+
+    def __eq__(self, other):
+        return (self.eq_base(other) and
+                self.name == other.name and
+                self.fields == other.fields)
+
+    def __str__(self):
+        out = []
+        out.append("<Union:%s>" % self.name)
+        for name, field in self.fields:
+            out.append("\t%-10s %s" % (name, field))
+        return '\n'.join(out)
+
+
+class CTypeEnum(CTypeBase):
+    """C type for enums"""
+
+    def __init__(self, name):
+        self.name = name
+        super(CTypeEnum, self).__init__()
+
+    def __hash__(self):
+        return hash((self.__class__, self.name))
+
+    def __eq__(self, other):
+        return (self.eq_base(other) and
+                self.name == other.name)
+
+    def __str__(self):
+        return "<Enum:%s>" % self.name
+
+
+class CTypeFunc(CTypeBase):
+    """C type for enums"""
+
+    def __init__(self, name, abi=None, type_ret=None, args=None):
+        if type_ret:
+            assert isinstance(type_ret, CTypeBase)
+        if args:
+            for arg in args:
+                assert isinstance(arg, CTypeBase)
+            args = tuple(args)
+        else:
+            args = tuple()
+        self.name = name
+        self.abi = abi
+        self.type_ret = type_ret
+        self.args = args
+        super(CTypeFunc, self).__init__()
+
+    def __hash__(self):
+        return hash((self.__class__, self.name, self.abi,
+                     self.type_ret, self.args))
+
+    def __eq__(self, other):
+        return (self.eq_base(other) and
+                self.name == other.name and
+                self.abi == other.abi and
+                self.type_ret == other.type_ret and
+                self.args == other.args)
+
+    def __str__(self):
+        return "<Func:%s (%s) %s(%s)>" % (self.type_ret,
+                                          self.abi,
+                                          self.name,
+                                          ", ".join([str(arg) for arg in self.args]))
+
+
+class CTypeEllipsis(CTypeBase):
+    """C type for ellipsis argument (...)"""
+
+    def __hash__(self):
+        return hash((self.__class__))
+
+    def __eq__(self, other):
+        return self.eq_base(other)
+
+    def __str__(self):
+        return "<Ellipsis>"
+
+
+class CTypeSizeof(CTypeBase):
+    """C type for sizeof"""
+
+    def __init__(self, target):
+        self.target = target
+        super(CTypeSizeof, self).__init__()
+
+    def __hash__(self):
+        return hash((self.__class__, self.target))
+
+    def __eq__(self, other):
+        return (self.eq_base(other) and
+                self.target == other.target)
+
+    def __str__(self):
+        return "<Sizeof(%s)>" % self.target
+
+
+class CTypeOp(CTypeBase):
+    """C type for operator (+ * ...)"""
+
+    def __init__(self, operator, *args):
+        self.operator = operator
+        self.args = tuple(args)
+        super(CTypeOp, self).__init__()
+
+    def __hash__(self):
+        return hash((self.__class__, self.operator, self.args))
+
+    def __eq__(self, other):
+        return (self.eq_base(other) and
+                self.operator == other.operator and
+                self.args == other.args)
+
+    def __str__(self):
+        return "<CTypeOp(%s, %s)>" % (self.operator,
+                                      ', '.join([str(arg) for arg in self.args]))
+
+
+class FuncNameIdentifier(c_ast.NodeVisitor):
+    """Visit an c_ast to find IdentifierType"""
+
+    def __init__(self):
+        super(FuncNameIdentifier, self).__init__()
+        self.node_name = None
+
+    def visit_TypeDecl(self, node):
+        """Retrieve the name in a function declaration:
+        Only one IdentifierType is present"""
+        self.node_name = node
+
+
+class CAstTypes(object):
+    """Store all defined C types and typedefs"""
+    INTERNAL_PREFIX = "__GENTYPE__"
+
+    def __init__(self, knowntypes=None, knowntypedefs=None):
+        if knowntypes is None:
+            knowntypes = {}
+        if knowntypedefs is None:
+            knowntypedefs = {}
+
         self._types = dict(knowntypes)
+        self._typedefs = dict(knowntypedefs)
         self.cpt = 0
+        self.loc_to_decl_info = {}
+
+        self.ast_to_typeid_rules = {
+            c_ast.Struct: self.ast_to_typeid_struct,
+            c_ast.Union: self.ast_to_typeid_union,
+            c_ast.IdentifierType: self.ast_to_typeid_identifiertype,
+            c_ast.TypeDecl: self.ast_to_typeid_typedecl,
+            c_ast.Decl: self.ast_to_typeid_decl,
+            c_ast.Typename: self.ast_to_typeid_typename,
+            c_ast.FuncDecl: self.ast_to_typeid_funcdecl,
+            c_ast.Enum: self.ast_to_typeid_enum,
+            c_ast.PtrDecl: self.ast_to_typeid_ptrdecl,
+            c_ast.EllipsisParam: self.ast_to_typeid_ellipsisparam,
+            c_ast.ArrayDecl: self.ast_to_typeid_arraydecl,
+        }
+
+        self.ast_parse_rules = {
+            c_ast.Struct: self.ast_parse_struct,
+            c_ast.Union: self.ast_parse_union,
+            c_ast.Typedef: self.ast_parse_typedef,
+            c_ast.TypeDecl: self.ast_parse_typedecl,
+            c_ast.IdentifierType: self.ast_parse_identifiertype,
+            c_ast.Decl: self.ast_parse_decl,
+            c_ast.PtrDecl: self.ast_parse_ptrdecl,
+            c_ast.Enum: self.ast_parse_enum,
+            c_ast.ArrayDecl: self.ast_parse_arraydecl,
+            c_ast.FuncDecl: self.ast_parse_funcdecl,
+            c_ast.FuncDef: self.ast_parse_funcdef,
+            c_ast.Pragma: self.ast_parse_pragma,
+        }
 
     def gen_uniq_name(self):
         """Generate uniq name for unamed strucs/union"""
         cpt = self.cpt
         self.cpt += 1
-        return "__TYPE_INTERNAL__%d" % cpt
+        return self.INTERNAL_PREFIX + "%d" % cpt
+
+    def is_generated_name(self, name):
+        """Return True if the name is internal"""
+        return name.startswith(self.INTERNAL_PREFIX)
 
     def add_type(self, type_id, type_obj):
         """Add new C type
-        @type_id: Type descriptor
-        @type_obj: ObjC* instance"""
-        self._types[type_id] = type_obj
+        @type_id: Type descriptor (CTypeBase instance)
+        @type_obj: Obj* instance"""
+        assert isinstance(type_id, CTypeBase)
+        if type_id in self._types:
+            assert self._types[type_id] == type_obj
+        else:
+            self._types[type_id] = type_obj
+
+    def add_typedef(self, type_new, type_src):
+        """Add new typedef
+        @type_new: CTypeBase instance of the new type name
+        @type_src: CTypeBase instance of the target type"""
+        assert isinstance(type_src, CTypeBase)
+        self._typedefs[type_new] = type_src
 
     def get_type(self, type_id):
-        """Get C type
-        @type_id: Type descriptor
+        """Get ObjC corresponding to the @type_id
+        @type_id: Type descriptor (CTypeBase instance)
         """
-        return self._types[type_id]
+        assert isinstance(type_id, CTypeBase)
+        if isinstance(type_id, CTypePtr):
+            subobj = self.get_type(type_id.target)
+            return CTypePtr(subobj)
+        if type_id in self._types:
+            return self._types[type_id]
+        elif type_id in self._typedefs:
+            return self.get_type(self._typedefs[type_id])
+        return type_id
 
     def is_known_type(self, type_id):
         """Return true if @type_id is known
-        @type_id: Type descriptor
+        @type_id: Type descriptor (CTypeBase instance)
         """
-        return type_id in self._types
+        if isinstance(type_id, CTypePtr):
+            return self.is_known_type(type_id.target)
+        if type_id in self._types:
+            return True
+        if type_id in self._typedefs:
+            return self.is_known_type(self._typedefs[type_id])
+        return False
 
     def add_c_decl_from_ast(self, ast):
         """
@@ -68,6 +390,63 @@ class CTypesManager(object):
         @ast: C ast
         """
         self.ast_parse_declarations(ast)
+
+
+    def digest_decl(self, c_str):
+
+        char_id = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+
+
+        # Seek deck
+        index_decl = []
+        index = 0
+        for decl in ['__cdecl__', '__stdcall__']:
+            index = 0
+            while True:
+                index = c_str.find(decl, index)
+                if index == -1:
+                    break
+                decl_off = index
+                decl_len = len(decl)
+
+                index = index+len(decl)
+                while c_str[index] not in char_id:
+                    index += 1
+
+                id_start = index
+
+                while c_str[index] in char_id:
+                    index += 1
+                id_stop = index
+
+                name = c_str[id_start:id_stop]
+                index_decl.append((decl_off, decl_len, id_start, id_stop, decl, ))
+
+        index_decl.sort()
+
+        # Remove decl
+        off = 0
+        offsets = []
+        for decl_off, decl_len, id_start, id_stop, decl in index_decl:
+            decl_off -= off
+            c_str = c_str[:decl_off] + c_str[decl_off+decl_len:]
+            off += decl_len
+            offsets.append((id_start-off, id_stop-off, decl))
+
+        index = 0
+        lineno = 1
+
+        # Index to lineno, column
+        for id_start, id_stop, decl in offsets:
+            nbr = c_str.count('\n', index, id_start)
+            lineno += nbr
+            last_cr = c_str.rfind('\n', 0, id_start)
+            # column starts at 1
+            column = id_start - last_cr
+            index = id_start
+            self.loc_to_decl_info[(lineno, column)] = decl
+        return c_str
+
 
     def add_c_decl(self, c_str):
         """
@@ -77,33 +456,12 @@ class CTypesManager(object):
         Returns the C ast
         @c_str: C string containing C types declarations
         """
+        c_str = self.digest_decl(c_str)
+
         ast = c_to_ast(c_str)
         self.add_c_decl_from_ast(ast)
 
         return ast
-
-    @property
-    def void_ptr(self):
-        """Return the void* type"""
-        return self.get_type(('void*',))
-
-    def ast_eval_size(self, ast):
-        """Evaluates the size of a C ast object
-
-        @ast: parsed pycparser.c_ast object
-        """
-
-        if isinstance(ast, c_ast.TypeDecl):
-            result = self.ast_eval_size(ast.type)
-        elif isinstance(ast, c_ast.PtrDecl):
-            void_type = self.void_ptr
-            result = void_type.size
-        elif isinstance(ast, c_ast.IdentifierType):
-            obj = self.get_type(tuple(ast.names))
-            result = obj.size
-        else:
-            raise NotImplementedError('TODO')
-        return result
 
     def ast_eval_int(self, ast):
         """Eval a C ast object integer
@@ -114,20 +472,32 @@ class CTypesManager(object):
         if isinstance(ast, c_ast.BinaryOp):
             left = self.ast_eval_int(ast.left)
             right = self.ast_eval_int(ast.right)
-            if ast.op == '*':
-                result = left * right
-            elif ast.op == '/':
-                assert left % right == 0
-                result = left / right
-            elif ast.op == '+':
-                result = left + right
-            elif ast.op == '-':
-                result = left - right
+            is_pure_int = (isinstance(left, (int, long)) and
+                           isinstance(right, (int, long)))
+
+            if is_pure_int:
+                if ast.op == '*':
+                    result = left * right
+                elif ast.op == '/':
+                    assert left % right == 0
+                    result = left / right
+                elif ast.op == '+':
+                    result = left + right
+                elif ast.op == '-':
+                    result = left - right
+                elif ast.op == '<<':
+                    result = left << right
+                elif ast.op == '>>':
+                    result = left >> right
+                else:
+                    raise NotImplementedError("Not implemented!")
             else:
-                raise NotImplementedError("Not implemented!")
+                result = CTypeOp(ast.op, left, right)
+
         elif isinstance(ast, c_ast.UnaryOp):
             if ast.op == 'sizeof' and isinstance(ast.expr, c_ast.Typename):
-                result = self.ast_eval_size(ast.expr.type)
+                subobj = self.ast_to_typeid(ast.expr)
+                result = CTypeSizeof(subobj)
             else:
                 raise NotImplementedError("Not implemented!")
 
@@ -140,131 +510,180 @@ class CTypesManager(object):
             raise NotImplementedError("Not implemented!")
         return result
 
+    def ast_to_typeid_struct(self, ast):
+        """Return the CTypeBase of an Struct ast"""
+        name = self.gen_uniq_name() if ast.name is None else ast.name
+        args = []
+        if ast.decls:
+            for arg in ast.decls:
+                args.append((arg.name, self.ast_to_typeid(arg)))
+        decl = CTypeStruct(name, args)
+        return decl
 
-    def ast_get_align_size(self, ast):
-        """Evaluates the size/alignment of a C ast object
+    def ast_to_typeid_union(self, ast):
+        """Return the CTypeBase of an Union ast"""
+        name = self.gen_uniq_name() if ast.name is None else ast.name
+        args = []
+        if ast.decls:
+            for arg in ast.decls:
+                args.append((arg.name, self.ast_to_typeid(arg)))
+        decl = CTypeUnion(name, args)
+        return decl
 
-        @ast: parsed pycparser.c_ast object
-        """
+    def ast_to_typeid_identifiertype(self, ast):
+        """Return the CTypeBase of an IdentifierType ast"""
+        return CTypeId(*ast.names)
 
-        if isinstance(ast, c_ast.Decl):
-            return self.ast_get_align_size(ast.type)
-        elif isinstance(ast, c_ast.TypeDecl):
-            return self.ast_get_align_size(ast.type)
-        elif isinstance(ast, c_ast.IdentifierType):
-            assert isinstance(ast, c_ast.IdentifierType)
-            names = ast.names
-            names = tuple(names)
-            if not self.is_known_type(names):
-                raise RuntimeError("Unknown type %r" % names)
-            obj = self.get_type(names)
-        elif isinstance(ast, c_ast.ArrayDecl):
-            subobj = self.ast_get_align_size(ast.type)
-            dim = ast.dim
-            value = self.ast_eval_int(dim)
-            obj = ObjCArray(subobj, value)
-        elif isinstance(ast, c_ast.Union):
-            obj = self.ast_gen_union_align_size(ast)
-        elif isinstance(ast, c_ast.Struct):
-            obj = self.ast_gen_struct_align_size(ast)
-        elif isinstance(ast, c_ast.PtrDecl):
-            void_type = self.void_ptr
-            subobj = self.ast_get_align_size(ast.type)
-            obj = ObjCPtr('noname', subobj, void_type.align, void_type.size)
+    def ast_to_typeid_typedecl(self, ast):
+        """Return the CTypeBase of a TypeDecl ast"""
+        return self.ast_to_typeid(ast.type)
+
+    def ast_to_typeid_decl(self, ast):
+        """Return the CTypeBase of a Decl ast"""
+        return self.ast_to_typeid(ast.type)
+
+    def ast_to_typeid_typename(self, ast):
+        """Return the CTypeBase of a TypeName ast"""
+        return self.ast_to_typeid(ast.type)
+
+    def get_funcname(self, ast):
+        """Return the name of a function declaration ast"""
+        funcnameid = FuncNameIdentifier()
+        funcnameid.visit(ast)
+        node_name = funcnameid.node_name
+        if node_name.coord is not None:
+            lineno, column = node_name.coord.line, node_name.coord.column
+            decl_info = self.loc_to_decl_info.get((lineno, column), None)
         else:
-            raise NotImplementedError("Not implemented!")
-        assert isinstance(obj, _ObjCRecurse) or obj.align in [
-            1, 2, 4, 8, 16, 32, 64, 128, 256]
+            decl_info = None
+        return node_name.declname, decl_info
+
+    def ast_to_typeid_funcdecl(self, ast):
+        """Return the CTypeBase of an FuncDecl ast"""
+        type_ret = self.ast_to_typeid(ast.type)
+        name, decl_info = self.get_funcname(ast.type)
+        if ast.args:
+            args = [self.ast_to_typeid(arg) for arg in ast.args.params]
+        else:
+            args = []
+
+        obj = CTypeFunc(name, decl_info, type_ret, args)
+        decl = CTypeFunc(name)
+        if not self.is_known_type(decl):
+            self.add_type(decl, obj)
         return obj
 
-    def struct_compute_field_offset(self, obj, offset):
-        """Compute the offset of the field @obj in the current structure"""
-        raise NotImplementedError("Abstract method")
+    def ast_to_typeid_enum(self, ast):
+        """Return the CTypeBase of an Enum ast"""
+        name = self.gen_uniq_name() if ast.name is None else ast.name
+        return CTypeEnum(name)
 
-    def struct_compute_align_size(self, align_max, size):
-        """Compute the alignment and size of the current structure"""
-        raise NotImplementedError("Abstract method")
+    def ast_to_typeid_ptrdecl(self, ast):
+        """Return the CTypeBase of a PtrDecl ast"""
+        return CTypePtr(self.ast_to_typeid(ast.type))
 
-    def union_compute_align_size(self, align_max, size):
-        """Compute the alignment and size of the current union"""
-        raise NotImplementedError("Abstract method")
+    def ast_to_typeid_ellipsisparam(self, _):
+        """Return the CTypeBase of an EllipsisParam ast"""
+        return CTypeEllipsis()
 
-    def ast_gen_struct_align_size(self, ast):
-        """Evaluates the size/alignment of a C ast structure
-        (default packed)
-
-        @ast: parsed pycparser.c_ast object
-        """
-
-        offset = 0
-        align_max = 1
-
-        if ast.name is None:
-            name = self.gen_uniq_name()
+    def ast_to_typeid_arraydecl(self, ast):
+        """Return the CTypeBase of an ArrayDecl ast"""
+        target = self.ast_to_typeid(ast.type)
+        if ast.dim is None:
+            value = None
         else:
-            name = ast.name
-        new_obj = ObjCStruct(name)
-        if ast.decls is None:
-            # If object is unknown, it's a recursive struct
-            if self.is_known_type((name,)):
-                obj = self.get_type((name,))
-            else:
-                obj = _ObjCRecurse(name)
-            return obj
-        for arg in ast.decls:
-            obj = self.ast_get_align_size(arg)
-            align_max = max(align_max, obj.align)
-            offset = self.struct_compute_field_offset(obj, offset)
-            new_obj.add_field(arg.name, obj, offset, obj.size)
-            offset += obj.size
+            value = self.ast_eval_int(ast.dim)
+        return CTypeArray(target, value)
 
-        # Structure alignement is its field max alignement
-        align, size = self.struct_compute_align_size(align_max, offset)
-        new_obj.set_align_size(align, size)
-        self.add_type((name, ), new_obj)
-        return new_obj
+    def ast_to_typeid(self, ast):
+        """Return the CTypeBase of the @ast
+        @ast: pycparser.c_ast instance"""
+        cls = ast.__class__
+        if not cls in self.ast_to_typeid_rules:
+            raise NotImplementedError("Strange type %r" % ast)
+        return self.ast_to_typeid_rules[cls](ast)
 
-    def ast_gen_union_align_size(self, ast):
-        """Evaluates the size/alignment of a C ast union
-        @ast: parsed pycparser.c_ast object
-        """
-        offset = 0
-        align_max, size_max = 0, 0
+    # Ast parse type declarators
 
-        if ast.name is None:
-            name = self.gen_uniq_name()
-        else:
-            name = ast.name
-        new_obj = ObjCUnion(name)
+    def ast_parse_decl(self, ast):
+        """Parse ast Decl"""
+        return self.ast_parse_declaration(ast.type)
 
-        for arg in ast.decls:
-            obj = self.ast_get_align_size(arg)
-            align_max = max(align_max, obj.align)
-            size_max = max(size_max, obj.size)
-            new_obj.add_field(arg.name, obj,
-                              offset, obj.size)
+    def ast_parse_typedecl(self, ast):
+        """Parse ast Typedecl"""
+        return self.ast_parse_declaration(ast.type)
 
-        align, size = self.union_compute_align_size(align_max, size_max)
-        new_obj.set_align_size(align, size)
-        self.add_type((name, ), new_obj)
-        return new_obj
+    def ast_parse_struct(self, ast):
+        """Parse ast Struct"""
+        obj = self.ast_to_typeid(ast)
+        if ast.decls and ast.name is not None:
+            # Add struct to types if named
+            decl = CTypeStruct(ast.name)
+            if not self.is_known_type(decl):
+                self.add_type(decl, obj)
+        return obj
 
-    def ast_gen_obj_align_size(self, ast):
-        """Evaluates the size/alignment of a C ast struct/union
+    def ast_parse_union(self, ast):
+        """Parse ast Union"""
+        obj = self.ast_to_typeid(ast)
+        if ast.decls and ast.name is not None:
+            # Add union to types if named
+            decl = CTypeUnion(ast.name)
+            if not self.is_known_type(decl):
+                self.add_type(decl, obj)
+        return obj
+
+    def ast_parse_typedef(self, ast):
+        """Parse ast TypeDef"""
+        decl = CTypeId(ast.name)
+        obj = self.ast_parse_declaration(ast.type)
+        if (isinstance(obj, (CTypeStruct, CTypeUnion)) and
+                self.is_generated_name(obj.name)):
+            # Add typedef name to default name
+            # for a question of clarity
+            obj.name += "__%s" % ast.name
+        self.add_typedef(decl, obj)
+        # Typedef does not return any object
+        return None
+
+    def ast_parse_identifiertype(self, ast):
+        """Parse ast IdentifierType"""
+        return CTypeId(*ast.names)
+
+    def ast_parse_ptrdecl(self, ast):
+        """Parse ast PtrDecl"""
+        return CTypePtr(self.ast_parse_declaration(ast.type))
+
+    def ast_parse_enum(self, ast):
+        """Parse ast Enum"""
+        return self.ast_to_typeid(ast)
+
+    def ast_parse_arraydecl(self, ast):
+        """Parse ast ArrayDecl"""
+        return self.ast_to_typeid(ast)
+
+    def ast_parse_funcdecl(self, ast):
+        """Parse ast FuncDecl"""
+        return self.ast_to_typeid(ast)
+
+    def ast_parse_funcdef(self, ast):
+        """Parse ast FuncDef"""
+        return self.ast_to_typeid(ast.decl)
+
+    def ast_parse_pragma(self, _):
+        """Prama does not return any object"""
+        return None
+
+    def ast_parse_declaration(self, ast):
+        """Add one ast type declaration to the type manager
         (packed style in type manager)
 
         @ast: parsed pycparser.c_ast object
         """
-
-        if isinstance(ast, c_ast.Struct):
-            obj = self.ast_gen_struct_align_size(ast)
-        elif isinstance(ast, c_ast.Union):
-            obj = self.ast_gen_union_align_size(ast)
-        else:
-            raise NotImplementedError("Not implemented!")
-
-        fix_recursive_objects(self, obj)
-        return obj
+        cls = ast.__class__
+        if not cls in self.ast_parse_rules:
+            raise NotImplementedError("Strange declaration %r" % cls)
+        return self.ast_parse_rules[cls](ast)
 
     def ast_parse_declarations(self, ast):
         """Add ast types declaration to the type manager
@@ -272,104 +691,5 @@ class CTypesManager(object):
 
         @ast: parsed pycparser.c_ast object
         """
-
         for ext in ast.ext:
-            if isinstance(ext, c_ast.Decl) and\
-               ext.name is None and\
-               isinstance(ext.type, (c_ast.Struct, c_ast.Union)):
-                obj = self.ast_gen_obj_align_size(ext.type)
-                self.add_type((ext.type.name, ), obj)
-
-            elif isinstance(ext, c_ast.Typedef) and\
-                    isinstance(ext.type.type, (c_ast.Struct, c_ast.Union)) and\
-                    not ext.type.type.decls:
-                new_type = ext.name
-                obj = self.get_type((ext.type.type.name,))
-                self.add_type((ext.name,), obj)
-
-            elif isinstance(ext, c_ast.Typedef) and\
-                    isinstance(ext.type.type, (c_ast.Struct, c_ast.Union)) and\
-                    ext.type.type.decls:
-                obj = self.ast_gen_obj_align_size(ext.type.type)
-                self.add_type((ext.type.declname, ), obj)
-
-            elif isinstance(ext, c_ast.Typedef) and\
-                    isinstance(ext.type, c_ast.TypeDecl) and\
-                    isinstance(ext.type.type, c_ast.IdentifierType):
-                ext.show()
-                names = tuple(ext.type.type.names)
-                new_type = ext.name
-
-                if not self.is_known_type(names):
-                    raise RuntimeError("Unknown type %s" % repr(names))
-                obj = self.get_type(names)
-                self.add_type((new_type,), obj)
-
-            elif isinstance(ext, c_ast.Typedef) and\
-                    isinstance(ext.type.type, c_ast.Enum) and\
-                    isinstance(ext.type.type.values, c_ast.EnumeratorList):
-                # Enum are ints
-                obj = self.get_type(('enum',))
-                self.add_type((ext.name,), obj)
-
-            elif isinstance(ext, c_ast.Typedef) and\
-                    isinstance(ext.type, c_ast.ArrayDecl) and\
-                    isinstance(ext.type.type.type, c_ast.IdentifierType) and\
-                    self.is_known_type(tuple(ext.type.type.type.names)):
-                obj = self.get_type(tuple(ext.type.type.type.names))
-                array = ext.type
-
-                value = self.ast_eval_int(array.dim)
-                subobj = self.ast_get_align_size(array.type)
-
-                obj = ObjCArray(subobj, value)
-                self.add_type((ext.name,), obj)
-
-            elif isinstance(ext, c_ast.FuncDef) or\
-                    isinstance(ext.type, c_ast.FuncDecl):
-                continue
-            else:
-                raise NotImplementedError("strange type %r" % ext)
-
-
-class CTypesManagerNotPacked(CTypesManager):
-    """Store defined C types (not packed)"""
-
-    def struct_compute_field_offset(self, obj, offset):
-        """Compute the offset of the field @obj in the current structure
-        (not packed)"""
-
-        if obj.align > 1:
-            offset = (offset + obj.align - 1) & ~(obj.align - 1)
-        return offset
-
-    def struct_compute_align_size(self, align_max, size):
-        """Compute the alignment and size of the current structure
-        (not packed)"""
-        if align_max > 1:
-            size = (size + align_max - 1) & ~(align_max - 1)
-        return align_max, size
-
-    def union_compute_align_size(self, align_max, size):
-        """Compute the alignment and size of the current union
-        (not packed)"""
-        return align_max, size
-
-
-class CTypesManagerPacked(CTypesManager):
-    """Store defined C types (packed form)"""
-
-    def struct_compute_field_offset(self, _, offset):
-        """Compute the offset of the field @obj in the current structure
-        (packed form)"""
-        return offset
-
-    def struct_compute_align_size(self, _, size):
-        """Compute the alignment and size of the current structure
-        (packed form)"""
-        return 1, size
-
-    def union_compute_align_size(self, align_max, size):
-        """Compute the alignment and size of the current union
-        (packed form)"""
-        return 1, size
+            ret = self.ast_parse_declaration(ext)


### PR DESCRIPTION
This PR fixes a design error in C objects representation
It can now parse various structures (EFI, winddk, winbase, ...)

Note: The function ABI declaration is supported, using `__cdecl__` or `__stdcall__`. To have this feature, you need at least pycparser version `516af9479b9bf23569024bf38e8f7cf2681f768c`.
 