### PR TITLE
Fix/aarch64 imm decode

### DIFF
--- a/miasm2/arch/aarch64/arch.py
+++ b/miasm2/arch/aarch64/arch.py
@@ -1074,17 +1074,6 @@ def rol(value, amount, size):
     mask = (1 << size) - 1
     return ((value << amount) | (value >> (size - amount)) & mask)
 
-UINTS = {32: uint32, 64: uint64}
-
-
-def imm_to_imm_rot_form(value, size):
-    for i in xrange(0, size):
-        mod_value = int(rol(value, i, size))
-        if (mod_value + 1) & mod_value == 0:
-            return i
-    return None
-
-
 # This implementation is inspired from ARM ISA v8.2
 # Exact Reference name:
 # "ARM Architecture Reference Manual ARMv8, for ARMv8-A architecture profile"

--- a/miasm2/arch/aarch64/arch.py
+++ b/miasm2/arch/aarch64/arch.py
@@ -1066,11 +1066,13 @@ class aarch64_gpreg_sftimm(reg_noarg, m_arg):
 
 
 def ror(value, amount, size):
-    return (value >> amount) | (value << (size - amount))
+    mask = (1 << size) - 1
+    return ((value >> amount) | (value << (size - amount))) & mask
 
 
 def rol(value, amount, size):
-    return (value << amount) | (value >> (size - amount))
+    mask = (1 << size) - 1
+    return ((value << amount) | (value >> (size - amount)) & mask)
 
 UINTS = {32: uint32, 64: uint64}
 

--- a/test/arch/aarch64/arch.py
+++ b/test/arch/aarch64/arch.py
@@ -1786,6 +1786,10 @@ reg_tests_aarch64 = [
      "E003809A"),
     ("XXXXXXXX    ADD        X0, SP, XZR UXTX 0x0",
      "E0633F8B"),
+
+    ("XXXXXXXX    ORR        X8, 0x0, 0x1000100010001",
+     "E88300B2"),
+
 ]
 
 


### PR DESCRIPTION
Enhance imm decoding for `ORR/AND/...`, and add its corresponding encoding routine.