### PR TITLE
Pure python miasm install (with no jitter engine)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,8 @@ def buil_all():
     print 'building'
     build_ok = False
     for name, ext_modules in [('all', ext_modules_all),
-                              ('notcc', ext_modules_no_tcc)]:
+                              ('notcc', ext_modules_no_tcc),
+                              ('novm', [])]:
         print 'build with', repr(name)
         try:
             s = setup(


### PR DESCRIPTION
This can be useful to run pure symbolic executions with other Python
implementations that do not support the CPython API (like Pypy)!

"Interesting" thing is that running a full symbolic execution of a kind of complex function is *slower* (like x3.5 slower on one example) using Pypy than the original CPython interpreter. One guess is that the benefits are visible if we emulate bigger functions or lots of them. It could also be interesting to try and have some kind of "Miasm" daemon that keeps the jitted code :) Or maybe the miasm code isn't just very "jitter"-friendly!

I think it can still be interesting to have this feature for future tests!