### PR TITLE
Fix/blockhash multiarch

### DIFF
--- a/miasm2/jitter/jitcore.py
+++ b/miasm2/jitter/jitcore.py
@@ -15,6 +15,8 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+from hashlib import md5
+
 from miasm2.core import asmblock
 from miasm2.core.interval import interval
 from miasm2.core.utils import BoundedDict
@@ -267,3 +269,15 @@ class JitCore(object):
         for addr_start, addr_stop in vm.get_memory_write():
             mem_range.append((addr_start, addr_stop))
         self.updt_automod_code_range(vm, mem_range)
+
+    def hash_block(self, block):
+        """
+        Build a hash of the block @block
+        @block: asmblock
+        """
+        block_raw = "".join(line.b for line in block.lines)
+        block_hash = md5("%X_%s_%s_%s" % (block.label.offset,
+                                          self.log_mn,
+                                          self.log_regs,
+                                          block_raw)).hexdigest()
+        return block_hash

--- a/miasm2/jitter/jitcore.py
+++ b/miasm2/jitter/jitcore.py
@@ -37,6 +37,7 @@ class JitCore(object):
         """
 
         self.ir_arch = ir_arch
+        self.arch_name = "%s%s" % (self.ir_arch.arch.name, self.ir_arch.attrib)
         self.bs = bs
         self.known_blocs = {}
         self.lbl2jitbloc = BoundedDict(self.jitted_block_max_size,
@@ -276,8 +277,9 @@ class JitCore(object):
         @block: asmblock
         """
         block_raw = "".join(line.b for line in block.lines)
-        block_hash = md5("%X_%s_%s_%s" % (block.label.offset,
-                                          self.log_mn,
-                                          self.log_regs,
-                                          block_raw)).hexdigest()
+        block_hash = md5("%X_%s_%s_%s_%s" % (block.label.offset,
+                                             self.arch_name,
+                                             self.log_mn,
+                                             self.log_regs,
+                                             block_raw)).hexdigest()
         return block_hash

--- a/miasm2/jitter/jitcore_cc_base.py
+++ b/miasm2/jitter/jitcore_cc_base.py
@@ -3,7 +3,6 @@
 import os
 import tempfile
 from distutils.sysconfig import get_python_inc
-from hashlib import md5
 
 from miasm2.jitter.jitcore import JitCore
 from miasm2.core.utils import keydefaultdict
@@ -109,15 +108,3 @@ class JitCore_Cc_Base(JitCore):
     @staticmethod
     def gen_C_source(ir_arch, func_code):
         raise NotImplementedError()
-
-    def hash_block(self, block):
-        """
-        Build a hash of the block @block
-        @block: asmblock
-        """
-        block_raw = "".join(line.b for line in block.lines)
-        block_hash = md5("%X_%s_%s_%s" % (block.label.offset,
-                                          self.log_mn,
-                                          self.log_regs,
-                                          block_raw)).hexdigest()
-        return block_hash

--- a/miasm2/jitter/jitcore_llvm.py
+++ b/miasm2/jitter/jitcore_llvm.py
@@ -1,7 +1,7 @@
 import os
 import importlib
 import tempfile
-from hashlib import md5
+
 from miasm2.jitter.llvmconvert import *
 import miasm2.jitter.jitcore as jitcore
 import Jitllvm
@@ -117,15 +117,3 @@ class JitCore_LLVM(jitcore.JitCore):
 
         # Store a pointer on the function jitted code
         self.lbl2jitbloc[block.label.offset] = ptr
-
-    def hash_block(self, block):
-        """
-        Build a hash of the block @block
-        @block: asmblock
-        """
-        block_raw = "".join(line.b for line in block.lines)
-        block_hash = md5("%X_%s_%s_%s" % (block.label.offset,
-                                          self.log_mn,
-                                          self.log_regs,
-                                          block_raw)).hexdigest()
-        return block_hash


### PR DESCRIPTION
Avoid a collision when 2 blocks come from different architecture.

Example: a block of `PUSH XXX` on x86 32/64