### PR TITLE
Allow python simulation of function with '-' in their name

### DIFF
--- a/miasm2/jitter/loader/utils.py
+++ b/miasm2/jitter/loader/utils.py
@@ -10,6 +10,8 @@ log.setLevel(logging.INFO)
 def canon_libname_libfunc(libname, libfunc):
     dn = libname.split('.')[0]
     if type(libfunc) == str:
+        # Avoid 'api-ms-win-*' bug, because '-' are not legitimate Python name
+        dn = dn.replace("-", "_")
         return "%s_%s" % (dn, libfunc)
     else:
         return str(dn), libfunc


### PR DESCRIPTION
See #695 .

In windows, DLL names could contains `-`, which is not a legit Python function name (for stubs definition).