### PR TITLE
DiGraph: fixed node order in natural loop backedges

### DIFF
--- a/miasm2/core/graph.py
+++ b/miasm2/core/graph.py
@@ -523,7 +523,7 @@ class DiGraph(object):
         """
         for a, b in self.compute_back_edges(head):
             body = self._compute_natural_loop_body(b, a)
-            yield ((b, a), body)
+            yield ((a, b), body)
 
     def compute_back_edges(self, head):
         """

--- a/test/core/graph.py
+++ b/test/core/graph.py
@@ -184,8 +184,8 @@ g3.add_edge(7, 8)
 g3.add_edge(8, 7)
 
 loops = set([(backedge, frozenset(body)) for backedge, body in g3.compute_natural_loops(1)])
-assert(loops == {((1, 9), frozenset({1, 2, 4, 5, 9})),
-                 ((2, 9), frozenset({2, 4, 5, 9}))})
+assert(loops == {((9, 1), frozenset({1, 2, 4, 5, 9})),
+                 ((9, 2), frozenset({2, 4, 5, 9}))})
 
 sccs = set([frozenset(scc) for scc in g3.compute_strongly_connected_components()])
 assert(sccs == {frozenset({6}),


### PR DESCRIPTION
just noticed that the returned back edge wasn't a back edge :D