### PR TITLE
Refactor/move to op semantics

### DIFF
--- a/miasm2/arch/arm/sem.py
+++ b/miasm2/arch/arm/sem.py
@@ -1038,7 +1038,7 @@ def pldw(ir, instr, a):
 
 def clz(ir, instr, a, b):
     e = []
-    e.append(ExprAff(a, ExprOp('clz', b)))
+    e.append(ExprAff(a, ExprOp('cntleadzeros', b)))
     return e, []
 
 def uxtab(ir, instr, a, b, c):

--- a/miasm2/ir/translators/C.py
+++ b/miasm2/ir/translators/C.py
@@ -50,9 +50,6 @@ class TranslatorC(Translator):
             elif expr.op == '!':
                 return "(~ %s)&0x%x" % (self.from_expr(expr.args[0]),
                                         size2mask(expr.args[0].size))
-            elif expr.op in ["hex2bcd", "bcd2hex"]:
-                return "%s_%d(%s)" % (expr.op, expr.args[0].size,
-                                      self.from_expr(expr.args[0]))
             elif (expr.op.startswith("double_to_") or
                   expr.op.endswith("_to_double")   or
                   expr.op.startswith("access_")    or

--- a/miasm2/ir/translators/C.py
+++ b/miasm2/ir/translators/C.py
@@ -47,9 +47,6 @@ class TranslatorC(Translator):
                 return "%s(0x%x, %s)" % (expr.op,
                                              expr.args[0].size,
                                              self.from_expr(expr.args[0]))
-            elif expr.op in ['clz']:
-                return "%s(%s)" % (expr.op,
-                                   self.from_expr(expr.args[0]))
             elif expr.op == '!':
                 return "(~ %s)&0x%x" % (self.from_expr(expr.args[0]),
                                         size2mask(expr.args[0].size))

--- a/miasm2/ir/translators/C.py
+++ b/miasm2/ir/translators/C.py
@@ -108,10 +108,10 @@ class TranslatorC(Translator):
                 return "segm2addr(jitcpu, %s, %s)" % (
                     self.from_expr(expr.args[0]), self.from_expr(expr.args[1]))
             elif expr.op in ['udiv', 'umod', 'idiv', 'imod']:
-                return '%s%d((vm_cpu_t*)jitcpu->cpu, %s, %s)' % (expr.op,
-                                                                 expr.args[0].size,
-                                                                 self.from_expr(expr.args[0]),
-                                                                 self.from_expr(expr.args[1]))
+                return '%s%d(%s, %s)' % (expr.op,
+                                         expr.args[0].size,
+                                         self.from_expr(expr.args[0]),
+                                         self.from_expr(expr.args[1]))
             elif expr.op in ["bcdadd", "bcdadd_cf"]:
                 return "%s_%d(%s, %s)" % (expr.op, expr.args[0].size,
                                           self.from_expr(expr.args[0]),

--- a/miasm2/jitter/arch/JitCore_aarch64.c
+++ b/miasm2/jitter/arch/JitCore_aarch64.c
@@ -284,25 +284,6 @@ PyObject* vm_set_mem(JitCpu *self, PyObject* args)
        return Py_None;
 }
 
-
-UDIV(16)
-UDIV(32)
-UDIV(64)
-
-UMOD(16)
-UMOD(32)
-UMOD(64)
-
-
-IDIV(16)
-IDIV(32)
-IDIV(64)
-
-IMOD(16)
-IMOD(32)
-IMOD(64)
-
-
 static PyMemberDef JitCpu_members[] = {
     {NULL}  /* Sentinel */
 };

--- a/miasm2/jitter/arch/JitCore_aarch64.h
+++ b/miasm2/jitter/arch/JitCore_aarch64.h
@@ -49,19 +49,4 @@ typedef struct {
 
 void dump_gpregs(vm_cpu_t* vmcpu);
 
-uint64_t udiv64(uint64_t a, uint64_t b);
-uint64_t umod64(uint64_t a, uint64_t b);
-int64_t idiv64(int64_t a, int64_t b);
-int64_t imod64(int64_t a, int64_t b);
-
-uint32_t udiv32(uint32_t a, uint32_t b);
-uint32_t umod32(uint32_t a, uint32_t b);
-int32_t idiv32(int32_t a, int32_t b);
-int32_t imod32(int32_t a, int32_t b);
-
-uint16_t udiv16(uint16_t a, uint16_t b);
-uint16_t umod16(uint16_t a, uint16_t b);
-int16_t idiv16(int16_t a, int16_t b);
-int16_t imod16(int16_t a, int16_t b);
-
 #define RETURN_PC return BlockDst;

--- a/miasm2/jitter/arch/JitCore_aarch64.h
+++ b/miasm2/jitter/arch/JitCore_aarch64.h
@@ -49,19 +49,19 @@ typedef struct {
 
 void dump_gpregs(vm_cpu_t* vmcpu);
 
-uint64_t udiv64(vm_cpu_t* vmcpu, uint64_t a, uint64_t b);
-uint64_t umod64(vm_cpu_t* vmcpu, uint64_t a, uint64_t b);
-int64_t idiv64(vm_cpu_t* vmcpu, int64_t a, int64_t b);
-int64_t imod64(vm_cpu_t* vmcpu, int64_t a, int64_t b);
+uint64_t udiv64(uint64_t a, uint64_t b);
+uint64_t umod64(uint64_t a, uint64_t b);
+int64_t idiv64(int64_t a, int64_t b);
+int64_t imod64(int64_t a, int64_t b);
 
-uint32_t udiv32(vm_cpu_t* vmcpu, uint32_t a, uint32_t b);
-uint32_t umod32(vm_cpu_t* vmcpu, uint32_t a, uint32_t b);
-int32_t idiv32(vm_cpu_t* vmcpu, int32_t a, int32_t b);
-int32_t imod32(vm_cpu_t* vmcpu, int32_t a, int32_t b);
+uint32_t udiv32(uint32_t a, uint32_t b);
+uint32_t umod32(uint32_t a, uint32_t b);
+int32_t idiv32(int32_t a, int32_t b);
+int32_t imod32(int32_t a, int32_t b);
 
-uint16_t udiv16(vm_cpu_t* vmcpu, uint16_t a, uint16_t b);
-uint16_t umod16(vm_cpu_t* vmcpu, uint16_t a, uint16_t b);
-int16_t idiv16(vm_cpu_t* vmcpu, int16_t a, int16_t b);
-int16_t imod16(vm_cpu_t* vmcpu, int16_t a, int16_t b);
+uint16_t udiv16(uint16_t a, uint16_t b);
+uint16_t umod16(uint16_t a, uint16_t b);
+int16_t idiv16(int16_t a, int16_t b);
+int16_t imod16(int16_t a, int16_t b);
 
 #define RETURN_PC return BlockDst;

--- a/miasm2/jitter/arch/JitCore_arm.c
+++ b/miasm2/jitter/arch/JitCore_arm.c
@@ -187,16 +187,6 @@ void check_automod(JitCpu* jitcpu, uint64_t addr, uint64_t size)
 
 }
 
-
-UDIV(32)
-
-UMOD(32)
-
-IDIV(32)
-
-IMOD(32)
-
-
 void MEM_WRITE_08(JitCpu* jitcpu, uint64_t addr, uint8_t src)
 {
 	vm_MEM_WRITE_08(&((VmMngr*)jitcpu->pyvm)->vm_mngr, addr, src);

--- a/miasm2/jitter/arch/JitCore_arm.c
+++ b/miasm2/jitter/arch/JitCore_arm.c
@@ -211,22 +211,6 @@ void MEM_WRITE_64(JitCpu* jitcpu, uint64_t addr, uint64_t src)
 	check_automod(jitcpu, addr, 64);
 }
 
-
-uint32_t clz(uint32_t arg)
-{
-
-	int i;
-
-	for (i=0; i<32; i++) {
-		if (arg & (1ull << (31-i)))
-			break;
-	}
-	return i;
-}
-
-
-
-
 PyObject* vm_set_mem(JitCpu *self, PyObject* args)
 {
        PyObject *py_addr;

--- a/miasm2/jitter/arch/JitCore_arm.h
+++ b/miasm2/jitter/arch/JitCore_arm.h
@@ -39,5 +39,3 @@ typedef struct {
 void dump_gpregs(vm_cpu_t* vmcpu);
 
 #define RETURN_PC return BlockDst;
-
-uint32_t clz(uint32_t arg);

--- a/miasm2/jitter/arch/JitCore_arm.h
+++ b/miasm2/jitter/arch/JitCore_arm.h
@@ -38,13 +38,6 @@ typedef struct {
 
 void dump_gpregs(vm_cpu_t* vmcpu);
 
-
-uint32_t udiv32(uint32_t a, uint32_t b);
-uint32_t umod32(uint32_t a, uint32_t b);
-int32_t idiv32(int32_t a, int32_t b);
-int32_t imod32(int32_t a, int32_t b);
-
-
 #define RETURN_PC return BlockDst;
 
 uint32_t clz(uint32_t arg);

--- a/miasm2/jitter/arch/JitCore_arm.h
+++ b/miasm2/jitter/arch/JitCore_arm.h
@@ -39,10 +39,10 @@ typedef struct {
 void dump_gpregs(vm_cpu_t* vmcpu);
 
 
-uint32_t udiv32(vm_cpu_t* vmcpu, uint32_t a, uint32_t b);
-uint32_t umod32(vm_cpu_t* vmcpu, uint32_t a, uint32_t b);
-int32_t idiv32(vm_cpu_t* vmcpu, int32_t a, int32_t b);
-int32_t imod32(vm_cpu_t* vmcpu, int32_t a, int32_t b);
+uint32_t udiv32(uint32_t a, uint32_t b);
+uint32_t umod32(uint32_t a, uint32_t b);
+int32_t idiv32(int32_t a, int32_t b);
+int32_t imod32(int32_t a, int32_t b);
 
 
 #define RETURN_PC return BlockDst;

--- a/miasm2/jitter/arch/JitCore_mips32.c
+++ b/miasm2/jitter/arch/JitCore_mips32.c
@@ -222,25 +222,6 @@ void check_automod(JitCpu* jitcpu, uint64_t addr, uint64_t size)
 }
 
 
-UDIV(16)
-UDIV(32)
-UDIV(64)
-
-UMOD(16)
-UMOD(32)
-UMOD(64)
-
-
-IDIV(16)
-IDIV(32)
-IDIV(64)
-
-IMOD(16)
-IMOD(32)
-IMOD(64)
-
-
-
 void MEM_WRITE_08(JitCpu* jitcpu, uint64_t addr, uint8_t src)
 {
 	vm_MEM_WRITE_08(&((VmMngr*)jitcpu->pyvm)->vm_mngr, addr, src);

--- a/miasm2/jitter/arch/JitCore_mips32.h
+++ b/miasm2/jitter/arch/JitCore_mips32.h
@@ -335,19 +335,19 @@ typedef struct {
 
 void dump_gpregs(vm_cpu_t* vmcpu);
 
-uint64_t udiv64(vm_cpu_t* vmcpu, uint64_t a, uint64_t b);
-uint64_t umod64(vm_cpu_t* vmcpu, uint64_t a, uint64_t b);
-int64_t idiv64(vm_cpu_t* vmcpu, int64_t a, int64_t b);
-int64_t imod64(vm_cpu_t* vmcpu, int64_t a, int64_t b);
+uint64_t udiv64(uint64_t a, uint64_t b);
+uint64_t umod64(uint64_t a, uint64_t b);
+int64_t idiv64(int64_t a, int64_t b);
+int64_t imod64(int64_t a, int64_t b);
 
-uint32_t udiv32(vm_cpu_t* vmcpu, uint32_t a, uint32_t b);
-uint32_t umod32(vm_cpu_t* vmcpu, uint32_t a, uint32_t b);
-int32_t idiv32(vm_cpu_t* vmcpu, int32_t a, int32_t b);
-int32_t imod32(vm_cpu_t* vmcpu, int32_t a, int32_t b);
+uint32_t udiv32(uint32_t a, uint32_t b);
+uint32_t umod32(uint32_t a, uint32_t b);
+int32_t idiv32(int32_t a, int32_t b);
+int32_t imod32(int32_t a, int32_t b);
 
-uint16_t udiv16(vm_cpu_t* vmcpu, uint16_t a, uint16_t b);
-uint16_t umod16(vm_cpu_t* vmcpu, uint16_t a, uint16_t b);
-int16_t idiv16(vm_cpu_t* vmcpu, int16_t a, int16_t b);
-int16_t imod16(vm_cpu_t* vmcpu, int16_t a, int16_t b);
+uint16_t udiv16(uint16_t a, uint16_t b);
+uint16_t umod16(uint16_t a, uint16_t b);
+int16_t idiv16(int16_t a, int16_t b);
+int16_t imod16(int16_t a, int16_t b);
 
 #define RETURN_PC return BlockDst;

--- a/miasm2/jitter/arch/JitCore_mips32.h
+++ b/miasm2/jitter/arch/JitCore_mips32.h
@@ -335,19 +335,4 @@ typedef struct {
 
 void dump_gpregs(vm_cpu_t* vmcpu);
 
-uint64_t udiv64(uint64_t a, uint64_t b);
-uint64_t umod64(uint64_t a, uint64_t b);
-int64_t idiv64(int64_t a, int64_t b);
-int64_t imod64(int64_t a, int64_t b);
-
-uint32_t udiv32(uint32_t a, uint32_t b);
-uint32_t umod32(uint32_t a, uint32_t b);
-int32_t idiv32(int32_t a, int32_t b);
-int32_t imod32(int32_t a, int32_t b);
-
-uint16_t udiv16(uint16_t a, uint16_t b);
-uint16_t umod16(uint16_t a, uint16_t b);
-int16_t idiv16(int16_t a, int16_t b);
-int16_t imod16(int16_t a, int16_t b);
-
 #define RETURN_PC return BlockDst;

--- a/miasm2/jitter/arch/JitCore_msp430.h
+++ b/miasm2/jitter/arch/JitCore_msp430.h
@@ -36,16 +36,4 @@ typedef struct {
 
 #define RETURN_PC return BlockDst;
 
-uint16_t bcdadd_16(uint16_t a, uint16_t b);
-
-uint16_t bcdadd_cf_16(uint16_t a, uint16_t b);
-
-uint16_t hex2bcd_16(uint16_t a);
-
-uint8_t hex2bcd_8(uint8_t a);
-
-uint8_t bcd2hex_8(uint8_t a);
-
-uint16_t bcd2hex_16(uint16_t a);
-
 void dump_gpregs(vm_cpu_t* vmcpu);

--- a/miasm2/jitter/arch/JitCore_ppc32.c
+++ b/miasm2/jitter/arch/JitCore_ppc32.c
@@ -246,38 +246,6 @@ get_gpreg_offset_all(void) {
     return dict;
 }
 
-int32_t
-idiv32(int32_t a, int32_t b) {
-    if (b == 0)
-	return 0;
-
-    return a / b;
-}
-
-uint32_t
-udiv32(uint32_t a, uint32_t b) {
-    if (b == 0)
-	return 0;
-
-    return a / b;
-}
-
-int32_t
-imod32(int32_t a, int32_t b) {
-    if (b == 0)
-	return 0;
-
-    return a % b;
-}
-
-uint32_t
-umod32(uint32_t a, uint32_t b) {
-    if (b == 0)
-	return 0;
-
-    return a % b;
-}
-
 static PyGetSetDef JitCpu_getseters[] = {
     {"vmmngr",
      (getter)JitCpu_get_vmmngr, (setter)JitCpu_set_vmmngr,

--- a/miasm2/jitter/arch/JitCore_ppc32.c
+++ b/miasm2/jitter/arch/JitCore_ppc32.c
@@ -247,7 +247,7 @@ get_gpreg_offset_all(void) {
 }
 
 int32_t
-idiv32(struct vm_cpu *cpu, int32_t a, int32_t b) {
+idiv32(int32_t a, int32_t b) {
     if (b == 0)
 	return 0;
 
@@ -255,7 +255,7 @@ idiv32(struct vm_cpu *cpu, int32_t a, int32_t b) {
 }
 
 uint32_t
-udiv32(struct vm_cpu *cpu, uint32_t a, uint32_t b) {
+udiv32(uint32_t a, uint32_t b) {
     if (b == 0)
 	return 0;
 
@@ -263,7 +263,7 @@ udiv32(struct vm_cpu *cpu, uint32_t a, uint32_t b) {
 }
 
 int32_t
-imod32(struct vm_cpu *cpu, int32_t a, int32_t b) {
+imod32(int32_t a, int32_t b) {
     if (b == 0)
 	return 0;
 
@@ -271,7 +271,7 @@ imod32(struct vm_cpu *cpu, int32_t a, int32_t b) {
 }
 
 uint32_t
-umod32(struct vm_cpu *cpu, uint32_t a, uint32_t b) {
+umod32(uint32_t a, uint32_t b) {
     if (b == 0)
 	return 0;
 

--- a/miasm2/jitter/arch/JitCore_ppc32.h
+++ b/miasm2/jitter/arch/JitCore_ppc32.h
@@ -14,10 +14,10 @@ struct vm_cpu {
     uint32_t reserve_address;
 };
 
-int32_t idiv32(struct vm_cpu *, int32_t, int32_t);
-uint32_t udiv32(struct vm_cpu *, uint32_t, uint32_t);
-int32_t imod32(struct vm_cpu *, int32_t, int32_t);
-uint32_t umod32(struct vm_cpu *, uint32_t, uint32_t);
+int32_t idiv32(int32_t, int32_t);
+uint32_t udiv32(uint32_t, uint32_t);
+int32_t imod32(int32_t, int32_t);
+uint32_t umod32(uint32_t, uint32_t);
 
 void dump_gpregs(struct vm_cpu *);
 

--- a/miasm2/jitter/arch/JitCore_ppc32.h
+++ b/miasm2/jitter/arch/JitCore_ppc32.h
@@ -14,11 +14,6 @@ struct vm_cpu {
     uint32_t reserve_address;
 };
 
-int32_t idiv32(int32_t, int32_t);
-uint32_t udiv32(uint32_t, uint32_t);
-int32_t imod32(int32_t, int32_t);
-uint32_t umod32(uint32_t, uint32_t);
-
 void dump_gpregs(struct vm_cpu *);
 
 typedef struct vm_cpu vm_cpu_t;

--- a/miasm2/jitter/arch/JitCore_x86.c
+++ b/miasm2/jitter/arch/JitCore_x86.c
@@ -330,24 +330,6 @@ uint64_t segm2addr(JitCpu* jitcpu, uint64_t segm, uint64_t addr)
 	return addr + ((vm_cpu_t*)jitcpu->cpu)->segm_base[segm];
 }
 
-
-UDIV(16)
-UDIV(32)
-UDIV(64)
-
-UMOD(16)
-UMOD(32)
-UMOD(64)
-
-
-IDIV(16)
-IDIV(32)
-IDIV(64)
-
-IMOD(16)
-IMOD(32)
-IMOD(64)
-
 void MEM_WRITE_08(JitCpu* jitcpu, uint64_t addr, uint8_t src)
 {
 	vm_MEM_WRITE_08(&((VmMngr*)jitcpu->pyvm)->vm_mngr, addr, src);

--- a/miasm2/jitter/arch/JitCore_x86.h
+++ b/miasm2/jitter/arch/JitCore_x86.h
@@ -108,19 +108,19 @@ void dump_gpregs_64(vm_cpu_t* vmcpu);
 uint64_t segm2addr(JitCpu* jitcpu, uint64_t segm, uint64_t addr);
 
 
-uint64_t udiv64(vm_cpu_t* vmcpu, uint64_t a, uint64_t b);
-uint64_t umod64(vm_cpu_t* vmcpu, uint64_t a, uint64_t b);
-int64_t idiv64(vm_cpu_t* vmcpu, int64_t a, int64_t b);
-int64_t imod64(vm_cpu_t* vmcpu, int64_t a, int64_t b);
+uint64_t udiv64(uint64_t a, uint64_t b);
+uint64_t umod64(uint64_t a, uint64_t b);
+int64_t idiv64(int64_t a, int64_t b);
+int64_t imod64(int64_t a, int64_t b);
 
-uint32_t udiv32(vm_cpu_t* vmcpu, uint32_t a, uint32_t b);
-uint32_t umod32(vm_cpu_t* vmcpu, uint32_t a, uint32_t b);
-int32_t idiv32(vm_cpu_t* vmcpu, int32_t a, int32_t b);
-int32_t imod32(vm_cpu_t* vmcpu, int32_t a, int32_t b);
+uint32_t udiv32(uint32_t a, uint32_t b);
+uint32_t umod32(uint32_t a, uint32_t b);
+int32_t idiv32(int32_t a, int32_t b);
+int32_t imod32(int32_t a, int32_t b);
 
-uint16_t udiv16(vm_cpu_t* vmcpu, uint16_t a, uint16_t b);
-uint16_t umod16(vm_cpu_t* vmcpu, uint16_t a, uint16_t b);
-int16_t idiv16(vm_cpu_t* vmcpu, int16_t a, int16_t b);
-int16_t imod16(vm_cpu_t* vmcpu, int16_t a, int16_t b);
+uint16_t udiv16(uint16_t a, uint16_t b);
+uint16_t umod16(uint16_t a, uint16_t b);
+int16_t idiv16(int16_t a, int16_t b);
+int16_t imod16(int16_t a, int16_t b);
 
 #define RETURN_PC return BlockDst;

--- a/miasm2/jitter/arch/JitCore_x86.h
+++ b/miasm2/jitter/arch/JitCore_x86.h
@@ -100,27 +100,8 @@ typedef struct {
 
 }vm_cpu_t;
 
-
-
-
 void dump_gpregs_32(vm_cpu_t* vmcpu);
 void dump_gpregs_64(vm_cpu_t* vmcpu);
 uint64_t segm2addr(JitCpu* jitcpu, uint64_t segm, uint64_t addr);
-
-
-uint64_t udiv64(uint64_t a, uint64_t b);
-uint64_t umod64(uint64_t a, uint64_t b);
-int64_t idiv64(int64_t a, int64_t b);
-int64_t imod64(int64_t a, int64_t b);
-
-uint32_t udiv32(uint32_t a, uint32_t b);
-uint32_t umod32(uint32_t a, uint32_t b);
-int32_t idiv32(int32_t a, int32_t b);
-int32_t imod32(int32_t a, int32_t b);
-
-uint16_t udiv16(uint16_t a, uint16_t b);
-uint16_t umod16(uint16_t a, uint16_t b);
-int16_t idiv16(int16_t a, int16_t b);
-int16_t imod16(int16_t a, int16_t b);
 
 #define RETURN_PC return BlockDst;

--- a/miasm2/jitter/op_semantics.c
+++ b/miasm2/jitter/op_semantics.c
@@ -774,3 +774,19 @@ uint64_t double_to_mem_64(double d)
 #endif
 	return m;
 }
+
+UDIV(16)
+UDIV(32)
+UDIV(64)
+
+UMOD(16)
+UMOD(32)
+UMOD(64)
+
+IDIV(16)
+IDIV(32)
+IDIV(64)
+
+IMOD(16)
+IMOD(32)
+IMOD(64)

--- a/miasm2/jitter/op_semantics.h
+++ b/miasm2/jitter/op_semantics.h
@@ -27,7 +27,7 @@ unsigned int cntleadzeros(uint64_t size, uint64_t src);
 unsigned int cnttrailzeros(uint64_t size, uint64_t src);
 
 #define UDIV(sizeA)						\
-	uint ## sizeA ## _t udiv ## sizeA (vm_cpu_t* vmcpu, uint ## sizeA ## _t a, uint ## sizeA ## _t b) \
+	uint ## sizeA ## _t udiv ## sizeA (uint ## sizeA ## _t a, uint ## sizeA ## _t b) \
 	{								\
 		uint ## sizeA ## _t r;					\
 		if (b == 0) {						\
@@ -40,7 +40,7 @@ unsigned int cnttrailzeros(uint64_t size, uint64_t src);
 
 
 #define UMOD(sizeA)						\
-	uint ## sizeA ## _t umod ## sizeA (vm_cpu_t* vmcpu, uint ## sizeA ## _t a, uint ## sizeA ## _t b) \
+	uint ## sizeA ## _t umod ## sizeA (uint ## sizeA ## _t a, uint ## sizeA ## _t b) \
 	{								\
 		uint ## sizeA ## _t r;					\
 		if (b == 0) {						\
@@ -53,7 +53,7 @@ unsigned int cnttrailzeros(uint64_t size, uint64_t src);
 
 
 #define IDIV(sizeA)						\
-	int ## sizeA ## _t idiv ## sizeA (vm_cpu_t* vmcpu, int ## sizeA ## _t a, int ## sizeA ## _t b) \
+	int ## sizeA ## _t idiv ## sizeA (int ## sizeA ## _t a, int ## sizeA ## _t b) \
 	{								\
 		int ## sizeA ## _t r;					\
 		if (b == 0) {						\
@@ -66,7 +66,7 @@ unsigned int cnttrailzeros(uint64_t size, uint64_t src);
 
 
 #define IMOD(sizeA)						\
-	int ## sizeA ## _t imod ## sizeA (vm_cpu_t* vmcpu, int ## sizeA ## _t a, int ## sizeA ## _t b) \
+	int ## sizeA ## _t imod ## sizeA (int ## sizeA ## _t a, int ## sizeA ## _t b) \
 	{								\
 		int ## sizeA ## _t r;					\
 		if (b == 0) {						\

--- a/miasm2/jitter/op_semantics.h
+++ b/miasm2/jitter/op_semantics.h
@@ -77,6 +77,21 @@ unsigned int cnttrailzeros(uint64_t size, uint64_t src);
 		return r;						\
 	}
 
+uint64_t udiv64(uint64_t a, uint64_t b);
+uint64_t umod64(uint64_t a, uint64_t b);
+int64_t idiv64(int64_t a, int64_t b);
+int64_t imod64(int64_t a, int64_t b);
+
+uint32_t udiv32(uint32_t a, uint32_t b);
+uint32_t umod32(uint32_t a, uint32_t b);
+int32_t idiv32(int32_t a, int32_t b);
+int32_t imod32(int32_t a, int32_t b);
+
+uint16_t udiv16(uint16_t a, uint16_t b);
+uint16_t umod16(uint16_t a, uint16_t b);
+int16_t idiv16(int16_t a, int16_t b);
+int16_t imod16(int16_t a, int16_t b);
+
 unsigned int x86_cpuid(unsigned int a, unsigned int reg_num);
 double int2double(unsigned int m);
 


### PR DESCRIPTION
This PR:
* Remove UDIV/UMOD/IDIV/IMOD unused argument `vmcpu`, and move them to the common `op_semantics`
* ARM `ctl` is actually the new common `cntleadzeros`