### PR TITLE
Ensure there is no multi-line basic block in the cache

### DIFF
--- a/miasm2/analysis/dse.py
+++ b/miasm2/analysis/dse.py
@@ -185,6 +185,9 @@ class DSEEngine(object):
         self.jitter.jit.set_options(max_exec_per_call=1, jit_maxline=1)
         self.jitter.exec_cb = self.callback
 
+        # Clean jit cache to avoid multi-line basic blocks already jitted
+        self.jitter.jit.lbl2jitbloc.clear()
+
     def attach(self, emulator):
         """Attach the DSE to @emulator
         @emulator: jitload (or API equivalent) instance"""


### PR DESCRIPTION
If there was any, the callback may be called after the execution of
several instruction, instead of the expected one-by-one