### PR TITLE
Raise a RuntimeError (as before) when addr is not found

### DIFF
--- a/miasm2/jitter/vm_mngr_py.c
+++ b/miasm2/jitter/vm_mngr_py.c
@@ -235,7 +235,7 @@ PyObject* vm_get_mem(VmMngr* self, PyObject* args)
 
        ret = vm_read_mem(&self->vm_mngr, addr, &buf_out, size);
        if (ret < 0) {
-	       RAISE(PyExc_TypeError,"Cannot find address");
+	       RAISE(PyExc_RuntimeError,"Cannot find address");
        }
 
        obj_out = PyString_FromStringAndSize(buf_out, size);


### PR DESCRIPTION
A typo in e1c0d1f03a6e245cb5cbceac72231f1317cc4173 had replace a `RuntimeError` by a `TypeError` when an address is not found on `vm.get_mem`, leaving a misleading error.