### PR TITLE
Fix/dse regs

### DIFF
--- a/miasm2/arch/x86/regs.py
+++ b/miasm2/arch/x86/regs.py
@@ -425,8 +425,8 @@ all_regs_ids_no_alias = [
 ] + fltregs32_expr
 
 attrib_to_regs = {
-    16: regs16_expr + all_regs_ids_no_alias[all_regs_ids_no_alias.index(zf):],
-    32: regs32_expr + all_regs_ids_no_alias[all_regs_ids_no_alias.index(zf):],
+    16: regs16_expr + all_regs_ids_no_alias[all_regs_ids_no_alias.index(zf):] + [IP],
+    32: regs32_expr + all_regs_ids_no_alias[all_regs_ids_no_alias.index(zf):] + [EIP],
     64: all_regs_ids_no_alias,
 }
 


### PR DESCRIPTION
DSE was using `cpu.get_gpregs`/ `cpu.set_gpregs` which use the jitter internal representation of regs (ie `RIP` in x86-32).
It now uses the registers corresponding to the architecture used.

Side effect: fix the snapshot for x86-32