### PR TITLE
Example/ida: use addr to guess arch

### DIFF
--- a/example/ida/depgraph.py
+++ b/example/ida/depgraph.py
@@ -198,8 +198,12 @@ def next_element():
 
 def launch_depgraph():
     global graphs, comments, sol_nb, settings, addr, ir_arch
+    # Get the current function
+    addr = idc.ScreenEA()
+    func = ida_funcs.get_func(addr)
+
     # Init
-    machine = guess_machine()
+    machine = guess_machine(addr=func.startEA)
     mn, dis_engine, ira = machine.mn, machine.dis_engine, machine.ira
 
     bs = bin_stream_ida()
@@ -212,9 +216,6 @@ def launch_depgraph():
             continue
         mdis.symbol_pool.add_location(name, ad)
 
-    # Get the current function
-    addr = idc.ScreenEA()
-    func = ida_funcs.get_func(addr)
     asmcfg = mdis.dis_multiblock(func.startEA)
 
     # Generate IR

--- a/example/ida/graph_ir.py
+++ b/example/ida/graph_ir.py
@@ -98,7 +98,9 @@ class GraphMiasmIR(idaapi.GraphViewer):
 
 
 def build_graph(verbose=False, simplify=False):
-    machine = guess_machine()
+    start_addr = idc.ScreenEA()
+
+    machine = guess_machine(addr=start_addr)
     mn, dis_engine, ira = machine.mn, machine.dis_engine, machine.ira
 
     if verbose:
@@ -125,17 +127,16 @@ def build_graph(verbose=False, simplify=False):
 
     if verbose:
         print "start disasm"
-    addr = idc.ScreenEA()
     if verbose:
         print hex(addr)
 
-    asmcfg = mdis.dis_multiblock(addr)
+    asmcfg = mdis.dis_multiblock(start_addr)
 
     if verbose:
         print "generating graph"
         open('asm_flow.dot', 'w').write(asmcfg.dot())
 
-        print "generating IR... %x" % addr
+        print "generating IR... %x" % start_addr
 
     for block in asmcfg.blocks:
         if verbose:
@@ -144,7 +145,7 @@ def build_graph(verbose=False, simplify=False):
         ir_arch.add_block(block)
 
     if verbose:
-        print "IR ok... %x" % addr
+        print "IR ok... %x" % start_addr
 
     for irb in ir_arch.blocks.itervalues():
         irs = []

--- a/example/ida/symbol_exec.py
+++ b/example/ida/symbol_exec.py
@@ -128,11 +128,12 @@ def symbolic_exec():
 
     from utils import guess_machine
 
+    start, end = idc.SelStart(), idc.SelEnd()
+
     bs = bin_stream_ida()
-    machine = guess_machine()
+    machine = guess_machine(addr=start)
 
     mdis = machine.dis_engine(bs)
-    start, end = idc.SelStart(), idc.SelEnd()
 
     if start == idc.BADADDR and end == idc.BADADDR:
         start = idc.ScreenEA()

--- a/example/ida/utils.py
+++ b/example/ida/utils.py
@@ -5,7 +5,7 @@ from miasm2.analysis.machine import Machine
 from miasm2.ir.translators import Translator
 import miasm2.expression.expression as m2_expr
 
-def guess_machine():
+def guess_machine(addr=None):
     "Return an instance of Machine corresponding to the IDA guessed processor"
 
     processor_name = GetLongPrm(INF_PROCNAME)
@@ -39,7 +39,14 @@ def guess_machine():
                         (False, 64, True): "aarch64b",
                         (False, 64, False): "aarch64l",
                         }
-        is_armt = globals().get('armt', False)
+
+        # Get T reg to detect arm/thumb function
+        # Default is arm
+        is_armt = False
+        if addr is not None:
+            t_reg = GetReg(addr, "T")
+            is_armt = t_reg == 1
+
         is_bigendian = info.is_be()
         infos = (is_armt, size, is_bigendian)
         if not infos in info2machine:

--- a/miasm2/analysis/binary.py
+++ b/miasm2/analysis/binary.py
@@ -202,6 +202,8 @@ class ContainerELF(Container):
                 offset = symb.value
                 if offset == 0:
                     continue
+                if not name:
+                    continue
                 try:
                     self._symbol_pool.add_location(name, offset)
                 except ValueError:

--- a/miasm2/expression/expression_reduce.py
+++ b/miasm2/expression/expression_reduce.py
@@ -4,8 +4,8 @@ Apply reduction rules to an Expression ast
 """
 
 import logging
-from miasm2.expression.expression import ExprInt, ExprId, ExprOp, ExprSlice,\
-    ExprCompose, ExprMem, ExprCond
+from miasm2.expression.expression import ExprInt, ExprId, ExprLoc, ExprOp, \
+    ExprSlice, ExprCompose, ExprMem, ExprCond
 
 log_reduce = logging.getLogger("expr_reduce")
 console_handler = logging.StreamHandler()
@@ -29,7 +29,7 @@ class ExprNode(object):
         expr = self.expr
         if self.info is not None:
             out = repr(self.info)
-        elif expr.is_int() or expr.is_id():
+        elif expr.is_int() or expr.is_id() or expr.is_loc():
             out = str(expr)
         elif expr.is_mem():
             out = "@%d[%r]" % (self.expr.size, self.arg)
@@ -76,7 +76,7 @@ class ExprReducer(object):
         @expr: Expression to analyze
         """
 
-        if isinstance(expr, (ExprId, ExprInt)):
+        if isinstance(expr, (ExprId, ExprLoc, ExprInt)):
             node = ExprNode(expr)
         elif isinstance(expr, (ExprMem, ExprSlice)):
             son = self.expr2node(expr.arg)
@@ -118,7 +118,7 @@ class ExprReducer(object):
 
         expr = node.expr
         log_reduce.debug("\t" * lvl + "Reduce...: %s", node.expr)
-        if isinstance(expr, (ExprId, ExprInt)):
+        if isinstance(expr, (ExprId, ExprInt, ExprLoc)):
             pass
         elif isinstance(expr, ExprMem):
             arg = self.categorize(node.arg, lvl=lvl + 1, **kwargs)

--- a/miasm2/ir/symbexec.py
+++ b/miasm2/ir/symbexec.py
@@ -1050,15 +1050,7 @@ class SymbolicExecutionEngine(object):
                 print '_' * 80
         dst = self.eval_expr(self.ir_arch.IRDst)
 
-        # Best effort to resolve destination as ExprLoc
-        if dst.is_loc():
-            ret = dst
-        elif dst.is_int():
-            label = self.ir_arch.symbol_pool.getby_offset_create(int(dst))
-            ret = ExprLoc(label, dst.size)
-        else:
-            ret = dst
-        return ret
+        return dst
 
     def run_block_at(self, addr, step=False):
         """


### PR DESCRIPTION
Some arch like ARM depends on address in order to determine which
attributes have to be used during analysis