### PR TITLE
Fix/support llvmlite 0.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,22 @@
 sudo: false
+dist: trusty
 language: python
 python:
 - "2.7"
 addons:
     apt:
-        sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test']
+        sources: ['llvm-toolchain-trusty-4.0', 'ubuntu-toolchain-r-test']
         packages:
             - make
             - gcc
             - python-virtualenv
             - unzip
-            - llvm-3.8
-            - llvm-3.8-dev
+            - llvm-4.0
+            - llvm-4.0-dev
             - g++-5
 before_script:
 - "cd .."
-- "export LLVM_CONFIG=$(which llvm-config-3.8)"
+- "export LLVM_CONFIG=$(which llvm-config-4.0)"
 - "export CXX=$(which g++-5)"
 # make virtual env
 - "python /usr/lib/python2.7/dist-packages/virtualenv.py virtualenv;"
@@ -27,11 +28,9 @@ before_script:
 - "make && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd);cd ..;"
 - "cp tinycc/libtcc.h include"
 - "cp tinycc/libtcc.so.1.0 tinycc/libtcc.so"
-# install llvmlite, using the system libdtc++ instead of statically linking it
+# install llvmlite
 - "pip install enum34"
-- "git clone https://github.com/numba/llvmlite llvmlite && cd llvmlite && git checkout 95d8c7c"
-- "sed -i 's/-static-libstdc++ //' ffi/Makefile.linux"
-- "python setup.py install && cd .."
+- "pip install llvmlite"
 # install elfesteem
 - "git clone https://github.com/serpilliere/elfesteem elfesteem && cd elfesteem && python setup.py install && cd ..;"
 # install pyparsing

--- a/miasm2/jitter/llvmconvert.py
+++ b/miasm2/jitter/llvmconvert.py
@@ -571,14 +571,14 @@ class LLVMFunction():
 
         base_name = "printf_format"
         count = 0
-        while self.mod.get_global("%s_%d" % (base_name, count)):
+        while "%s_%d" % (base_name, count) in self.mod.globals:
             count += 1
         global_fmt = self.global_constant("%s_%d" % (base_name, count),
                                           fmt_bytes)
         fnty = llvm_ir.FunctionType(llvm_ir.IntType(32), [cstring],
                                     var_arg=True)
         # Insert printf()
-        fn = mod.get_global('printf')
+        fn = mod.globals.get('printf', None)
         if fn is None:
             fn = llvm_ir.Function(mod, fnty, name="printf")
         # Call


### PR DESCRIPTION
Fix #630 

LLVMlite globals management has changed (`KeyError` instead of returning `False` on miss).
This PR:
* Update the corresponding API calls
* Switch to pip LLVMlite version in Travis CI to follow the README
* Use `trusty` distrib to obtain the required LLVM-4.0 toolchain