### PR TITLE
Travis: switch to llvm-5.0 for LLVMLite 0.21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,18 @@ python:
 - "2.7"
 addons:
     apt:
-        sources: ['llvm-toolchain-trusty-4.0', 'ubuntu-toolchain-r-test']
+        sources: ['llvm-toolchain-trusty-5.0', 'ubuntu-toolchain-r-test']
         packages:
             - make
             - gcc
             - python-virtualenv
             - unzip
-            - llvm-4.0
-            - llvm-4.0-dev
+            - llvm-5.0
+            - llvm-5.0-dev
             - g++-5
 before_script:
 - "cd .."
-- "export LLVM_CONFIG=$(which llvm-config-4.0)"
+- "export LLVM_CONFIG=$(which llvm-config-5.0)"
 - "export CXX=$(which g++-5)"
 # make virtual env
 - "python /usr/lib/python2.7/dist-packages/virtualenv.py virtualenv;"


### PR DESCRIPTION
LLVMLite is now in version 0.21, and requires LLVM-5.0.

Should fix #642 regression test error