### PR TITLE
Add SSE instructions

### DIFF
--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4488,6 +4488,10 @@ addop("pmulhw", [bs8(0x0f), bs8(0xe5), no_xmm_pref] +
       rmmod(mm_reg, rm_arg_mm_m64))
 addop("pmulhw", [bs8(0x0f), bs8(0xe5), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128))
+addop("pmuludq", [bs8(0x0f), bs8(0xf4), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("pmuludq", [bs8(0x0f), bs8(0xf4), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
 
 
 addop("psubusb", [bs8(0x0f), bs8(0xd8), no_xmm_pref] +

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4476,6 +4476,15 @@ addop("pmullw", [bs8(0x0f), bs8(0xd5), no_xmm_pref] +
       rmmod(mm_reg, rm_arg_mm_m64))
 addop("pmullw", [bs8(0x0f), bs8(0xd5), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128))
+addop("pmulhuw", [bs8(0x0f), bs8(0xe4), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("pmulhuw", [bs8(0x0f), bs8(0xe4), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+addop("pmulhw", [bs8(0x0f), bs8(0xe5), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("pmulhw", [bs8(0x0f), bs8(0xe5), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+
 
 addop("psubusb", [bs8(0x0f), bs8(0xd8), no_xmm_pref] +
       rmmod(mm_reg, rm_arg_mm_m64))

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4534,6 +4534,11 @@ addop("pmaddwd", [bs8(0x0f), bs8(0xf5), no_xmm_pref] +
 addop("pmaddwd", [bs8(0x0f), bs8(0xf5), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128))
 
+addop("psadbw", [bs8(0x0f), bs8(0xf6), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("psadbw", [bs8(0x0f), bs8(0xf6), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+
 mn_x86.bintree = factor_one_bit(mn_x86.bintree)
 # mn_x86.bintree = factor_fields_all(mn_x86.bintree)
 """

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4548,6 +4548,12 @@ addop("pavgw", [bs8(0x0f), bs8(0xe3), no_xmm_pref] +
 addop("pavgw", [bs8(0x0f), bs8(0xe3), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128))
 
+addop("maskmovq", [bs8(0x0f), bs8(0xf7), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_reg))
+addop("maskmovdqu", [bs8(0x0f), bs8(0xf7), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_reg))
+
+
 mn_x86.bintree = factor_one_bit(mn_x86.bintree)
 # mn_x86.bintree = factor_fields_all(mn_x86.bintree)
 """

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4453,6 +4453,11 @@ addop("aesdec", [bs8(0x0f), bs8(0x38), bs8(0xde), pref_66] + rmmod(xmm_reg, rm_a
 addop("aesenclast", [bs8(0x0f), bs8(0x38), bs8(0xdd), pref_66] + rmmod(xmm_reg, rm_arg_xmm))
 addop("aesdeclast", [bs8(0x0f), bs8(0x38), bs8(0xdf), pref_66] + rmmod(xmm_reg, rm_arg_xmm))
 
+addop("packsswb", [bs8(0x0f), bs8(0x63), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("packsswb", [bs8(0x0f), bs8(0x63), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+
 mn_x86.bintree = factor_one_bit(mn_x86.bintree)
 # mn_x86.bintree = factor_fields_all(mn_x86.bintree)
 """

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4539,6 +4539,15 @@ addop("psadbw", [bs8(0x0f), bs8(0xf6), no_xmm_pref] +
 addop("psadbw", [bs8(0x0f), bs8(0xf6), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128))
 
+addop("pavgb", [bs8(0x0f), bs8(0xe0), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("pavgb", [bs8(0x0f), bs8(0xe0), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+addop("pavgw", [bs8(0x0f), bs8(0xe3), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("pavgw", [bs8(0x0f), bs8(0xe3), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+
 mn_x86.bintree = factor_one_bit(mn_x86.bintree)
 # mn_x86.bintree = factor_fields_all(mn_x86.bintree)
 """

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4462,6 +4462,10 @@ addop("packsswb", [bs8(0x0f), bs8(0x63), no_xmm_pref] +
       rmmod(mm_reg, rm_arg_mm_m64))
 addop("packsswb", [bs8(0x0f), bs8(0x63), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128))
+addop("packssdw", [bs8(0x0f), bs8(0x6b), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("packssdw", [bs8(0x0f), bs8(0x6b), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
 
 addop("packuswb", [bs8(0x0f), bs8(0x67), no_xmm_pref] +
       rmmod(mm_reg, rm_arg_mm_m64))

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4477,6 +4477,15 @@ addop("pmullw", [bs8(0x0f), bs8(0xd5), no_xmm_pref] +
 addop("pmullw", [bs8(0x0f), bs8(0xd5), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128))
 
+addop("psubusb", [bs8(0x0f), bs8(0xd8), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("psubusb", [bs8(0x0f), bs8(0xd8), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+addop("psubusw", [bs8(0x0f), bs8(0xd9), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("psubusw", [bs8(0x0f), bs8(0xd9), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+
 
 mn_x86.bintree = factor_one_bit(mn_x86.bintree)
 # mn_x86.bintree = factor_fields_all(mn_x86.bintree)

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4512,6 +4512,14 @@ addop("paddusw", [bs8(0x0f), bs8(0xdd), no_xmm_pref] +
       rmmod(mm_reg, rm_arg_mm_m64))
 addop("paddusw", [bs8(0x0f), bs8(0xdd), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128))
+addop("paddsb", [bs8(0x0f), bs8(0xec), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("paddsb", [bs8(0x0f), bs8(0xec), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+addop("paddsw", [bs8(0x0f), bs8(0xed), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("paddsw", [bs8(0x0f), bs8(0xed), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
 
 
 mn_x86.bintree = factor_one_bit(mn_x86.bintree)

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4339,6 +4339,11 @@ addop("pcmpgtb", [bs8(0x0f), bs8(0x64), no_xmm_pref] +
 addop("pcmpgtb", [bs8(0x0f), bs8(0x64), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm))
 
+addop("pcmpgtw", [bs8(0x0f), bs8(0x65), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm))
+addop("pcmpgtw", [bs8(0x0f), bs8(0x65), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm))
+
 addop("pcmpgtd", [bs8(0x0f), bs8(0x66), no_xmm_pref] +
       rmmod(mm_reg, rm_arg_mm))
 addop("pcmpgtd", [bs8(0x0f), bs8(0x66), pref_66] +

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4432,9 +4432,9 @@ addop("pextrq", [bs8(0x0f), bs8(0x3a), bs8(0x16), pref_66] +
 addop("pextrw", [bs8(0x0f), bs8(0x3a), bs8(0x15), pref_66] +
       rmmod(xmm_reg, rm_arg_reg_m16) + [u08], [rm_arg_reg_m16, xmm_reg, u08])
 addop("pextrw", [bs8(0x0f), bs8(0xc5), no_xmm_pref] +
-      rmmod(mm_reg, rm_arg_reg_m16) + [u08], [rm_arg_reg_m16, mm_reg, u08])
+      rmmod(rmreg, rm_arg_mm) + [u08], [rmreg, rm_arg_mm, u08])
 addop("pextrw", [bs8(0x0f), bs8(0xc5), pref_66] +
-      rmmod(xmm_reg, rm_arg_reg_m16) + [u08], [rm_arg_reg_m16, xmm_reg, u08])
+      rmmod(rmreg, rm_arg_xmm) + [u08], [rmreg, rm_arg_xmm, u08])
 
 
 addop("sqrtpd", [bs8(0x0f), bs8(0x51), pref_66] +

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4529,6 +4529,10 @@ addop("paddsw", [bs8(0x0f), bs8(0xed), no_xmm_pref] +
 addop("paddsw", [bs8(0x0f), bs8(0xed), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128))
 
+addop("pmaddwd", [bs8(0x0f), bs8(0xf5), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("pmaddwd", [bs8(0x0f), bs8(0xf5), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
 
 mn_x86.bintree = factor_one_bit(mn_x86.bintree)
 # mn_x86.bintree = factor_fields_all(mn_x86.bintree)

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4463,6 +4463,11 @@ addop("packsswb", [bs8(0x0f), bs8(0x63), no_xmm_pref] +
 addop("packsswb", [bs8(0x0f), bs8(0x63), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128))
 
+addop("packuswb", [bs8(0x0f), bs8(0x67), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("packuswb", [bs8(0x0f), bs8(0x67), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+
 mn_x86.bintree = factor_one_bit(mn_x86.bintree)
 # mn_x86.bintree = factor_fields_all(mn_x86.bintree)
 """

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4486,6 +4486,15 @@ addop("psubusw", [bs8(0x0f), bs8(0xd9), no_xmm_pref] +
 addop("psubusw", [bs8(0x0f), bs8(0xd9), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128))
 
+addop("paddusb", [bs8(0x0f), bs8(0xdc), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("paddusb", [bs8(0x0f), bs8(0xdc), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+addop("paddusw", [bs8(0x0f), bs8(0xdd), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("paddusw", [bs8(0x0f), bs8(0xdd), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+
 
 mn_x86.bintree = factor_one_bit(mn_x86.bintree)
 # mn_x86.bintree = factor_fields_all(mn_x86.bintree)

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4553,6 +4553,8 @@ addop("maskmovq", [bs8(0x0f), bs8(0xf7), no_xmm_pref] +
 addop("maskmovdqu", [bs8(0x0f), bs8(0xf7), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_reg))
 
+addop("emms", [bs8(0x0f), bs8(0x77)])
+
 
 mn_x86.bintree = factor_one_bit(mn_x86.bintree)
 # mn_x86.bintree = factor_fields_all(mn_x86.bintree)

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4306,6 +4306,10 @@ addop("pmaxuw", [bs8(0x0f), bs8(0x38), bs8(0x3e), pref_66] +
 addop("pmaxud", [bs8(0x0f), bs8(0x38), bs8(0x3f), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm))
 
+addop("pmaxsw", [bs8(0x0f), bs8(0xee), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("pmaxsw", [bs8(0x0f), bs8(0xee), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
 
 addop("pminub", [bs8(0x0f), bs8(0xda), no_xmm_pref] +
       rmmod(mm_reg, rm_arg_mm))

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4494,6 +4494,15 @@ addop("psubusw", [bs8(0x0f), bs8(0xd9), no_xmm_pref] +
       rmmod(mm_reg, rm_arg_mm_m64))
 addop("psubusw", [bs8(0x0f), bs8(0xd9), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128))
+addop("psubsb", [bs8(0x0f), bs8(0xe8), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("psubsb", [bs8(0x0f), bs8(0xe8), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+addop("psubsw", [bs8(0x0f), bs8(0xe9), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("psubsw", [bs8(0x0f), bs8(0xe9), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+
 
 addop("paddusb", [bs8(0x0f), bs8(0xdc), no_xmm_pref] +
       rmmod(mm_reg, rm_arg_mm_m64))

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -4472,6 +4472,12 @@ addop("packuswb", [bs8(0x0f), bs8(0x67), no_xmm_pref] +
 addop("packuswb", [bs8(0x0f), bs8(0x67), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128))
 
+addop("pmullw", [bs8(0x0f), bs8(0xd5), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("pmullw", [bs8(0x0f), bs8(0xd5), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+
+
 mn_x86.bintree = factor_one_bit(mn_x86.bintree)
 # mn_x86.bintree = factor_fields_all(mn_x86.bintree)
 """

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -4447,6 +4447,11 @@ def maskmovq(ir, instr, src, mask):
     return e, blks
 
 
+def emms(ir, instr):
+    # Implemented as a NOP
+    return [], []
+
+
 mnemo_func = {'mov': mov,
               'xchg': xchg,
               'movzx': movzx,
@@ -4984,6 +4989,7 @@ mnemo_func = {'mov': mov,
               "smsw": smsw,
               "maskmovq": maskmovq,
               "maskmovdqu": maskmovq,
+              "emms": emms,
               }
 
 

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -4347,6 +4347,16 @@ def _saturation_add(expr):
     return m2_expr.ExprCond((arg1 + arg2).msb(), m2_expr.ExprInt(-1, expr.size),
                             expr)
 
+def _saturation_add_signed(expr):
+    assert expr.is_op("+") and len(expr.args) == 2
+
+    # Compute the substraction on two more bits, see _saturation_add_unsigned
+
+    arg1 = expr.args[0].signExtend(expr.size + 2)
+    arg2 = expr.args[1].signExtend(expr.size + 2)
+
+    return _signed_saturation(arg1 + arg2, expr.size)
+
 
 # Saturate SSE operations
 
@@ -4356,6 +4366,8 @@ paddusb = vec_vertical_instr('+', 8, _saturation_add)
 paddusw = vec_vertical_instr('+', 16, _saturation_add)
 psubsb = vec_vertical_instr('-', 8, _saturation_sub_signed)
 psubsw = vec_vertical_instr('-', 16, _saturation_sub_signed)
+paddsb = vec_vertical_instr('+', 8, _saturation_add_signed)
+paddsw = vec_vertical_instr('+', 16, _saturation_add_signed)
 
 
 mnemo_func = {'mov': mov,
@@ -4881,6 +4893,8 @@ mnemo_func = {'mov': mov,
               "paddusw": paddusw,
               "psubsb": psubsb,
               "psubsw": psubsw,
+              "paddsb": paddsb,
+              "paddsw": paddsw,
 
               "smsw": smsw,
 

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -3418,6 +3418,7 @@ def _min_max(expr, signed):
         expr.args[0],
     )
 
+
 # Integer arithmetic
 #
 
@@ -3455,6 +3456,27 @@ pmulhb = vec_vertical_instr('*', 8, lambda x: _keep_mul_high(x, signed=True))
 pmulhw = vec_vertical_instr('*', 16, lambda x: _keep_mul_high(x, signed=True))
 pmulhd = vec_vertical_instr('*', 32, lambda x: _keep_mul_high(x, signed=True))
 pmulhq = vec_vertical_instr('*', 64, lambda x: _keep_mul_high(x, signed=True))
+
+def pmuludq(ir, instr, dst, src):
+    e = []
+    if dst.size == 64:
+        e.append(m2_expr.ExprAff(
+            dst,
+            src[:32].zeroExtend(64) * dst[:32].zeroExtend(64)
+        ))
+    elif dst.size == 128:
+        e.append(m2_expr.ExprAff(
+            dst[:64],
+            src[:32].zeroExtend(64) * dst[:32].zeroExtend(64)
+        ))
+        e.append(m2_expr.ExprAff(
+            dst[64:],
+            src[64:96].zeroExtend(64) * dst[64:96].zeroExtend(64)
+        ))
+    else:
+        raise RuntimeError("Unsupported size %d" % dst.size)
+    return e, []
+
 
 # Comparisons
 #
@@ -4725,6 +4747,7 @@ mnemo_func = {'mov': mov,
               "pmulhw": pmulhw,
               "pmulhd": pmulhd,
               "pmulhq": pmulhq,
+              "pmuludq": pmuludq,
 
 
               # Arithmetic (floating-point)

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -3477,6 +3477,22 @@ def pmuludq(ir, instr, dst, src):
         raise RuntimeError("Unsupported size %d" % dst.size)
     return e, []
 
+# Mix
+#
+
+# SSE
+def pmaddwd(ir, instr, dst, src):
+    sizedst = 32
+    sizesrc = 16
+    out = []
+    for start in xrange(0, dst.size, sizedst):
+        base = start
+        mul1 = src[base: base + sizesrc].signExtend(sizedst) * dst[base: base + sizesrc].signExtend(sizedst)
+        base += sizesrc
+        mul2 = src[base: base + sizesrc].signExtend(sizedst) * dst[base: base + sizesrc].signExtend(sizedst)
+        out.append(mul1 + mul2)
+    return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out))], []
+
 
 # Comparisons
 #
@@ -4749,6 +4765,9 @@ mnemo_func = {'mov': mov,
               "pmulhq": pmulhq,
               "pmuludq": pmuludq,
 
+              # Mix
+              # SSE
+              "pmaddwd": pmaddwd,
 
               # Arithmetic (floating-point)
               #

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -3398,6 +3398,15 @@ psubw = vec_vertical_instr('-', 16)
 psubd = vec_vertical_instr('-', 32)
 psubq = vec_vertical_instr('-', 64)
 
+# Multiplications
+#
+
+# SSE
+pmullb = vec_vertical_instr('*', 8)
+pmullw = vec_vertical_instr('*', 16)
+pmulld = vec_vertical_instr('*', 32)
+pmullq = vec_vertical_instr('*', 64)
+
 # Floating-point arithmetic
 #
 
@@ -4644,6 +4653,12 @@ mnemo_func = {'mov': mov,
               "psubw": psubw,
               "psubd": psubd,
               "psubq": psubq,
+
+              # SSE
+              "pmullb": pmullb,
+              "pmullw": pmullw,
+              "pmulld": pmulld,
+              "pmullq": pmullq,
 
               # Arithmetic (floating-point)
               #

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -3518,6 +3518,17 @@ def psadbw(ir, instr, dst, src):
 
     return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out_dst))], []
 
+def _average(expr):
+    assert expr.is_op("avg") and len(expr.args) == 2
+
+    arg1 = expr.args[0].zeroExtend(expr.size * 2)
+    arg2 = expr.args[1].zeroExtend(expr.size * 2)
+    one = m2_expr.ExprInt(1, arg1.size)
+    # avg(unsigned) = (a + b + 1) >> 1, addition beeing at least on one more bit
+    return ((arg1 + arg2 + one) >> one)[:expr.size]
+
+pavgb = vec_vertical_instr('avg', 8, _average)
+pavgw = vec_vertical_instr('avg', 16, _average)
 
 # Comparisons
 #
@@ -4794,6 +4805,8 @@ mnemo_func = {'mov': mov,
               # SSE
               "pmaddwd": pmaddwd,
               "psadbw": psadbw,
+              "pavgb": pavgb,
+              "pavgw": pavgw,
 
               # Arithmetic (floating-point)
               #

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -4245,6 +4245,14 @@ def packsswb(ir, instr, dst, src):
     return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out))], []
 
 
+def packssdw(ir, instr, dst, src):
+    out = []
+    for source in [dst, src]:
+        for start in xrange(0, dst.size, 32):
+            out.append(_signed_saturation(source[start:start + 32], 16))
+    return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out))], []
+
+
 def packuswb(ir, instr, dst, src):
     out = []
     for source in [dst, src]:
@@ -4751,6 +4759,7 @@ mnemo_func = {'mov': mov,
               "pmovmskb": pmovmskb,
 
               "packsswb": packsswb,
+              "packssdw": packssdw,
               "packuswb": packuswb,
 
               "smsw": smsw,

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -3467,6 +3467,7 @@ pminud = vec_vertical_instr('min', 32, lambda x: _min_max(x, signed=False))
 pmaxub = vec_vertical_instr('max', 8, lambda x: _min_max(x, signed=False))
 pmaxuw = vec_vertical_instr('max', 16, lambda x: _min_max(x, signed=False))
 pmaxud = vec_vertical_instr('max', 32, lambda x: _min_max(x, signed=False))
+pmaxsw = vec_vertical_instr('max', 16, lambda x: _min_max(x, signed=True))
 
 # Floating-point arithmetic
 #
@@ -4783,6 +4784,7 @@ mnemo_func = {'mov': mov,
               "pmaxub": pmaxub,
               "pmaxuw": pmaxuw,
               "pmaxud": pmaxud,
+              "pmaxsw": pmaxsw,
 
               "pminub": pminub,
               "pminuw": pminuw,

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -3392,6 +3392,17 @@ def float_vec_vertical_instr(op, elt_size, apply_on_output=lambda x: x):
                                     apply_on_output)
 
 
+def _keep_mul_high(expr, signed=False):
+    assert expr.is_op("*") and len(expr.args) == 2
+
+    if signed:
+        arg1 = expr.args[0].signExtend(expr.size * 2)
+        arg2 = expr.args[1].signExtend(expr.size * 2)
+    else:
+        arg1 = expr.args[0].zeroExtend(expr.size * 2)
+        arg2 = expr.args[1].zeroExtend(expr.size * 2)
+    return m2_expr.ExprOp("*", arg1, arg2)[expr.size:]
+
 # Integer arithmetic
 #
 
@@ -3421,6 +3432,14 @@ pmullb = vec_vertical_instr('*', 8)
 pmullw = vec_vertical_instr('*', 16)
 pmulld = vec_vertical_instr('*', 32)
 pmullq = vec_vertical_instr('*', 64)
+pmulhub = vec_vertical_instr('*', 8, _keep_mul_high)
+pmulhuw = vec_vertical_instr('*', 16, _keep_mul_high)
+pmulhud = vec_vertical_instr('*', 32, _keep_mul_high)
+pmulhuq = vec_vertical_instr('*', 64, _keep_mul_high)
+pmulhb = vec_vertical_instr('*', 8, lambda x: _keep_mul_high(x, signed=True))
+pmulhw = vec_vertical_instr('*', 16, lambda x: _keep_mul_high(x, signed=True))
+pmulhd = vec_vertical_instr('*', 32, lambda x: _keep_mul_high(x, signed=True))
+pmulhq = vec_vertical_instr('*', 64, lambda x: _keep_mul_high(x, signed=True))
 
 # Floating-point arithmetic
 #
@@ -4704,11 +4723,21 @@ mnemo_func = {'mov': mov,
               "psubd": psubd,
               "psubq": psubq,
 
+              # Multiplications
               # SSE
               "pmullb": pmullb,
               "pmullw": pmullw,
               "pmulld": pmulld,
               "pmullq": pmullq,
+              "pmulhub": pmulhub,
+              "pmulhuw": pmulhuw,
+              "pmulhud": pmulhud,
+              "pmulhuq": pmulhuq,
+              "pmulhb": pmulhb,
+              "pmulhw": pmulhw,
+              "pmulhd": pmulhd,
+              "pmulhq": pmulhq,
+
 
               # Arithmetic (floating-point)
               #

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -3403,6 +3403,14 @@ def _keep_mul_high(expr, signed=False):
         arg2 = expr.args[1].zeroExtend(expr.size * 2)
     return m2_expr.ExprOp("*", arg1, arg2)[expr.size:]
 
+def _signed_min(expr):
+    assert expr.is_op("min") and len(expr.args) == 2
+    return m2_expr.ExprCond(
+        m2_expr.expr_is_signed_lower(expr.args[1], expr.args[0]),
+        expr.args[1],
+        expr.args[0],
+    )
+
 # Integer arithmetic
 #
 
@@ -3440,6 +3448,13 @@ pmulhb = vec_vertical_instr('*', 8, lambda x: _keep_mul_high(x, signed=True))
 pmulhw = vec_vertical_instr('*', 16, lambda x: _keep_mul_high(x, signed=True))
 pmulhd = vec_vertical_instr('*', 32, lambda x: _keep_mul_high(x, signed=True))
 pmulhq = vec_vertical_instr('*', 64, lambda x: _keep_mul_high(x, signed=True))
+
+# Comparisons
+#
+
+# SSE
+pminsw = vec_vertical_instr('min', 16, _signed_min)
+
 
 # Floating-point arithmetic
 #
@@ -3488,12 +3503,6 @@ def por(_, instr, dst, src):
     e = []
     result = dst | src
     e.append(m2_expr.ExprAff(dst, result))
-    return e, []
-
-
-def pminsw(_, instr, dst, src):
-    e = []
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprCond((dst - src).msb(), dst, src)))
     return e, []
 
 

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -2974,6 +2974,11 @@ reg_tests = [
      "0f63f8"),
     (m32, "00000000    PACKSSWB   XMM0, XMM5",
      "660f63c5"),
+
+    (m32, "00000000    PACKUSWB   MM1, MM7",
+     "0f67cf"),
+    (m32, "00000000    PACKUSWB   XMM0, XMM6",
+     "660f67c6"),
 ]
 
 

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -3074,6 +3074,9 @@ reg_tests = [
      "0ff7d3"),
     (m32, "00000000    MASKMOVDQU XMM4, XMM5",
      "660ff7e5"),
+
+    (m32, "00000000    EMMS",
+     "0f77"),
 ]
 
 

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -2989,6 +2989,17 @@ reg_tests = [
      "0fd5e2"),
     (m32, "00000000    PMULLW     XMM0, XMM3",
      "660fd5c3"),
+
+    (m32, "00000000    PSUBUSB    MM5, MM3",
+     "0fd8eb"),
+    (m32, "00000000    PSUBUSB    XMM0, XMM5",
+     "660fd8c5"),
+
+    (m32, "00000000    PSUBUSW    MM5, MM3",
+     "0fd9eb"),
+    (m32, "00000000    PSUBUSW    XMM0, XMM5",
+     "660fd9c5"),
+
 ]
 
 

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -3069,6 +3069,11 @@ reg_tests = [
      "0fe3d9"),
     (m32, "00000000    PAVGW      XMM0, XMM6",
      "660fe3c6"),
+
+    (m32, "00000000    MASKMOVQ   MM2, MM3",
+     "0ff7d3"),
+    (m32, "00000000    MASKMOVDQU XMM4, XMM5",
+     "660ff7e5"),
 ]
 
 

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -3000,6 +3000,15 @@ reg_tests = [
     (m32, "00000000    PSUBUSW    XMM0, XMM5",
      "660fd9c5"),
 
+    (m32, "00000000    PADDUSB    MM5, MM3",
+     "0fdceb"),
+    (m32, "00000000    PADDUSB    XMM0, XMM6",
+     "660fdcc6"),
+
+    (m32, "00000000    PADDUSW    MM7, MM5",
+     "0fddfd"),
+    (m32, "00000000    PADDUSW    XMM0, XMM1",
+     "660fddc1"),
 ]
 
 

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -3019,6 +3019,16 @@ reg_tests = [
      "0fe5f4"),
     (m32, "00000000    PMULHW     XMM0, XMM7",
      "660fe5c7"),
+
+    (m32, "00000000    PSUBSB     MM2, MM0",
+     "0fe8d0"),
+    (m32, "00000000    PSUBSB     XMM0, XMM4",
+     "660fe8c4"),
+
+    (m32, "00000000    PSUBSW     MM3, MM1",
+     "0fe9d9"),
+    (m32, "00000000    PSUBSW     XMM0, XMM6",
+     "660fe9c6"),
 ]
 
 

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -3044,6 +3044,11 @@ reg_tests = [
      "0feed9"),
     (m32, "00000000    PMAXSW     XMM0, XMM6",
      "660feec6"),
+
+    (m32, "00000000    PMULUDQ    MM3, MM1",
+     "0ff4d9"),
+    (m32, "00000000    PMULUDQ    XMM0, XMM6",
+     "660ff4c6"),
 ]
 
 

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -2902,11 +2902,11 @@ reg_tests = [
     (m32, "00000000    PEXTRW     WORD PTR [EDX], XMM2, 0x5",
     "660F3A151205"),
 
+    (m32, "00000000    PEXTRW     EAX, MM2, 0x5",
+    "0fc5c205"),
+    (m32, "00000000    PEXTRW     EAX, XMM2, 0x5",
+    "660fc5c205"),
 
-    (m32, "00000000    PEXTRW     WORD PTR [EDX], MM2, 0x5",
-    "0FC51205"),
-    (m32, "00000000    PEXTRW     WORD PTR [EDX], XMM2, 0x5",
-    "660FC51205"),
 
     (m32, "00000000    PEXTRD     DWORD PTR [EDX], XMM2, 0x5",
     "660F3A161205"),

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -3029,6 +3029,16 @@ reg_tests = [
      "0fe9d9"),
     (m32, "00000000    PSUBSW     XMM0, XMM6",
      "660fe9c6"),
+
+    (m32, "00000000    PADDSB     MM2, MM0",
+     "0fecd0"),
+    (m32, "00000000    PADDSB     XMM0, XMM4",
+     "660fecc4"),
+
+    (m32, "00000000    PADDSW     MM3, MM1",
+     "0fedd9"),
+    (m32, "00000000    PADDSW     XMM0, XMM6",
+     "660fedc6"),
 ]
 
 

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -3059,6 +3059,16 @@ reg_tests = [
      "0ff6d9"),
     (m32, "00000000    PSADBW     XMM0, XMM6",
      "660ff6c6"),
+
+    (m32, "00000000    PAVGB      MM3, MM1",
+     "0fe0d9"),
+    (m32, "00000000    PAVGB      XMM0, XMM6",
+     "660fe0c6"),
+
+    (m32, "00000000    PAVGW      MM3, MM1",
+     "0fe3d9"),
+    (m32, "00000000    PAVGW      XMM0, XMM6",
+     "660fe3c6"),
 ]
 
 

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -2975,6 +2975,11 @@ reg_tests = [
     (m32, "00000000    PACKSSWB   XMM0, XMM5",
      "660f63c5"),
 
+    (m32, "00000000    PACKSSDW   MM2, MM0",
+     "0f6bd0"),
+    (m32, "00000000    PACKSSDW   XMM0, XMM7",
+     "660f6bc7"),
+
     (m32, "00000000    PACKUSWB   MM1, MM7",
      "0f67cf"),
     (m32, "00000000    PACKUSWB   XMM0, XMM6",

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -2984,6 +2984,11 @@ reg_tests = [
      "0f67cf"),
     (m32, "00000000    PACKUSWB   XMM0, XMM6",
      "660f67c6"),
+
+    (m32, "00000000    PMULLW     MM4, MM2",
+     "0fd5e2"),
+    (m32, "00000000    PMULLW     XMM0, XMM3",
+     "660fd5c3"),
 ]
 
 

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -3054,6 +3054,11 @@ reg_tests = [
      "0ff5d9"),
     (m32, "00000000    PMADDWD    XMM0, XMM6",
      "660ff5c6"),
+
+    (m32, "00000000    PSADBW     MM3, MM1",
+     "0ff6d9"),
+    (m32, "00000000    PSADBW     XMM0, XMM6",
+     "660ff6c6"),
 ]
 
 

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -2970,6 +2970,10 @@ reg_tests = [
     (m64, "00000000    BNDMOV     BND3, XMMWORD PTR [RSP + 0xB0]",
      "660f1a9c24b0000000"),
 
+    (m32, "00000000    PACKSSWB   MM7, MM0",
+     "0f63f8"),
+    (m32, "00000000    PACKSSWB   XMM0, XMM5",
+     "660f63c5"),
 ]
 
 

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -3049,6 +3049,11 @@ reg_tests = [
      "0ff4d9"),
     (m32, "00000000    PMULUDQ    XMM0, XMM6",
      "660ff4c6"),
+
+    (m32, "00000000    PMADDWD    MM3, MM1",
+     "0ff5d9"),
+    (m32, "00000000    PMADDWD    XMM0, XMM6",
+     "660ff5c6"),
 ]
 
 

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -3039,6 +3039,11 @@ reg_tests = [
      "0fedd9"),
     (m32, "00000000    PADDSW     XMM0, XMM6",
      "660fedc6"),
+
+    (m32, "00000000    PMAXSW     MM3, MM1",
+     "0feed9"),
+    (m32, "00000000    PMAXSW     XMM0, XMM6",
+     "660feec6"),
 ]
 
 

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -3009,6 +3009,16 @@ reg_tests = [
      "0fddfd"),
     (m32, "00000000    PADDUSW    XMM0, XMM1",
      "660fddc1"),
+
+    (m32, "00000000    PMULHUW    MM6, MM4",
+     "0fe4f4"),
+    (m32, "00000000    PMULHUW    XMM0, XMM7",
+     "660fe4c7"),
+
+    (m32, "00000000    PMULHW     MM6, MM4",
+     "0fe5f4"),
+    (m32, "00000000    PMULHW     XMM0, XMM7",
+     "660fe5c7"),
 ]
 
 


### PR DESCRIPTION
This PR fixes and introduces new SSE instructions for x86.
These instructions have been tested with LLVM jitter against QEMU `test-i386`, function `test_sse`. The XMM (with 128 bits) patch is necessary to reproduce these tests.

Without the patch, the first 12 lines of the tests works.
With the patch, the first 224 lines are now working (next instruction to be implemented being `SHUFPS`).