### PR TITLE
Fix BSR / BSL / CLZ implementation to avoid signed overflow

### DIFF
--- a/miasm2/jitter/arch/JitCore_arm.c
+++ b/miasm2/jitter/arch/JitCore_arm.c
@@ -207,7 +207,7 @@ uint32_t clz(uint32_t arg)
 	int i;
 
 	for (i=0; i<32; i++) {
-		if (arg & (1 << (31-i)))
+		if (arg & (1ull << (31-i)))
 			break;
 	}
 	return i;

--- a/miasm2/jitter/vm_mngr.c
+++ b/miasm2/jitter/vm_mngr.c
@@ -843,24 +843,23 @@ unsigned int rcr_rez_op(unsigned int size, unsigned int a, unsigned int b, unsig
     return tmp;
 }
 
-unsigned int x86_bsr(unsigned int size, uint64_t src)
+unsigned int x86_bsr(uint64_t size, uint64_t src)
 {
-	int i;
+	uint64_t i;
 
 	for (i=size-1; i>=0; i--){
-		if (src & (1<<i))
+		if (src & (1ull << i))
 			return i;
 	}
 	fprintf(stderr, "sanity check error bsr\n");
 	exit(0);
 }
 
-unsigned int x86_bsf(unsigned int size, uint64_t src)
+unsigned int x86_bsf(uint64_t size, uint64_t src)
 {
-	int i;
-
+	uint64_t i;
 	for (i=0; i<size; i++){
-		if (src & (1<<i))
+		if (src & (1ull << i))
 			return i;
 	}
 	fprintf(stderr, "sanity check error bsf\n");


### PR DESCRIPTION
Avoid unwanted behavior when `i` reach too high value (`1` being signed, `1 << 32` ends up with a `0xffffffff....` value, breaking the expected mask comparison.