### PR TITLE
Asmblock: remove disasm engine job_done attribute

### DIFF
--- a/example/disasm/callback.py
+++ b/example/disasm/callback.py
@@ -54,9 +54,6 @@ cb_x86_funcs.append(cb_x86_callpop)
 ## Other method:
 ## mdis.dis_bloc_callback = cb_x86_callpop
 
-# Clean disassembly cache
-mdis.job_done.clear()
-
 print "=" * 40
 print "With callback:\n"
 blocks_after = mdis.dis_multiblock(0)

--- a/example/ida/ctype_propagation.py
+++ b/example/ida/ctype_propagation.py
@@ -57,7 +57,6 @@ Dependency Graph Settings
 
 def get_block(ir_arch, mdis, addr):
     """Get IRBlock at address @addr"""
-    mdis.job_done.clear()
     lbl = ir_arch.get_label(addr)
     if not lbl in ir_arch.blocks:
         block = mdis.dis_block(lbl.offset)

--- a/miasm2/analysis/dse.py
+++ b/miasm2/analysis/dse.py
@@ -297,7 +297,6 @@ class DSEEngine(object):
         else:
 
             ## Reset cache structures
-            self.mdis.job_done.clear()
             self.ir_arch.blocks.clear()# = {}
 
             ## Update current state

--- a/miasm2/jitter/jitcore.py
+++ b/miasm2/jitter/jitcore.py
@@ -47,7 +47,6 @@ class JitCore(object):
         self.log_regs = False
         self.log_newbloc = False
         self.segm_to_do = set()
-        self.job_done = set()
         self.jitcount = 0
         self.addr2obj = {}
         self.addr2objref = {}
@@ -140,7 +139,6 @@ class JitCore(object):
             addr = addr.offset
 
         # Prepare disassembler
-        self.mdis.job_done.clear()
         self.mdis.lines_wd = self.options["jit_maxline"]
         self.mdis.dis_bloc_callback = self.disasm_cb
 

--- a/test/core/asmblock.py
+++ b/test/core/asmblock.py
@@ -19,12 +19,16 @@ first_block = mdis.dis_block(0)
 assert len(first_block.lines) == 5
 print first_block
 
+## Test redisassemble blocks
+first_block_bis = mdis.dis_block(0)
+assert len(first_block.lines) == len(first_block_bis.lines)
+print first_block_bis
+
 ## Disassembly of several block, with cache
 blocks = mdis.dis_multiblock(0)
-assert len(blocks) == 0
+assert len(blocks) == 17
 
-## Test cache
-mdis.job_done.clear()
+## Test redisassemble blocks
 blocks = mdis.dis_multiblock(0)
 assert len(blocks) == 17
 ## Equality between assembly lines is not yet implemented


### PR DESCRIPTION
WARNING: disasmEngine behaviour modification

Before patch: job_done containted the already disassembled addresses. If the
user disassembled twice the same addresse, the engine will return empty
object on the second call.

After patch: If the user disassemble twice the same addresse, the engine will
return result of the disassembling in both cases.