### PR TITLE
Added support to parse  sxtb, sxth, sxtx, uxtw, uxth, uxtx, uxtb

### DIFF
--- a/miasm2/arch/aarch64/sem.py
+++ b/miasm2/arch/aarch64/sem.py
@@ -124,9 +124,32 @@ def extend_arg(dst, arg):
         return arg
 
     op, (reg, shift) = arg.op, arg.args
-    if op == 'SXTW':
+    if op == "SXTB":
+        base = reg[:8].signExtend(dst.size)
+        op = "<<"
+    elif op == "SXTH":
+        base = reg[:16].signExtend(dst.size)
+        op = "<<"
+    elif op == 'SXTW':
+        base = reg[:32].signExtend(dst.size)
+        op = "<<"
+    elif op == "SXTX":
         base = reg.signExtend(dst.size)
         op = "<<"
+
+    elif op == "UXTB":
+        base = reg[:8].zeroExtend(dst.size)
+        op = "<<"
+    elif op == "UXTH":
+        base = reg[:16].zeroExtend(dst.size)
+        op = "<<"
+    elif op == 'UXTW':
+        base = reg[:32].zeroExtend(dst.size)
+        op = "<<"
+    elif op == "UXTX":
+        base = reg.zeroExtend(dst.size)
+        op = "<<"
+
     elif op in ['<<', '>>', '<<a', 'a>>', '<<<', '>>>']:
         base = reg.zeroExtend(dst.size)
     else:


### PR DESCRIPTION
Hi, 

I have added the  code for parsing ARM register extender instructions, viz. sxtb, sxth, sxtx, uxtw, uxth, uxtx, uxtb. I have tested it for UXTW, and assumed the things will be same for other instructions as well. 

For reference, apart from ARM ASM documentation, I have used this blog https://community.arm.com/processors/b/blog/posts/a64-shift-and-extend-operations-operand-modifiers. 

Please let me know if anything is missing. 