### PR TITLE
Various Win32 API additions/fixes

### DIFF
--- a/miasm2/os_dep/common.py
+++ b/miasm2/os_dep/common.py
@@ -79,7 +79,25 @@ class heap(object):
         return addr
 
     def get_size(self, vm, ptr):
-        return vm.get_all_memory()[ptr]["size"]
+        """
+        @vm: a VmMngr instance
+        @size: ptr to get the size of the associated allocation.
+        
+        `ptr` can be the base address of a previous allocation, or an address
+        within the allocated range. The size of the whole allocation is always
+        returned, regardless ptr is the base address or not.
+        """
+	assert vm.is_mapped(ptr, 1)
+	data = vm.get_all_memory()
+	ptr_page = data.get(ptr, None)
+	if ptr_page is None:
+	    for address, page_info in data.iteritems():
+		if address <= ptr < address + page_info["size"]:
+		    ptr_page = page_info
+		    break
+	    else:
+		raise RuntimeError("Must never happen (unmapped but mark as mapped by API)")
+	return ptr_page["size"]
 
 
 def windows_to_sbpath(path):

--- a/miasm2/os_dep/linux_stdlib.py
+++ b/miasm2/os_dep/linux_stdlib.py
@@ -4,6 +4,7 @@ from sys import stdout
 from string import printable
 
 from miasm2.os_dep.common import heap
+from miasm2.os_dep.common import get_fmt_args as _get_fmt_args
 
 
 class c_linobjs(object):
@@ -104,28 +105,7 @@ def xxx_puts(jitter):
 
 
 def get_fmt_args(jitter, fmt, cur_arg):
-    output = ""
-    while True:
-        char = jitter.vm.get_mem(fmt, 1)
-        fmt += 1
-        if char == '\x00':
-            break
-        if char == '%':
-            token = '%'
-            while True:
-                char = jitter.vm.get_mem(fmt, 1)
-                fmt += 1
-                token += char
-                if char.lower() in '%cdfsux':
-                    break
-            if token.endswith('s'):
-                arg = jitter.get_str_ansi(jitter.get_arg_n_systemv(cur_arg))
-            else:
-                arg = jitter.get_arg_n_systemv(cur_arg)
-            char = token % arg
-            cur_arg += 1
-        output += char
-    return output
+    return _get_fmt_args(fmt, cur_arg, jitter.get_str_ansi, jitter.get_arg_n_systemv)
 
 
 def xxx_snprintf(jitter):

--- a/test/os_dep/common.py
+++ b/test/os_dep/common.py
@@ -1,0 +1,35 @@
+#! /usr/bin/env python2
+#-*- coding:utf-8 -*-
+
+import unittest
+import logging
+from miasm2.analysis.machine import Machine
+import miasm2.os_dep.common as commonapi
+from miasm2.core.utils import pck32
+from miasm2.jitter.csts import PAGE_READ, PAGE_WRITE
+
+machine = Machine("x86_32")
+
+jit = machine.jitter()
+jit.init_stack()
+
+class TestCommonAPI(unittest.TestCase):
+
+    def test_get_size(self):
+        heap = commonapi.heap()
+        with self.assertRaises(AssertionError):
+            heap.get_size(jit.vm, 0)
+        heap.alloc(jit, 20)
+        heap.alloc(jit, 40)
+        heap.alloc(jit, 50)
+        heap.alloc(jit, 60)
+        ptr = heap.alloc(jit, 10)
+        heap.alloc(jit, 80)
+        for i in xrange(10):
+            self.assertEqual(heap.get_size(jit.vm, ptr+i), 10)
+
+if __name__ == '__main__':
+    testsuite = unittest.TestLoader().loadTestsFromTestCase(TestCommonAPI)
+    report = unittest.TextTestRunner(verbosity=2).run(testsuite)
+    exit(len(report.errors + report.failures))
+

--- a/test/os_dep/linux/stdlib.py
+++ b/test/os_dep/linux/stdlib.py
@@ -1,0 +1,43 @@
+#! /usr/bin/env python2
+#-*- coding:utf-8 -*-
+
+import unittest
+import logging
+from miasm2.analysis.machine import Machine
+import miasm2.os_dep.linux_stdlib as stdlib
+from miasm2.core.utils import pck32
+from miasm2.jitter.csts import PAGE_READ, PAGE_WRITE
+
+machine = Machine("x86_32")
+
+jit = machine.jitter()
+jit.init_stack()
+
+heap = stdlib.linobjs.heap
+
+class TestLinuxStdlib(unittest.TestCase):
+
+    def test_xxx_sprintf(self):
+        def alloc_str(s):
+            s += "\x00"
+            ptr = heap.alloc(jit, len(s))
+            jit.vm.set_mem(ptr, s)
+            return ptr
+        fmt  = alloc_str("'%s' %d")
+        str_ = alloc_str("coucou")
+        buf = heap.alloc(jit,1024)
+
+        jit.push_uint32_t(1111)
+        jit.push_uint32_t(str_)
+        jit.push_uint32_t(fmt)
+        jit.push_uint32_t(buf)
+        jit.push_uint32_t(0) # ret_ad
+        stdlib.xxx_sprintf(jit)
+        ret = jit.get_str_ansi(buf)
+        self.assertEqual(ret, "'coucou' 1111")
+
+
+if __name__ == '__main__':
+    testsuite = unittest.TestLoader().loadTestsFromTestCase(TestLinuxStdlib)
+    report = unittest.TextTestRunner(verbosity=2).run(testsuite)
+    exit(len(report.errors + report.failures))

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -265,7 +265,9 @@ testset += RegressionTest(["z3_ir.py"], base_dir="ir/translators",
 testset += RegressionTest(["smt2.py"], base_dir="ir/translators",
                           tags=[TAGS["z3"]])
 ## OS_DEP
-for script in ["win_api_x86_32.py",
+for script in ["common.py",
+               "win_api_x86_32.py",
+               os.path.join("linux", "stdlib.py"),
                ]:
     testset += RegressionTest([script], base_dir="os_dep", tags=[TAGS['gcc']])
 


### PR DESCRIPTION
This PR contains various Win32 API additions/fixes:
* add a get_size method to Miasm heap object, which allows the
implementation of mscvrt_realloc
* add the concept of "current directory", with the default value being
arbitrary set to "c:\tmp", which allows the implementation of
{Get,Set}CurrentDirecrtory

Various other methods implemented:

 - advapi32_RegCloseKey
 - advapi32_RegCreateKeyW
 - advapi32_RegSetValueExA
 - advapi32_RegSetValueExW
 - kernel32_GetProcessHeap
 - msvcrt_delete
 - msvcrt_fprintf
 - msvcrt_fwrite
 - msvcrt__mbscpy
 - msvcrt_new
 - msvcrt_realloc
 - msvcrt_sprintf
 - msvcrt_srand
 - msvcrt_strrchr
 - msvcrt_swprintf
 - msvcrt_wcscat
 - msvcrt_wcscmp
 - msvcrt_wcscpy
 - msvcrt__wcsicmp
 - msvcrt_wcslen
 - msvcrt_wcsncpy
 - msvcrt__wcsnicmp
 - msvcrt_wcsrchr