### PR TITLE
Refactor/remove default exprmem size

### DIFF
--- a/example/expression/expr_grapher.py
+++ b/example/expression/expr_grapher.py
@@ -6,7 +6,7 @@ a = ExprId("A", 32)
 b = ExprId("B", 32)
 c = ExprId("C", 32)
 d = ExprId("D", 32)
-m = ExprMem(a + b + c + a)
+m = ExprMem(a + b + c + a, 32)
 
 e1 = ExprCompose(a + b - (c * a) / m | b, a + m)
 e2 = ExprInt(15, 64)

--- a/example/expression/expr_reduce.py
+++ b/example/expression/expr_reduce.py
@@ -81,8 +81,8 @@ def test():
         (ptr, StructLookup.FIELD_A_PTR),
         (ptr + int4, StructLookup.FIELD_A_PTR),
         (ptr + int4 * int4, StructLookup.FIELD_A_PTR),
-        (ExprMem(ptr), StructLookup.FIELD_A),
-        (ExprMem(ptr + int4 * int4), StructLookup.FIELD_A),
+        (ExprMem(ptr, 32), StructLookup.FIELD_A),
+        (ExprMem(ptr + int4 * int4, 32), StructLookup.FIELD_A),
     ]
 
     for expr_in, result in tests:

--- a/example/expression/simplification_tools.py
+++ b/example/expression/simplification_tools.py
@@ -13,7 +13,7 @@ c = ExprId('c', 32)
 d = ExprId('d', 32)
 e = ExprId('e', 32)
 
-m = ExprMem(a)
+m = ExprMem(a, 32)
 s = a[:8]
 
 i1 = ExprInt(0x1, 32)
@@ -28,7 +28,7 @@ l = [a[:8], b[:8], c[:8], m[:8], s, i1[:8], i2[:8], o[:8]]
 l2 = l[::-1]
 
 
-x = ExprMem(a + b + ExprInt(0x42, 32))
+x = ExprMem(a + b + ExprInt(0x42, 32), 32)
 
 
 def replace_expr(e):

--- a/miasm2/arch/arm/arch.py
+++ b/miasm2/arch/arm/arch.py
@@ -224,9 +224,9 @@ def deref2expr_pre(s, l, t):
 def deref2expr_pre_mem(s, l, t):
     t = t[0]
     if len(t) == 1:
-        return ExprMem(ExprOp("preinc", t[0], ExprInt(0, 32)))
+        return ExprMem(ExprOp("preinc", t[0], ExprInt(0, 32)), 32)
     elif len(t) == 2:
-        return ExprMem(ExprOp("preinc", t[0], t[1]))
+        return ExprMem(ExprOp("preinc", t[0], t[1]), 32)
     else:
         raise NotImplementedError('len(t) > 2')
 
@@ -239,8 +239,8 @@ def deref2expr_post(s, l, t):
 def deref_wb(s, l, t):
     t = t[0]
     if t[-1] == '!':
-        return ExprMem(ExprOp('wback', *t[:-1]))
-    return ExprMem(t[0])
+        return ExprMem(ExprOp('wback', *t[:-1]), 32)
+    return ExprMem(t[0], 32)
 
 # shift_off.setParseAction(deref_off)
 deref_nooff = Group(
@@ -855,7 +855,7 @@ class arm_imm8_12(m_arg):
             e = ExprOp('postinc', self.parent.rn.expr, e)
         if self.parent.wback.value == 1:
             e = ExprOp('wback', e)
-        self.expr = ExprMem(e)
+        self.expr = ExprMem(e, 32)
         return True
 
     def encode(self):
@@ -1056,7 +1056,7 @@ class arm_op2imm(arm_imm8_12):
                 e = ExprOp('postinc', self.parent.rn.expr, ExprInt(imm, 32))
             if self.parent.wback.value == 1:
                 e = ExprOp('wback', e)
-            self.expr = ExprMem(e)
+            self.expr = ExprMem(e, 32)
             return True
         rm = val & 0xf
         shift = val >> 4
@@ -1083,7 +1083,7 @@ class arm_op2imm(arm_imm8_12):
             e = ExprOp('postinc', self.parent.rn.expr, a)
         if self.parent.wback.value == 1:
             e = ExprOp('wback', e)
-        self.expr = ExprMem(e)
+        self.expr = ExprMem(e, 32)
         return True
 
     def encode(self):
@@ -1372,7 +1372,7 @@ class arm_immed(m_arg):
             e = ExprOp('postinc', self.parent.rn.expr, imm)
         if self.parent.wback.value == 1:
             e = ExprOp('wback', e)
-        self.expr = ExprMem(e)
+        self.expr = ExprMem(e, 32)
 
         return True
 
@@ -1459,9 +1459,9 @@ class arm_mem_rn_imm(m_arg):
         imm = ExprInt(value, 32)
         reg = gpregs.expr[v]
         if value:
-            expr = ExprMem(reg + imm)
+            expr = ExprMem(reg + imm, 32)
         else:
-            expr = ExprMem(reg)
+            expr = ExprMem(reg, 32)
         self.expr = expr
         return True
 
@@ -1748,9 +1748,9 @@ class arm_offpc(arm_offreg):
         v = v & self.lmask
         v <<= 2
         if v:
-            self.expr = ExprMem(self.off_reg + ExprInt(v, 32))
+            self.expr = ExprMem(self.off_reg + ExprInt(v, 32), 32)
         else:
-            self.expr = ExprMem(self.off_reg)
+            self.expr = ExprMem(self.off_reg, 32)
 
         e = self.expr.arg
         if isinstance(e, ExprOp) and e.op == 'wback':
@@ -1823,7 +1823,7 @@ class arm_deref(m_arg):
         v = v & self.lmask
         rbase = regs_expr[v]
         e = ExprOp('preinc', rbase, self.parent.off.expr)
-        self.expr = ExprMem(e)
+        self.expr = ExprMem(e, 32)
         return True
 
     def encode(self):

--- a/miasm2/arch/arm/sem.py
+++ b/miasm2/arch/arm/sem.py
@@ -672,11 +672,11 @@ def st_ld_m(ir, instr, a, b, store=False, postinc=False, updown=False):
     for i, r in enumerate(regs):
         ad = base + ExprInt(i * step, 32)
         if store:
-            e.append(ExprAff(ExprMem(ad), r))
+            e.append(ExprAff(ExprMem(ad, 32), r))
         else:
-            e.append(ExprAff(r, ExprMem(ad)))
+            e.append(ExprAff(r, ExprMem(ad, 32)))
             if r == PC:
-                e.append(ExprAff(ir.IRDst, ExprMem(ad)))
+                e.append(ExprAff(ir.IRDst, ExprMem(ad, 32)))
     # XXX TODO check multiple write cause by wb
     if wb:
         if postinc:
@@ -813,7 +813,7 @@ def push(ir, instr, a):
     regs = list(a.args)
     for i in xrange(len(regs)):
         r = SP + ExprInt(-4 * (i + 1), 32)
-        e.append(ExprAff(ExprMem(r), regs[i]))
+        e.append(ExprAff(ExprMem(r, 32), regs[i]))
     r = SP + ExprInt(-4 * len(regs), 32)
     e.append(ExprAff(SP, r))
     return e
@@ -825,9 +825,9 @@ def pop(ir, instr, a):
     dst = None
     for i in xrange(len(regs)):
         r = SP + ExprInt(4 * i, 32)
-        e.append(ExprAff(regs[i], ExprMem(r)))
+        e.append(ExprAff(regs[i], ExprMem(r, 32)))
         if regs[i] == ir.pc:
-            dst = ExprMem(r)
+            dst = ExprMem(r, 32)
     r = SP + ExprInt(4 * len(regs), 32)
     e.append(ExprAff(SP, r))
     if dst is not None:

--- a/miasm2/arch/mips32/arch.py
+++ b/miasm2/arch/mips32/arch.py
@@ -29,13 +29,13 @@ def deref2expr(s, l, t):
     if len(t) != 4:
         raise NotImplementedError("TODO")
 
-    return ExprMem(t[2] + t[0])
+    return ExprMem(t[2] + t[0], 32)
 
 def deref2expr_nooff(s, l, t):
     t = t[0]
     if len(t) != 3:
         raise NotImplementedError("TODO")
-    return ExprMem(t[1])
+    return ExprMem(t[1], 32)
 
 base_expr = cpu.base_expr
 
@@ -380,7 +380,7 @@ class mips32_dreg_imm(cpu.m_arg):
     def decode(self, v):
         imm = self.parent.imm.expr
         r = gpregs.expr[v]
-        self.expr = ExprMem(r+imm)
+        self.expr = ExprMem(r+imm, 32)
         return True
 
     def encode(self):

--- a/miasm2/arch/sh4/arch.py
+++ b/miasm2/arch/sh4/arch.py
@@ -67,25 +67,25 @@ def parse_deref_mem(s, l, t):
 
 def parse_predec(s, l, t):
     t = t[0]
-    e = ExprMem(ExprOp('predec', t[0]))
+    e = ExprMem(ExprOp('predec', t[0]), 32)
     return e
 
 
 def parse_postinc(s, l, t):
     t = t[0]
-    e = ExprMem(ExprOp('postinc', t[0]))
+    e = ExprMem(ExprOp('postinc', t[0]), 32)
     return e
 
 
 def parse_regdisp(t):
     t = t[0]
-    e = ExprMem(t[0] + t[1])
+    e = ExprMem(t[0] + t[1], 32)
     return e
 
 
 def parse_regreg(t):
     t = t[0]
-    e = ExprMem(t[0] + t[1])
+    e = ExprMem(t[0] + t[1], 32)
     return e
 
 
@@ -314,7 +314,7 @@ class sh4_dgbrimm8(sh4_dgpreg):
     def encode(self):
         e = self.expr
         s = self.sz
-        if e == ExprMem(GBR):
+        if e == ExprMem(GBR, 32):
             self.value = 0
             return True
         res = match_expr(self.expr, ExprMem(GBR + jra, s), [jra])
@@ -331,7 +331,7 @@ class sh4_dpc32imm(sh4_dpc16imm):
 
     def decode(self, v):
         self.expr = ExprMem(
-            (PC & ExprInt(0xfffffffc, 32)) + ExprInt(v * 4 + 4, 32))
+            (PC & ExprInt(0xfffffffc, 32)) + ExprInt(v * 4 + 4, 32), 32)
         return True
 
     def calcdisp(self, v):

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -1078,7 +1078,7 @@ def pushfw(ir, instr):
 
 
 def popfd(ir, instr):
-    tmp = ir.ExprMem(mRSP[instr.mode])
+    tmp = ir.ExprMem(mRSP[instr.mode], 32)
     e = []
     e.append(m2_expr.ExprAff(cf, m2_expr.ExprSlice(tmp, 0, 1)))
     e.append(m2_expr.ExprAff(pf, m2_expr.ExprSlice(tmp, 2, 3)))
@@ -1121,7 +1121,7 @@ def _tpl_eflags(tmp):
 
 
 def popfw(ir, instr):
-    tmp = ir.ExprMem(mRSP[instr.mode])
+    tmp = ir.ExprMem(mRSP[instr.mode], 32)
     e = _tpl_eflags(tmp)
     e.append(
         m2_expr.ExprAff(mRSP[instr.mode], mRSP[instr.mode] + m2_expr.ExprInt(2, mRSP[instr.mode].size)))
@@ -5046,7 +5046,7 @@ class ir_x86_16(IntermediateRepresentation):
     def mod_pc(self, instr, instr_ir, extra_ir):
         pass
 
-    def ExprMem(self, ptr, size=32):
+    def ExprMem(self, ptr, size):
         """Generate a memory access to @ptr
         The ptr is resized to a fixed size self.addrsize
 

--- a/miasm2/expression/expression.py
+++ b/miasm2/expression/expression.py
@@ -787,11 +787,14 @@ class ExprMem(Expr):
 
     __slots__ = Expr.__slots__ + ["_arg"]
 
-    def __init__(self, arg, size=32):
+    def __init__(self, arg, size=None):
         """Create an ExprMem
         @arg: Expr, memory access address
         @size: int, memory access size
         """
+        if size is None:
+            warnings.warn('DEPRECATION WARNING: size is a mandatory argument: use ExprMem(arg, SIZE)')
+            size = 32
 
         # arg must be Expr
         assert isinstance(arg, Expr)
@@ -810,7 +813,7 @@ class ExprMem(Expr):
         state = self._arg, self._size
         return self.__class__, state
 
-    def __new__(cls, arg, size=32):
+    def __new__(cls, arg, size=None):
         return Expr.get_object(cls, (arg, size))
 
     def __str__(self):

--- a/miasm2/expression/expression.py
+++ b/miasm2/expression/expression.py
@@ -542,7 +542,7 @@ class ExprId(Expr):
         state = self._name, self._size
         return self.__class__, state
 
-    def __new__(cls, name, size=32):
+    def __new__(cls, name, size=None):
         return Expr.get_object(cls, (name, size))
 
     def __str__(self):

--- a/test/analysis/data_flow.py
+++ b/test/analysis/data_flow.py
@@ -553,7 +553,7 @@ G17_IRB0 = gen_irblock(LBL0, [[ExprAff(a, a*b),
                                ExprAff(b, a),
                                ExprAff(c, b)],
 
-                              [ExprAff(ExprMem(d+CST1), a),
+                              [ExprAff(ExprMem(d+CST1, 32), a),
                                ExprAff(a, b),
                                ExprAff(b, c),
                                ExprAff(c, CST1)],
@@ -562,7 +562,7 @@ G17_IRB0 = gen_irblock(LBL0, [[ExprAff(a, a*b),
                                ExprAff(b, a),
                                ExprAff(c, b)],
 
-                              [ExprAff(ExprMem(d+CST2), a),
+                              [ExprAff(ExprMem(d+CST2, 32), a),
                                ExprAff(a, b),
                                ExprAff(b, c),
                                ExprAff(c, CST1)],
@@ -593,7 +593,7 @@ G17_IRB0 = gen_irblock(LBL0, [[ExprAff(a, a*b),
                                ExprAff(b, a),
                                ExprAff(c, b)],
 
-                              [ExprAff(ExprMem(d), a+b+c)],
+                              [ExprAff(ExprMem(d, 32), a+b+c)],
 
                          ])
 
@@ -610,11 +610,11 @@ G17_EXP_IRB0 = gen_irblock(LBL0, [[],
 
                                   [ExprAff(a, CST1)],
 
-                                  [ExprAff(ExprMem(d+CST1), a)],
+                                  [ExprAff(ExprMem(d+CST1, 32), a)],
 
                                   [ExprAff(a, CST1)],
 
-                                  [ExprAff(ExprMem(d+CST2), a)],
+                                  [ExprAff(ExprMem(d+CST2, 32), a)],
 
                                   [ExprAff(a, CST2)],
 

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -89,7 +89,7 @@ d8 = ExprId('d8', 8)
 e8 = ExprId('e8', 8)
 
 
-m = ExprMem(a)
+m = ExprMem(a, 32)
 s = a[:8]
 
 i0 = ExprInt(0, 32)
@@ -106,7 +106,7 @@ l = [a[:8], b[:8], c[:8], m[:8], s, i1[:8], i2[:8], o[:8]]
 l2 = l[::-1]
 
 
-x = ExprMem(a + b + ExprInt(0x42, 32))
+x = ExprMem(a + b + ExprInt(0x42, 32), 32)
 
 # Define tests: (expression to simplify, expected value)
 to_test = [(ExprInt(1, 32) - ExprInt(1, 32), ExprInt(0, 32)),
@@ -189,8 +189,8 @@ to_test = [(ExprInt(1, 32) - ExprInt(1, 32), ExprInt(0, 32)),
             ExprCompose(a[:16], a[:16]),),
            (ExprCompose(a[:16], a[16:32]), a),
 
-           (ExprMem(a)[:32], ExprMem(a)),
-           (ExprMem(a)[:16], ExprMem(a, size=16)),
+           (ExprMem(a, 32)[:32], ExprMem(a, 32)),
+           (ExprMem(a, 32)[:16], ExprMem(a, size=16)),
 
            (ExprCond(ExprInt(1, 32), a, b), a),
            (ExprCond(ExprInt(0, 32), b, a), a),
@@ -518,8 +518,8 @@ match_tests = [
     (match_expr(x + y, x + a, [a]), {a: y}),
     (match_expr(x + y, a + b, [a, b]), {a: x, b: y}),
     (match_expr(x + ExprInt(12, 32), a + b, [a, b]), {a: x, b: ExprInt(12, 32)}),
-    (match_expr(ExprMem(x), a, [a]), {a: ExprMem(x)}),
-    (match_expr(ExprMem(x), ExprMem(a), [a]), {a: x}),
+    (match_expr(ExprMem(x, 32), a, [a]), {a: ExprMem(x, 32)}),
+    (match_expr(ExprMem(x, 32), ExprMem(a, 32), [a]), {a: x}),
     (match_expr(x[0:8], a, [a]), {a: x[0:8]}),
     (match_expr(x[0:8], a[0:8], [a]), {a: x}),
     (match_expr(ExprCond(x, y, z), a, [a]), {a: ExprCond(x, y, z)}),
@@ -544,10 +544,10 @@ for test, res in match_tests:
 
 
 get_tests = [
-    (ExprAff(ExprMem(a), ExprMem(b)).get_r(True), set([a, b, ExprMem(b)])),
-    (ExprAff(ExprMem(a), ExprMem(b)).get_w(), set([ExprMem(a)])),
-    (ExprAff(ExprMem(ExprMem(a)), ExprMem(b))
-     .get_r(True), set([a, b, ExprMem(b), ExprMem(a)])),
+    (ExprAff(ExprMem(a, 32), ExprMem(b, 32)).get_r(True), set([a, b, ExprMem(b, 32)])),
+    (ExprAff(ExprMem(a, 32), ExprMem(b, 32)).get_w(), set([ExprMem(a, 32)])),
+    (ExprAff(ExprMem(ExprMem(a, 32), 32), ExprMem(b, 32))
+     .get_r(True), set([a, b, ExprMem(b, 32), ExprMem(a, 32)])),
 ]
 
 

--- a/test/ir/symbexec.py
+++ b/test/ir/symbexec.py
@@ -21,11 +21,11 @@ class TestSymbExec(unittest.TestCase):
         addr20 = ExprInt(20, 32)
         addr40 = ExprInt(40, 32)
         addr50 = ExprInt(50, 32)
-        mem0 = ExprMem(addr0)
+        mem0 = ExprMem(addr0, 32)
         mem1 = ExprMem(addr1, 8)
-        mem8 = ExprMem(addr8)
-        mem9 = ExprMem(addr9)
-        mem20 = ExprMem(addr20)
+        mem8 = ExprMem(addr8, 32)
+        mem9 = ExprMem(addr9, 32)
+        mem20 = ExprMem(addr20, 32)
         mem40v = ExprMem(addr40,  8)
         mem40w = ExprMem(addr40, 16)
         mem50v = ExprMem(addr50,  8)
@@ -41,9 +41,9 @@ class TestSymbExec(unittest.TestCase):
                                      id_a: addr0, id_eax: addr0})
         self.assertEqual(e.find_mem_by_addr(addr0), mem0)
         self.assertEqual(e.find_mem_by_addr(addrX), None)
-        self.assertEqual(e.eval_expr(ExprMem(addr1 - addr1)), id_x)
+        self.assertEqual(e.eval_expr(ExprMem(addr1 - addr1, 32)), id_x)
         self.assertEqual(e.eval_expr(ExprMem(addr1, 8)), id_y)
-        self.assertEqual(e.eval_expr(ExprMem(addr1 + addr1)), ExprCompose(
+        self.assertEqual(e.eval_expr(ExprMem(addr1 + addr1, 32)), ExprCompose(
             id_x[16:32], ExprMem(ExprInt(4, 32), 16)))
         self.assertEqual(e.eval_expr(mem8), ExprCompose(
             id_x[0:24], ExprMem(ExprInt(11, 32), 8)))
@@ -55,7 +55,7 @@ class TestSymbExec(unittest.TestCase):
         self.assertEqual(e.eval_expr(mem20), mem20)
         self.assertEqual(set(e.modified()), set(e.symbols))
         self.assertRaises(
-            KeyError, e.symbols.__getitem__, ExprMem(ExprInt(100, 32)))
+            KeyError, e.symbols.__getitem__, ExprMem(ExprInt(100, 32), 32))
         self.assertEqual(e.apply_expr(id_eax), addr0)
         self.assertEqual(e.apply_expr(ExprAff(id_eax, addr9)), addr9)
         self.assertEqual(e.apply_expr(id_eax), addr9)


### PR DESCRIPTION
The size of `ExprMem` is now mandatory.
With this PR, there is no more `Expr` with a default size