### PR TITLE
Fix the 011111 group of store instructions wrt r0

### DIFF
--- a/miasm2/arch/ppc/arch.py
+++ b/miasm2/arch/ppc/arch.py
@@ -653,8 +653,9 @@ ppcop("slogic2", [bs_name(l=6, name=slogic2_name), rs, ra, u16imm],
       [ra, rs, u16imm])
 
 ppcop("store1", [bs('011111'), rs, ra_or_0, rb,
-                 bs_name(l=11, name=store1_name_u)])
-ppcop("store1u", [bs('011111'), rs, ra, rb, bs_name(l=11, name=store1_name)])
+                 bs_name(l=11, name=store1_name)])
+ppcop("store1u", [bs('011111'), rs, ra, rb,
+                  bs_name(l=11, name=store1_name_u)])
 
 ppcop("store2", [bs('10'), bs_name(l=4, name=store2_name), rs,
                     ra_noarg, dregimm])


### PR DESCRIPTION
The 011111 group of store instructions is split in two sets: one in
which r0 has value 0, and another where r0 mustn't be used.
A "typographical inversion" interverted the two sets, leading to
a semantics error when r0 is used with the subset which expects a
hardcoded 0 value.

Found by @commial, thanks!