### PR TITLE
Display expr

### DIFF
--- a/example/ida/utils.py
+++ b/example/ida/utils.py
@@ -3,7 +3,8 @@ from idc import *
 
 from miasm2.analysis.machine import Machine
 from miasm2.ir.translators import Translator
-import miasm2.expression.expression as m2_expr
+from miasm2.expression.expression import ExprInt, ExprId, ExprSlice, ExprMem, \
+    ExprCond, ExprCompose, ExprOp, ExprAff
 
 def max_size_to_size(max_size):
     for size in [16, 32, 64]:
@@ -66,62 +67,89 @@ def guess_machine():
     return machine
 
 
+class ExprInt_ida(ExprInt):
+    def __str__(self):
+        return idaapi.COLSTR(super(ExprInt_ida, self).__str__(), idaapi.SCOLOR_NUMBER)
+
+class ExprId_ida(ExprId):
+    def __str__(self):
+        out = super(ExprId_ida, self).__str__()
+        expr = ExprId(self.name, self.size)
+        if expr in self.regs_ids:
+            return idaapi.COLSTR(out, idaapi.SCOLOR_REG)
+        else:
+            return out
+
+class ExprSlice_ida(ExprSlice):
+    def __str__(self):
+        s = "%s[%s:%s]" % (self.arg._str_sub_expr(self),
+                           idaapi.COLSTR(str(self.start),
+                                         idaapi.SCOLOR_RPTCMT),
+                           idaapi.COLSTR(str(self.stop),
+                                         idaapi.SCOLOR_RPTCMT))
+        return s
+
+class ExprMem_ida(ExprMem):
+    def __str__(self):
+        return '%s[%s]' % (idaapi.COLSTR('@' + str(self.size),
+                                         idaapi.SCOLOR_RPTCMT),
+                           self.arg)
+
+class ExprCond_ida(ExprCond):
+    pass
+
+class ExprCompose_ida(ExprCompose):
+    def __str__(self):
+        s = '{'
+        s += ", ".join("%s, %s, %s" % (subexpr,
+                                       idaapi.COLSTR(str(idx),
+                                                     idaapi.SCOLOR_RPTCMT),
+                                       idaapi.COLSTR(str(idx + subexpr.size),
+                                                     idaapi.SCOLOR_RPTCMT))
+                       for idx, subexpr in self.iter_args())
+        s += '}'
+        return s
+
+class ExprOp_ida(ExprOp):
+    pass
+
+class ExprAff_ida(ExprAff):
+    pass
+
+def expr2exprida(regs_ids, expr):
+    """Translate an Expr into an ExprIda
+    @regs_ids: list of ExprId corresponding to available registers
+    @expr: Expr instance to transform
+    """
+
+    if expr.is_int():
+        new_expr = ExprInt_ida(expr.arg, expr.size)
+    elif expr.is_id():
+        new_expr =  ExprId_ida(expr.name, expr.size)
+    elif expr.is_slice():
+        new_expr =  ExprSlice_ida(expr2exprida(regs_ids, expr.arg), expr.start, expr.stop)
+    elif expr.is_mem():
+        new_expr =  ExprMem_ida(expr2exprida(regs_ids, expr.arg), expr.size)
+    elif expr.is_cond():
+        new_expr =  ExprCond_ida(expr2exprida(regs_ids, expr.cond),
+                                 expr2exprida(regs_ids, expr.src1),
+                                 expr2exprida(regs_ids, expr.src2))
+    elif expr.is_compose():
+        new_expr =  ExprCompose_ida(*[expr2exprida(regs_ids, arg) for arg in expr.args])
+    elif expr.is_op():
+        new_expr =  ExprOp_ida(expr.op, *[expr2exprida(regs_ids, arg) for arg in expr.args])
+    elif expr.is_aff():
+        new_expr =  ExprMem_ida(expr2exprida(regs_ids, expr.dst),
+                                expr2exprida(regs_ids, expr.src))
+    new_expr.regs_ids = regs_ids
+    return new_expr
+
 def expr2colorstr(regs_ids, expr):
     """Colorize an Expr instance for IDA
     @regs_ids: list of ExprId corresponding to available registers
     @expr: Expr instance to colorize
     """
-
-    if isinstance(expr, m2_expr.ExprId):
-        s = str(expr)
-        if expr in regs_ids:
-            s = idaapi.COLSTR(s, idaapi.SCOLOR_REG)
-    elif isinstance(expr, m2_expr.ExprInt):
-        s = str(expr)
-        s = idaapi.COLSTR(s, idaapi.SCOLOR_NUMBER)
-    elif isinstance(expr, m2_expr.ExprMem):
-        s = '%s[%s]' % (idaapi.COLSTR('@' + str(expr.size),
-                                      idaapi.SCOLOR_RPTCMT),
-                         expr2colorstr(regs_ids, expr.arg))
-    elif isinstance(expr, m2_expr.ExprOp):
-        out = []
-        for a in expr.args:
-            s = expr2colorstr(regs_ids, a)
-            if isinstance(a, m2_expr.ExprOp):
-                s = "(%s)" % s
-            out.append(s)
-        if len(out) == 1:
-            s = "%s %s" % (expr.op, str(out[0]))
-        else:
-            s = (" " + expr.op + " ").join(out)
-    elif isinstance(expr, m2_expr.ExprAff):
-        s = "%s = %s" % (
-            expr2colorstr(regs_ids, expr.dst), expr2colorstr(regs_ids, expr.src))
-    elif isinstance(expr, m2_expr.ExprCond):
-        cond = expr2colorstr(regs_ids, expr.cond)
-        src1 = expr2colorstr(regs_ids, expr.src1)
-        src2 = expr2colorstr(regs_ids, expr.src2)
-        s = "(%s?%s:%s)" % (cond, src1, src2)
-    elif isinstance(expr, m2_expr.ExprSlice):
-        s = "(%s)[%s:%s]" % (expr2colorstr(regs_ids, expr.arg),
-                             idaapi.COLSTR(str(expr.start),
-                                           idaapi.SCOLOR_RPTCMT),
-                             idaapi.COLSTR(str(expr.stop),
-                                           idaapi.SCOLOR_RPTCMT))
-    elif isinstance(expr, m2_expr.ExprCompose):
-        s = "{"
-        s += ", ".join(["%s, %s, %s" % (expr2colorstr(regs_ids, subexpr),
-                                        idaapi.COLSTR(str(idx),
-                                                      idaapi.SCOLOR_RPTCMT),
-                                        idaapi.COLSTR(str(idx + subexpr.size),
-                                                      idaapi.SCOLOR_RPTCMT))
-                        for idx, subexpr in expr.iter_args()])
-        s += "}"
-    else:
-        s = str(expr)
-
-    return s
-
+    return str(expr2exprida(regs_ids, expr))
 
 class translatorForm(idaapi.Form):
     """Translator Form.


### PR DESCRIPTION
```
@64[(RSP+0x8)] = RBX

@64[(RSP+0x18)] = RSI

RSP = (RSP+(- 0x8))
@64[(RSP+(- 0x8))] = RDI

af = ((RSP^0x30)^(RSP+(- 0x30)))[4:5]
pf = parity(((RSP+(- 0x30))&0xFF))

```

is replaced by:

```
@64[RSP+0x8] = RBX

@64[RSP+0x18] = RSI

RSP = RSP+(-0x8)
@64[RSP+(-0x8)] = RDI

af = ((RSP^0x30)^(RSP+(-0x30)))[4:5]
pf = parity((RSP+(-0x30))&0xFF)
```
