### PR TITLE
Feature/xmm regs

### DIFF
--- a/miasm2/jitter/JitCore.c
+++ b/miasm2/jitter/JitCore.c
@@ -74,6 +74,11 @@ uint64_t __attribute__((weak)) MEM_LOOKUP_64(JitCpu* jitcpu, uint64_t addr)
 	return vm_MEM_LOOKUP_64(&(jitcpu->pyvm->vm_mngr), addr);
 }
 
+uint128_t __attribute__((weak)) MEM_LOOKUP_128(JitCpu* jitcpu, uint64_t addr)
+{
+	return vm_MEM_LOOKUP_128(&((VmMngr*)jitcpu->pyvm)->vm_mngr, addr);
+}
+
 void __attribute__((weak)) MEM_WRITE_08(JitCpu* jitcpu, uint64_t addr, uint8_t src)
 {
 	vm_MEM_WRITE_08(&((VmMngr*)jitcpu->pyvm)->vm_mngr, addr, src);
@@ -94,8 +99,10 @@ void __attribute__((weak)) MEM_WRITE_64(JitCpu* jitcpu, uint64_t addr, uint64_t 
 	vm_MEM_WRITE_64(&((VmMngr*)jitcpu->pyvm)->vm_mngr, addr, src);
 }
 
-
-
+void __attribute__((weak)) MEM_WRITE_128(JitCpu* jitcpu, uint64_t addr, uint128_t src)
+{
+	vm_MEM_WRITE_128(&((VmMngr*)jitcpu->pyvm)->vm_mngr, addr, src);
+}
 
 PyObject* __attribute__((weak)) vm_get_mem(JitCpu *self, PyObject* args)
 {

--- a/miasm2/jitter/arch/JitCore_x86.c
+++ b/miasm2/jitter/arch/JitCore_x86.c
@@ -120,6 +120,23 @@ PyObject* cpu_get_gpreg(JitCpu* self)
     get_reg(MM6);
     get_reg(MM7);
 
+    get_reg(XMM0);
+    get_reg(XMM1);
+    get_reg(XMM2);
+    get_reg(XMM3);
+    get_reg(XMM4);
+    get_reg(XMM5);
+    get_reg(XMM6);
+    get_reg(XMM7);
+    get_reg(XMM8);
+    get_reg(XMM9);
+    get_reg(XMM10);
+    get_reg(XMM11);
+    get_reg(XMM12);
+    get_reg(XMM13);
+    get_reg(XMM14);
+    get_reg(XMM15);
+
     get_reg(tsc1);
     get_reg(tsc2);
 
@@ -526,6 +543,23 @@ getset_reg_u64(MM5);
 getset_reg_u64(MM6);
 getset_reg_u64(MM7);
 
+getset_reg_u128(XMM0);
+getset_reg_u128(XMM1);
+getset_reg_u128(XMM2);
+getset_reg_u128(XMM3);
+getset_reg_u128(XMM4);
+getset_reg_u128(XMM5);
+getset_reg_u128(XMM6);
+getset_reg_u128(XMM7);
+getset_reg_u128(XMM8);
+getset_reg_u128(XMM9);
+getset_reg_u128(XMM10);
+getset_reg_u128(XMM11);
+getset_reg_u128(XMM12);
+getset_reg_u128(XMM13);
+getset_reg_u128(XMM14);
+getset_reg_u128(XMM15);
+
 getset_reg_u32(tsc1);
 getset_reg_u32(tsc2);
 
@@ -601,6 +635,23 @@ PyObject* get_gpreg_offset_all(void)
     get_reg_off(MM5);
     get_reg_off(MM6);
     get_reg_off(MM7);
+
+    get_reg_off(XMM0);
+    get_reg_off(XMM1);
+    get_reg_off(XMM2);
+    get_reg_off(XMM3);
+    get_reg_off(XMM4);
+    get_reg_off(XMM5);
+    get_reg_off(XMM6);
+    get_reg_off(XMM7);
+    get_reg_off(XMM8);
+    get_reg_off(XMM9);
+    get_reg_off(XMM10);
+    get_reg_off(XMM11);
+    get_reg_off(XMM12);
+    get_reg_off(XMM13);
+    get_reg_off(XMM14);
+    get_reg_off(XMM15);
 
     get_reg_off(tsc1);
     get_reg_off(tsc2);
@@ -689,6 +740,23 @@ static PyGetSetDef JitCpu_getseters[] = {
     {"MM5", (getter)JitCpu_get_MM5, (setter)JitCpu_set_MM5, "MM5", NULL},
     {"MM6", (getter)JitCpu_get_MM6, (setter)JitCpu_set_MM6, "MM6", NULL},
     {"MM7", (getter)JitCpu_get_MM7, (setter)JitCpu_set_MM7, "MM7", NULL},
+
+    {"XMM0", (getter)JitCpu_get_XMM0, (setter)JitCpu_set_XMM0, "XMM0", NULL},
+    {"XMM1", (getter)JitCpu_get_XMM1, (setter)JitCpu_set_XMM1, "XMM1", NULL},
+    {"XMM2", (getter)JitCpu_get_XMM2, (setter)JitCpu_set_XMM2, "XMM2", NULL},
+    {"XMM3", (getter)JitCpu_get_XMM3, (setter)JitCpu_set_XMM3, "XMM3", NULL},
+    {"XMM4", (getter)JitCpu_get_XMM4, (setter)JitCpu_set_XMM4, "XMM4", NULL},
+    {"XMM5", (getter)JitCpu_get_XMM5, (setter)JitCpu_set_XMM5, "XMM5", NULL},
+    {"XMM6", (getter)JitCpu_get_XMM6, (setter)JitCpu_set_XMM6, "XMM6", NULL},
+    {"XMM7", (getter)JitCpu_get_XMM7, (setter)JitCpu_set_XMM7, "XMM7", NULL},
+    {"XMM8", (getter)JitCpu_get_XMM8, (setter)JitCpu_set_XMM8, "XMM8", NULL},
+    {"XMM9", (getter)JitCpu_get_XMM9, (setter)JitCpu_set_XMM9, "XMM9", NULL},
+    {"XMM10", (getter)JitCpu_get_XMM10, (setter)JitCpu_set_XMM10, "XMM10", NULL},
+    {"XMM11", (getter)JitCpu_get_XMM11, (setter)JitCpu_set_XMM11, "XMM11", NULL},
+    {"XMM12", (getter)JitCpu_get_XMM12, (setter)JitCpu_set_XMM12, "XMM12", NULL},
+    {"XMM13", (getter)JitCpu_get_XMM13, (setter)JitCpu_set_XMM13, "XMM13", NULL},
+    {"XMM14", (getter)JitCpu_get_XMM14, (setter)JitCpu_set_XMM14, "XMM14", NULL},
+    {"XMM15", (getter)JitCpu_get_XMM15, (setter)JitCpu_set_XMM15, "XMM15", NULL},
 
     {"tsc1", (getter)JitCpu_get_tsc1, (setter)JitCpu_set_tsc1, "tsc1", NULL},
     {"tsc2", (getter)JitCpu_get_tsc2, (setter)JitCpu_set_tsc2, "tsc2", NULL},

--- a/miasm2/jitter/arch/JitCore_x86.h
+++ b/miasm2/jitter/arch/JitCore_x86.h
@@ -1,3 +1,4 @@
+#define uint128_t __uint128_t
 
 typedef struct {
 	uint32_t exception_flags;
@@ -95,6 +96,24 @@ typedef struct {
 	uint64_t MM5;
 	uint64_t MM6;
 	uint64_t MM7;
+
+	/* SSE */
+	uint128_t XMM0;
+	uint128_t XMM1;
+	uint128_t XMM2;
+	uint128_t XMM3;
+	uint128_t XMM4;
+	uint128_t XMM5;
+	uint128_t XMM6;
+	uint128_t XMM7;
+	uint128_t XMM8;
+	uint128_t XMM9;
+	uint128_t XMM10;
+	uint128_t XMM11;
+	uint128_t XMM12;
+	uint128_t XMM13;
+	uint128_t XMM14;
+	uint128_t XMM15;
 
 	uint32_t segm_base[0x10000];
 

--- a/miasm2/jitter/codegen.py
+++ b/miasm2/jitter/codegen.py
@@ -10,9 +10,8 @@ from miasm2.core.asmblock import expr_is_label, AsmBlockBad, AsmLabel
 # Miasm to C translator
 TRANSLATOR = Translator.to_language("C")
 
-SIZE_TO_MASK = {x: 2**x - 1 for x in (1, 2, 3, 7, 8, 16, 32, 64)}
-
-MASK_INT = 0xffffffffffffffff
+SIZE_TO_MASK = {size: TRANSLATOR.from_expr(m2_expr.ExprInt(0, size).mask)
+                for size in (1, 2, 3, 7, 8, 16, 32, 64, 128)}
 
 
 class Attributes(object):
@@ -246,9 +245,9 @@ class CGen(object):
                         '%s = (%s);' % (self.id_to_c(new_dst), self.id_to_c(src)))
                 else:
                     c_main.append(
-                        '%s = (%s)&0x%X;' % (self.id_to_c(new_dst),
-                                             self.id_to_c(src),
-                                             SIZE_TO_MASK[src.size]))
+                        '%s = (%s)&%s;' % (self.id_to_c(new_dst),
+                                           self.id_to_c(src),
+                                           SIZE_TO_MASK[src.size]))
             elif isinstance(dst, m2_expr.ExprMem):
                 ptr = dst.arg.replace_expr(prefetchers)
                 new_dst = m2_expr.ExprMem(ptr, dst.size)

--- a/miasm2/jitter/llvmconvert.py
+++ b/miasm2/jitter/llvmconvert.py
@@ -193,7 +193,7 @@ class LLVMContext_JIT(LLVMContext):
 
         fc = {}
         p8 = llvm_ir.PointerType(LLVMType.IntType(8))
-        for i in [8, 16, 32, 64]:
+        for i in [8, 16, 32, 64, 128]:
             fc["MEM_LOOKUP_%02d" % i] = {"ret": LLVMType.IntType(i),
                                          "args": [p8,
                                                   LLVMType.IntType(64)]}

--- a/miasm2/jitter/vm_mngr.c
+++ b/miasm2/jitter/vm_mngr.c
@@ -101,6 +101,13 @@ uint64_t set_endian64(vm_mngr_t* vm_mngr, uint64_t val)
 		return Endian64_Swap(val);
 }
 
+uint128_t set_endian128(vm_mngr_t* vm_mngr, uint128_t val)
+{
+	if (vm_mngr->sex == __BYTE_ORDER)
+		return val;
+	else
+		return Endian128_Swap(val);
+}
 
 void print_val(uint64_t base, uint64_t addr)
 {
@@ -159,11 +166,11 @@ struct memory_page_node * get_memory_page_from_address(vm_mngr_t* vm_mngr, uint6
 
 
 
-static uint64_t memory_page_read(vm_mngr_t* vm_mngr, unsigned int my_size, uint64_t ad)
+static uint128_t memory_page_read(vm_mngr_t* vm_mngr, unsigned int my_size, uint64_t ad)
 {
 	struct memory_page_node * mpn;
 	unsigned char * addr;
-	uint64_t ret = 0;
+	uint128_t ret = 0;
 	struct memory_breakpoint_info * b;
 
 
@@ -206,6 +213,10 @@ static uint64_t memory_page_read(vm_mngr_t* vm_mngr, unsigned int my_size, uint6
 			ret = *((uint64_t*)addr)&0xFFFFFFFFFFFFFFFFULL;
 			ret = set_endian64(vm_mngr, ret);
 			break;
+		case 128:
+			ret = *((uint128_t*)addr)&MASK_128;
+			ret = set_endian128(vm_mngr, ret);
+			break;
 		default:
 			exit(EXIT_FAILURE);
 			break;
@@ -238,6 +249,9 @@ static uint64_t memory_page_read(vm_mngr_t* vm_mngr, unsigned int my_size, uint6
 		case 64:
 			ret = set_endian64(vm_mngr, ret);
 			break;
+		case 128:
+			ret = set_endian128(vm_mngr, ret);
+			break;
 		default:
 			exit(EXIT_FAILURE);
 			break;
@@ -247,7 +261,7 @@ static uint64_t memory_page_read(vm_mngr_t* vm_mngr, unsigned int my_size, uint6
 }
 
 static void memory_page_write(vm_mngr_t* vm_mngr, unsigned int my_size,
-			      uint64_t ad, uint64_t src)
+			      uint64_t ad, uint128_t src)
 {
 	struct memory_page_node * mpn;
 	unsigned char * addr;
@@ -291,6 +305,10 @@ static void memory_page_write(vm_mngr_t* vm_mngr, unsigned int my_size,
 			src = set_endian64(vm_mngr, src);
 			*((uint64_t*)addr) = src&0xFFFFFFFFFFFFFFFFULL;
 			break;
+		case 128:
+			src = set_endian128(vm_mngr, src);
+			*((uint128_t*)addr) = src&MASK_128;
+			break;
 		default:
 			exit(EXIT_FAILURE);
 			break;
@@ -311,6 +329,9 @@ static void memory_page_write(vm_mngr_t* vm_mngr, unsigned int my_size,
 			break;
 		case 64:
 			src = set_endian64(vm_mngr, src);
+			break;
+		case 128:
+			src = set_endian128(vm_mngr, src);
 			break;
 		default:
 			exit(EXIT_FAILURE);
@@ -480,6 +501,12 @@ void vm_MEM_WRITE_64(vm_mngr_t* vm_mngr, uint64_t addr, uint64_t src)
 	memory_page_write(vm_mngr, 64, addr, src);
 }
 
+void vm_MEM_WRITE_128(vm_mngr_t* vm_mngr, uint64_t addr, uint128_t src)
+{
+	add_mem_write(vm_mngr, addr, 16);
+	memory_page_write(vm_mngr, 128, addr, src);
+}
+
 unsigned char vm_MEM_LOOKUP_08(vm_mngr_t* vm_mngr, uint64_t addr)
 {
 	unsigned char ret;
@@ -506,6 +533,13 @@ uint64_t vm_MEM_LOOKUP_64(vm_mngr_t* vm_mngr, uint64_t addr)
 	uint64_t ret;
 	add_mem_read(vm_mngr, addr, 8);
 	ret = memory_page_read(vm_mngr, 64, addr);
+	return ret;
+}
+uint128_t vm_MEM_LOOKUP_128(vm_mngr_t* vm_mngr, uint128_t addr)
+{
+	uint128_t ret;
+	add_mem_read(vm_mngr, addr, 16);
+	ret = memory_page_read(vm_mngr, 128, addr);
 	return ret;
 }
 

--- a/miasm2/jitter/vm_mngr.h
+++ b/miasm2/jitter/vm_mngr.h
@@ -26,6 +26,8 @@
 #define __LITTLE_ENDIAN _LITTLE_ENDIAN
 #endif
 
+#define uint128_t __uint128_t
+
 #define Endian16_Swap(value) \
       ((((uint16_t)((value) & 0x00FF)) << 8) | \
        (((uint16_t)((value) & 0xFF00)) >> 8))
@@ -46,8 +48,25 @@
 	 ((((uint64_t)value)>>40) & 0x000000000000FF00ULL)  |	      \
 	 ((((uint64_t)value)>>56) & 0x00000000000000FFULL))
 
+#define Endian128_Swap(value)                                   \
+	(((((uint128_t)value)>>120) & 0xFF)             |	\
+	 ((((uint128_t)value)>>112) & 0xFF) << 8	|	\
+	 ((((uint128_t)value)>>104) & 0xFF) << 16       |	\
+	 ((((uint128_t)value)>>96) & 0xFF) << 24	|	\
+	 ((((uint128_t)value)>>88) & 0xFF) << 32	|	\
+	 ((((uint128_t)value)>>80) & 0xFF) << 40	|	\
+	 ((((uint128_t)value)>>72) & 0xFF) << 48	|	\
+	 ((((uint128_t)value)>>64) & 0xFF) << 56	|	\
+	 ((((uint128_t)value)>>56) & 0xFF) << 64	|	\
+	 ((((uint128_t)value)>>48) & 0xFF) << 72	|	\
+	 ((((uint128_t)value)>>40) & 0xFF) << 80	|	\
+	 ((((uint128_t)value)>>32) & 0xFF) << 88	|	\
+	 ((((uint128_t)value)>>24) & 0xFF) << 96	|	\
+	 ((((uint128_t)value)>>16) & 0xFF) << 104       |	\
+	 ((((uint128_t)value)>>8) & 0xFF) << 112	|	\
+	 ((((uint128_t)value)) & 0xFF) << 120)
 
-
+#define MASK_128 ((uint128_t) 0xFFFFFFFFFFFFFFFFULL | (uint128_t) 0xFFFFFFFFFFFFFFFFULL << 64)
 
 LIST_HEAD(code_bloc_list_head, code_bloc_node);
 LIST_HEAD(memory_breakpoint_info_head, memory_breakpoint_info);
@@ -174,13 +193,13 @@ void vm_MEM_WRITE_08(vm_mngr_t* vm_mngr, uint64_t addr, unsigned char src);
 void vm_MEM_WRITE_16(vm_mngr_t* vm_mngr, uint64_t addr, unsigned short src);
 void vm_MEM_WRITE_32(vm_mngr_t* vm_mngr, uint64_t addr, unsigned int src);
 void vm_MEM_WRITE_64(vm_mngr_t* vm_mngr, uint64_t addr, uint64_t src);
-
+void vm_MEM_WRITE_128(vm_mngr_t* vm_mngr, uint64_t addr, uint128_t src);
 
 unsigned char vm_MEM_LOOKUP_08(vm_mngr_t* vm_mngr, uint64_t addr);
 unsigned short vm_MEM_LOOKUP_16(vm_mngr_t* vm_mngr, uint64_t addr);
 unsigned int vm_MEM_LOOKUP_32(vm_mngr_t* vm_mngr, uint64_t addr);
 uint64_t vm_MEM_LOOKUP_64(vm_mngr_t* vm_mngr, uint64_t addr);
-
+uint128_t vm_MEM_LOOKUP_128(vm_mngr_t* vm_mngr, uint128_t addr);
 
 void MEM_WRITE_08_PASSTHROUGH(uint64_t addr, unsigned char src);
 void MEM_WRITE_16_PASSTHROUGH(uint64_t addr, unsigned short src);

--- a/test/arch/x86/unit/access_xmm.py
+++ b/test/arch/x86/unit/access_xmm.py
@@ -1,0 +1,16 @@
+#! /usr/bin/env python2
+"""Test getter and setter for XMM registers (128 bits)"""
+
+from miasm2.analysis.machine import Machine
+
+# Jitter engine doesn't matter, use the always available 'python' one
+myjit = Machine("x86_32").jitter("python")
+
+# Test basic access (get)
+assert myjit.cpu.XMM0 == 0
+
+# Test set
+myjit.cpu.XMM1 = 0x00112233445566778899aabbccddeeffL
+
+# Ensure set has been correctly handled
+assert myjit.cpu.XMM1 == 0x00112233445566778899aabbccddeeffL

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -97,6 +97,8 @@ for script in ["x86/sem.py",
         tags = [TAGS[jitter]] if jitter in TAGS else []
         testset += ArchUnitTest(script, jitter, base_dir="arch", tags=tags)
 
+testset += ArchUnitTest("x86/unit/access_xmm.py", "python", base_dir="arch")
+
 ### QEMU regression tests
 class QEMUTest(RegressionTest):
     """Test against QEMU regression tests


### PR DESCRIPTION
Add support for:
* XMM registers in x86, including accessors and setters
* 128bits memory lookup and write in VmMngr
* 128bits operations in GCC jitter engine outputs

Note: as 128 bits constants are not supported by GCC, the following format is used: `"(0x%{low_part}x | ((uint128_t) 0x%{high_part}x << 64))"`, which is accepted and correctly handled by GCC
Note (2nd): `PyObject <-> uint128_t` conversion are done through `_PyLong_FromByteArray` and `_PyLong_AsByteArray`. The endless support of these functions is not guaranteed, but unlikely to change (see this [Python developer statement](http://grokbase.com/t/python/python-list/068cxrdske/pylong-frombytearray))

One can check that XMM is correctly handled by running `python arch/x86/qemu/testqemu.py -j {jitter_engine} arch/x86/qemu/test-i386 test_sse arch/x86/qemu/expected/test_sse.exp`, which should run correctly for the 224 first checks (see #674 for more details)