### PR TITLE
Fix a few simplifications

### DIFF
--- a/miasm2/expression/simplifications_common.py
+++ b/miasm2/expression/simplifications_common.py
@@ -40,13 +40,26 @@ def simp_cst_propagation(e_s, expr):
             elif op_name == '|':
                 out = int1.arg | int2.arg
             elif op_name == '>>':
-                out = int1.arg >> int2.arg
+                if int(int2) > int1.size:
+                    out = 0
+                else:
+                    out = int1.arg >> int2.arg
             elif op_name == '<<':
-                out = int1.arg << int2.arg
+                if int(int2) > int1.size:
+                    out = 0
+                else:
+                    out = int1.arg << int2.arg
             elif op_name == 'a>>':
                 tmp1 = mod_size2int[int1.arg.size](int1.arg)
                 tmp2 = mod_size2uint[int2.arg.size](int2.arg)
-                out = mod_size2uint[int1.arg.size](tmp1 >> tmp2)
+                if tmp2 > int1.size:
+                    is_signed = int(int1) & (1 << (int1.size - 1))
+                    if is_signed:
+                        out = -1
+                    else:
+                        out = 0
+                else:
+                    out = mod_size2uint[int1.arg.size](tmp1 >> tmp2)
             elif op_name == '>>>':
                 shifter = int2.arg % int2.size
                 out = (int1.arg >> shifter) | (int1.arg << (int2.size - shifter))

--- a/miasm2/expression/simplifications_common.py
+++ b/miasm2/expression/simplifications_common.py
@@ -539,7 +539,7 @@ def simp_compose(e_s, expr):
         nxt = args[i + 1]
         if arg.is_mem() and nxt.is_mem():
             gap = e_s(nxt.arg - arg.arg)
-            if gap.is_int() and int(gap) == arg.size / 8:
+            if gap.is_int() and arg.size % 8 == 0 and int(gap) == arg.size / 8:
                 args = args[:i] + [ExprMem(arg.arg,
                                           arg.size + nxt.size)] + args[i + 2:]
                 return ExprCompose(*args)

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -411,6 +411,10 @@ to_test = [(ExprInt(1, 32) - ExprInt(1, 32), ExprInt(0, 32)),
     (a >> b >> c, a >> b >> c), # Left unmodified
     (a >> b_msb_null >> c_msb_null,
      a >> (b_msb_null + c_msb_null)),
+
+    # Degenerated case from fuzzing, which had previously raised bugs
+    (ExprCompose(ExprInt(0x7, 3), ExprMem(ExprInt(0x39E21, 19), 1), ExprMem(ExprInt(0x39E21, 19), 1)),
+     ExprCompose(ExprInt(0x7, 3), ExprMem(ExprInt(0x39E21, 19), 1), ExprMem(ExprInt(0x39E21, 19), 1))),
 ]
 
 for e_input, e_check in to_test:

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -415,6 +415,12 @@ to_test = [(ExprInt(1, 32) - ExprInt(1, 32), ExprInt(0, 32)),
     # Degenerated case from fuzzing, which had previously raised bugs
     (ExprCompose(ExprInt(0x7, 3), ExprMem(ExprInt(0x39E21, 19), 1), ExprMem(ExprInt(0x39E21, 19), 1)),
      ExprCompose(ExprInt(0x7, 3), ExprMem(ExprInt(0x39E21, 19), 1), ExprMem(ExprInt(0x39E21, 19), 1))),
+    (ExprOp('>>', ExprInt(0x5E580475, 92), ExprInt(0x7D800000000000000331720, 92)),
+     ExprInt(0x0, 92)),
+    (ExprOp('a>>', ExprInt(0x5E580475, 92), ExprInt(0x7D800000000000000331720, 92)),
+     ExprInt(0x0, 92)),
+    (ExprOp('a>>', ExprInt(-0x5E580475, 92), ExprInt(0x7D800000000000000331720, 92)),
+     ExprInt(-1, 92)),
 ]
 
 for e_input, e_check in to_test:


### PR DESCRIPTION
This PR fixes 3 bugs obtained by fuzzing Miasm simplifications against z3.

With this PR, my fuzzer is not able to find any more  bugs after ~ 4 000 000 tries (with `ExprRandom`, expression size of depth 8, expr_reuse set to `True`, `ExprMem` of the same size in a given expression).