### PR TITLE
Use ExprCond for {f,}cmov and do not generate a new block

### DIFF
--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -261,17 +261,12 @@ def gen_fcmov(ir, instr, cond, arg1, arg2, mov_if):
     @cond: condition
     @mov_if: invert condition if False"""
 
-    lbl_do = m2_expr.ExprId(ir.gen_label(), ir.IRDst.size)
-    lbl_skip = m2_expr.ExprId(ir.get_next_label(instr), ir.IRDst.size)
     if mov_if:
-        dstA, dstB = lbl_do, lbl_skip
+        dstA, dstB = arg2, arg1
     else:
-        dstA, dstB = lbl_skip, lbl_do
-    e = []
-    e_do, extra_irs = [m2_expr.ExprAff(arg1, arg2)], []
-    e_do.append(m2_expr.ExprAff(ir.IRDst, lbl_skip))
-    e.append(m2_expr.ExprAff(ir.IRDst, m2_expr.ExprCond(cond, dstA, dstB)))
-    return e, [IRBlock(lbl_do.name, [AssignBlock(e_do, instr)])]
+        dstA, dstB = arg1, arg2
+    e = [m2_expr.ExprAff(arg1, m2_expr.ExprCond(cond, dstA, dstB))]
+    return e, []
 
 
 def gen_cmov(ir, instr, cond, dst, src, mov_if):
@@ -281,17 +276,16 @@ def gen_cmov(ir, instr, cond, dst, src, mov_if):
     @cond: condition
     @mov_if: invert condition if False"""
 
-    lbl_do = m2_expr.ExprId(ir.gen_label(), ir.IRDst.size)
-    lbl_skip = m2_expr.ExprId(ir.get_next_label(instr), ir.IRDst.size)
+    if dst in [ES, CS, SS, DS, FS, GS]:
+        src = src[:dst.size]
+    if src in [ES, CS, SS, DS, FS, GS]:
+        src = src.zeroExtend(dst.size)
     if mov_if:
-        dstA, dstB = lbl_do, lbl_skip
+        dstA, dstB = src,dst 
     else:
-        dstA, dstB = lbl_skip, lbl_do
-    e = []
-    e_do, extra_irs = mov(ir, instr, dst, src)
-    e_do.append(m2_expr.ExprAff(ir.IRDst, lbl_skip))
-    e.append(m2_expr.ExprAff(ir.IRDst, m2_expr.ExprCond(cond, dstA, dstB)))
-    return e, [IRBlock(lbl_do.name, [AssignBlock(e_do, instr)])]
+        dstA, dstB = dst,src 
+    e = [m2_expr.ExprAff(dst, m2_expr.ExprCond(cond, dstA, dstB))]
+    return e, []
 
 
 def mov(_, instr, dst, src):


### PR DESCRIPTION
This makes symbolic emulation really much faster on codes where a lot of
cmov happen (like some code from some grehack challenge ;))! I think the performance gain comes from the fact that we do not need to "clone" the symbolic state and execute two branches just for a cmov operation.

One other way to do this I think if we want to keep the branch associated with a ``cmov`` operation is to have some kind of pre-optimisation of the CFG where small if-then-else subgraphs could be "pre-computed" and replaced by ``ExprCond`` expressions! This would have the advantage to be generic and potentially optimize more code for full symbolic executions.