### PR TITLE
Refactor/jitter cleaning

### DIFF
--- a/miasm2/analysis/dse.py
+++ b/miasm2/analysis/dse.py
@@ -189,7 +189,7 @@ class DSEEngine(object):
         self.jitter.exec_cb = self.callback
 
         # Clean jit cache to avoid multi-line basic blocks already jitted
-        self.jitter.jit.loc_key_to_jit_block.clear()
+        self.jitter.jit.clear_jitted_blocks()
 
     def attach(self, emulator):
         """Attach the DSE to @emulator

--- a/miasm2/arch/mips32/jit.py
+++ b/miasm2/arch/mips32/jit.py
@@ -71,7 +71,7 @@ class mipsCGen(CGen):
 
         loc_key = self.get_block_post_label(block)
         offset = self.ir_arch.symbol_pool.loc_key_to_offset(loc_key)
-        out = (self.CODE_RETURN_NO_EXCEPTION % (self.loc_key_to_jitlabel(loc_key),
+        out = (self.CODE_RETURN_NO_EXCEPTION % (loc_key,
                                                 self.C_PC,
                                                 m2_expr.ExprId('branch_dst_irdst', 32),
                                                 m2_expr.ExprId('branch_dst_irdst', 32),

--- a/miasm2/ir/translators/C.py
+++ b/miasm2/ir/translators/C.py
@@ -56,10 +56,9 @@ class TranslatorC(Translator):
             return str(loc_key)
 
         offset = self.symbol_pool.loc_key_to_offset(loc_key)
-        name = self.symbol_pool.loc_key_to_name(loc_key)
-
         if offset is None:
-            return name
+            return str(loc_key)
+
         return "0x%x" % offset
 
     def from_ExprAff(self, expr):

--- a/miasm2/jitter/Jitgcc.c
+++ b/miasm2/jitter/Jitgcc.c
@@ -16,7 +16,7 @@ PyObject* gcc_exec_block(PyObject* self, PyObject* args)
 	PyObject* jitcpu;
 	PyObject* func_py;
 	PyObject* lbl2ptr;
-	PyObject* breakpoints;
+	PyObject* stop_offsets;
 	PyObject* retaddr = NULL;
 	int status;
 	block_id BlockDst;
@@ -26,7 +26,7 @@ PyObject* gcc_exec_block(PyObject* self, PyObject* args)
 
 
 	if (!PyArg_ParseTuple(args, "OOOO|K",
-			      &retaddr, &jitcpu, &lbl2ptr, &breakpoints,
+			      &retaddr, &jitcpu, &lbl2ptr, &stop_offsets,
 			      &max_exec_per_call))
 		return NULL;
 
@@ -73,8 +73,8 @@ PyObject* gcc_exec_block(PyObject* self, PyObject* args)
 		if (status)
 			return retaddr;
 
-		// Check breakpoint
-		if (PyDict_Contains(breakpoints, retaddr))
+		// Check stop offsets
+		if (PySet_Contains(stop_offsets, retaddr))
 			return retaddr;
 	}
 }

--- a/miasm2/jitter/Jitgcc.c
+++ b/miasm2/jitter/Jitgcc.c
@@ -10,7 +10,7 @@ typedef struct {
 typedef int (*jitted_func)(block_id*, PyObject*);
 
 
-PyObject* gcc_exec_bloc(PyObject* self, PyObject* args)
+PyObject* gcc_exec_block(PyObject* self, PyObject* args)
 {
 	jitted_func func;
 	PyObject* jitcpu;
@@ -85,8 +85,8 @@ static PyObject *GccError;
 
 
 static PyMethodDef GccMethods[] = {
-    {"gcc_exec_bloc",  gcc_exec_bloc, METH_VARARGS,
-     "gcc exec bloc"},
+    {"gcc_exec_block",  gcc_exec_block, METH_VARARGS,
+     "gcc exec block"},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/miasm2/jitter/Jitllvm.c
+++ b/miasm2/jitter/Jitllvm.c
@@ -20,14 +20,14 @@ PyObject* llvm_exec_block(PyObject* self, PyObject* args)
 	uint8_t status;
 	PyObject* func_py;
 	PyObject* lbl2ptr;
-	PyObject* breakpoints;
+	PyObject* stop_offsets;
 	PyObject* retaddr = NULL;
 	uint64_t max_exec_per_call = 0;
 	uint64_t cpt;
 	int do_cpt;
 
 	if (!PyArg_ParseTuple(args, "OOOO|K",
-			      &retaddr, &jitcpu, &lbl2ptr, &breakpoints,
+			      &retaddr, &jitcpu, &lbl2ptr, &stop_offsets,
 			      &max_exec_per_call))
 		return NULL;
 
@@ -68,8 +68,8 @@ PyObject* llvm_exec_block(PyObject* self, PyObject* args)
 		if (status)
 			return retaddr;
 
-		// Check breakpoint
-		if (PyDict_Contains(breakpoints, retaddr))
+		// Check stop offsets
+		if (PySet_Contains(stop_offsets, retaddr))
 			return retaddr;
 	}
 }

--- a/miasm2/jitter/Jitllvm.c
+++ b/miasm2/jitter/Jitllvm.c
@@ -10,7 +10,7 @@
 // Needed to get the JitCpu.cpu offset, arch independent
 #include "arch/JitCore_x86.h"
 
-PyObject* llvm_exec_bloc(PyObject* self, PyObject* args)
+PyObject* llvm_exec_block(PyObject* self, PyObject* args)
 {
 	uint64_t (*func)(void*, void*, void*, uint8_t*);
 	vm_cpu_t* cpu;
@@ -76,8 +76,8 @@ PyObject* llvm_exec_bloc(PyObject* self, PyObject* args)
 
 
 static PyMethodDef LLVMMethods[] = {
-    {"llvm_exec_bloc",  llvm_exec_bloc, METH_VARARGS,
-     "llvm exec bloc"},
+    {"llvm_exec_block",  llvm_exec_block, METH_VARARGS,
+     "llvm exec block"},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/miasm2/jitter/jitcore.py
+++ b/miasm2/jitter/jitcore.py
@@ -29,6 +29,9 @@ class JitCore(object):
 
     "JiT management. This is an abstract class"
 
+    # Jitted function's name
+    FUNCNAME = "block_entry"
+
     jitted_block_delete_cb = None
     jitted_block_max_size = 10000
 

--- a/miasm2/jitter/jitcore.py
+++ b/miasm2/jitter/jitcore.py
@@ -166,10 +166,16 @@ class JitCore(object):
         self.add_block_to_mem_interval(vm, cur_block)
         return cur_block
 
-    def run_at(self, cpu, offset, breakpoints):
-        """Run from the starting address @offset
+    def run_at(self, cpu, offset, stop_offsets):
+        """Run from the starting address @offset.
+        Execution will stop if:
+        - max_exec_per_call option is reached
+        - a new, yet unknown, block is reached after the execution of block at
+          address @offset
+        - an address in @stop_offsets is reached
         @cpu: JitCpu instance
-        @offset: target offset
+        @offset: starting address (int)
+        @stop_offsets: set of address on which the jitter must stop
         """
 
         if offset is None:
@@ -189,7 +195,8 @@ class JitCore(object):
                 return offset
 
         # Run the block and update cpu/vmmngr state
-        return self.exec_wrapper(offset, cpu, self.offset_to_jitted_func.data, breakpoints,
+        return self.exec_wrapper(offset, cpu, self.offset_to_jitted_func.data,
+                                 stop_offsets,
                                  self.options["max_exec_per_call"])
 
     def blocks_to_memrange(self, blocks):

--- a/miasm2/jitter/jitcore.py
+++ b/miasm2/jitter/jitcore.py
@@ -35,34 +35,33 @@ class JitCore(object):
     jitted_block_delete_cb = None
     jitted_block_max_size = 10000
 
-    def __init__(self, ir_arch, bs=None):
+    def __init__(self, ir_arch, bin_stream):
         """Initialise a JitCore instance.
         @ir_arch: ir instance for current architecture
-        @bs: bitstream
+        @bin_stream: bin_stream instance
         """
-
+        # Arch related
         self.ir_arch = ir_arch
         self.arch_name = "%s%s" % (self.ir_arch.arch.name, self.ir_arch.attrib)
-        self.bs = bs
-        self.known_blocs = {}
-        self.loc_key_to_jit_block = BoundedDict(self.jitted_block_max_size,
+
+        # Structures for block tracking
+        self.offset_to_jitted_func = BoundedDict(self.jitted_block_max_size,
                                        delete_cb=self.jitted_block_delete_cb)
-        self.lbl2bloc = {}
+        self.loc_key_to_block = {}
+        self.blocks_mem_interval = interval()
+
+        # Logging & options
         self.log_mn = False
         self.log_regs = False
         self.log_newbloc = False
-        self.segm_to_do = set()
-        self.jitcount = 0
-        self.addr2obj = {}
-        self.addr2objref = {}
-        self.blocs_mem_interval = interval()
-        self.split_dis = set()
         self.options = {"jit_maxline": 50,  # Maximum number of line jitted
                         "max_exec_per_call": 0 # 0 means no limit
                         }
 
+        # Disassembly Engine
+        self.split_dis = set()
         self.mdis = disasmEngine(
-            ir_arch.arch, ir_arch.attrib, bs,
+            ir_arch.arch, ir_arch.attrib, bin_stream,
             lines_wd=self.options["jit_maxline"],
             symbol_pool=ir_arch.symbol_pool,
             follow_call=False,
@@ -73,14 +72,13 @@ class JitCore(object):
 
     def set_options(self, **kwargs):
         "Set options relative to the backend"
-
         self.options.update(kwargs)
 
     def clear_jitted_blocks(self):
         "Reset all jitted blocks"
-        self.loc_key_to_jit_block.clear()
-        self.lbl2bloc.clear()
-        self.blocs_mem_interval = interval()
+        self.offset_to_jitted_func.clear()
+        self.loc_key_to_block.clear()
+        self.blocks_mem_interval = interval()
 
     def add_disassembly_splits(self, *args):
         """The disassembly engine will stop on address in args if they
@@ -95,7 +93,7 @@ class JitCore(object):
         "Initialise the Jitter"
         raise NotImplementedError("Abstract class")
 
-    def get_bloc_min_max(self, cur_block):
+    def set_block_min_max(self, cur_block):
         "Update cur_block to set min/max address"
 
         if cur_block.lines:
@@ -108,32 +106,31 @@ class JitCore(object):
             cur_block.ad_max = offset+1
 
 
-    def add_bloc_to_mem_interval(self, vm, block):
+    def add_block_to_mem_interval(self, vm, block):
         "Update vm to include block addresses in its memory range"
-
-        self.blocs_mem_interval += interval([(block.ad_min, block.ad_max - 1)])
+        self.blocks_mem_interval += interval([(block.ad_min, block.ad_max - 1)])
 
         vm.reset_code_bloc_pool()
-        for a, b in self.blocs_mem_interval:
+        for a, b in self.blocks_mem_interval:
             vm.add_code_bloc(a, b + 1)
 
-    def jitirblocs(self, label, irblocks):
+    def jit_irblocks(self, label, irblocks):
         """JiT a group of irblocks.
         @label: the label of the irblocks
-        @irblocks: a gorup of irblocks
+        @irblocks: a group of irblocks
         """
 
         raise NotImplementedError("Abstract class")
 
-    def add_bloc(self, block):
+    def add_block(self, block):
         """Add a block to JiT and JiT it.
         @block: asm_bloc to add
         """
         irblocks = self.ir_arch.add_block(block, gen_pc_updt = True)
         block.blocks = irblocks
-        self.jitirblocs(block.loc_key, irblocks)
+        self.jit_irblocks(block.loc_key, irblocks)
 
-    def disbloc(self, addr, vm):
+    def disasm_and_jit_block(self, addr, vm):
         """Disassemble a new block and JiT it
         @addr: address of the block to disassemble (LocKey or int)
         @vm: VmMngr instance
@@ -157,30 +154,30 @@ class JitCore(object):
             print cur_block.to_string(self.mdis.symbol_pool)
 
         # Update label -> block
-        self.lbl2bloc[cur_block.loc_key] = cur_block
+        self.loc_key_to_block[cur_block.loc_key] = cur_block
 
         # Store min/max block address needed in jit automod code
-        self.get_bloc_min_max(cur_block)
+        self.set_block_min_max(cur_block)
 
         # JiT it
-        self.add_bloc(cur_block)
+        self.add_block(cur_block)
 
         # Update jitcode mem range
-        self.add_bloc_to_mem_interval(vm, cur_block)
+        self.add_block_to_mem_interval(vm, cur_block)
         return cur_block
 
-    def runbloc(self, cpu, lbl, breakpoints):
-        """Run the block starting at lbl.
+    def run_at(self, cpu, offset, breakpoints):
+        """Run from the starting address @offset
         @cpu: JitCpu instance
-        @lbl: target label
+        @offset: target offset
         """
 
-        if lbl is None:
-            lbl = getattr(cpu, self.ir_arch.pc.name)
+        if offset is None:
+            offset = getattr(cpu, self.ir_arch.pc.name)
 
-        if not lbl in self.loc_key_to_jit_block:
+        if offset not in self.offset_to_jitted_func:
             # Need to JiT the block
-            cur_block = self.disbloc(lbl, cpu.vmmngr)
+            cur_block = self.disasm_and_jit_block(offset, cpu.vmmngr)
             if isinstance(cur_block, AsmBlockBad):
                 errno = cur_block.errno
                 if errno == AsmBlockBad.ERROR_IO:
@@ -189,15 +186,15 @@ class JitCore(object):
                     cpu.set_exception(EXCEPT_UNK_MNEMO)
                 else:
                     raise RuntimeError("Unhandled disasm result %r" % errno)
-                return lbl
+                return offset
 
         # Run the block and update cpu/vmmngr state
-        return self.exec_wrapper(lbl, cpu, self.loc_key_to_jit_block.data, breakpoints,
+        return self.exec_wrapper(offset, cpu, self.offset_to_jitted_func.data, breakpoints,
                                  self.options["max_exec_per_call"])
 
-    def blocs2memrange(self, blocks):
+    def blocks_to_memrange(self, blocks):
         """Return an interval instance standing for blocks addresses
-        @blocks: list of asm_bloc instances
+        @blocks: list of AsmBlock instances
         """
 
         mem_range = interval()
@@ -216,10 +213,10 @@ class JitCore(object):
         vm.reset_code_bloc_pool()
 
         # Add blocks in the pool
-        for start, stop in self.blocs_mem_interval:
+        for start, stop in self.blocks_mem_interval:
             vm.add_code_bloc(start, stop + 1)
 
-    def del_bloc_in_range(self, ad1, ad2):
+    def del_block_in_range(self, ad1, ad2):
         """Find and remove jitted block in range [ad1, ad2].
         Return the list of block removed.
         @ad1: First address
@@ -228,7 +225,7 @@ class JitCore(object):
 
         # Find concerned blocks
         modified_blocks = set()
-        for block in self.lbl2bloc.values():
+        for block in self.loc_key_to_block.values():
             if not block.lines:
                 continue
             if block.ad_max <= ad1 or block.ad_min >= ad2:
@@ -239,10 +236,10 @@ class JitCore(object):
                 modified_blocks.add(block)
 
         # Generate interval to delete
-        del_interval = self.blocs2memrange(modified_blocks)
+        del_interval = self.blocks_to_memrange(modified_blocks)
 
         # Remove interval from monitored interval list
-        self.blocs_mem_interval -= del_interval
+        self.blocks_mem_interval -= del_interval
 
         # Remove modified blocks
         for block in modified_blocks:
@@ -250,17 +247,17 @@ class JitCore(object):
                 for irblock in block.blocks:
                     # Remove offset -> jitted block link
                     offset = self.ir_arch.symbol_pool.loc_key_to_offset(irblock.loc_key)
-                    if offset in self.loc_key_to_jit_block:
-                        del(self.loc_key_to_jit_block[offset])
+                    if offset in self.offset_to_jitted_func:
+                        del(self.offset_to_jitted_func[offset])
 
             except AttributeError:
                 # The block has never been translated in IR
                 offset = self.ir_arch.symbol_pool.loc_key_to_offset(block.loc_key)
-                if offset in self.loc_key_to_jit_block:
-                    del(self.loc_key_to_jit_block[offset])
+                if offset in self.offset_to_jitted_func:
+                    del(self.offset_to_jitted_func[offset])
 
             # Remove label -> block link
-            del(self.lbl2bloc[block.loc_key])
+            del(self.loc_key_to_block[block.loc_key])
 
         return modified_blocks
 
@@ -270,7 +267,7 @@ class JitCore(object):
         @mem_range: list of start/stop addresses
         """
         for addr_start, addr_stop in mem_range:
-            self.del_bloc_in_range(addr_start, addr_stop)
+            self.del_block_in_range(addr_start, addr_stop)
         self.__updt_jitcode_mem_range(vm)
         vm.reset_memory_access()
 

--- a/miasm2/jitter/jitcore_cc_base.py
+++ b/miasm2/jitter/jitcore_cc_base.py
@@ -46,9 +46,9 @@ class resolver:
 class JitCore_Cc_Base(JitCore):
     "JiT management, abstract class using a C compiler as backend"
 
-    def __init__(self, ir_arch, bs=None):
+    def __init__(self, ir_arch, bin_stream):
         self.jitted_block_delete_cb = self.deleteCB
-        super(JitCore_Cc_Base, self).__init__(ir_arch, bs)
+        super(JitCore_Cc_Base, self).__init__(ir_arch, bin_stream)
         self.resolver = resolver()
         self.ir_arch = ir_arch
         self.states = {}

--- a/miasm2/jitter/jitcore_cc_base.py
+++ b/miasm2/jitter/jitcore_cc_base.py
@@ -85,21 +85,12 @@ class JitCore_Cc_Base(JitCore):
         """
         self.codegen = codegen
 
-    def loc_key_to_filename(self, loc_key):
-        """
-        Generate function name from @loc_key
-        @loc_key: LocKey instance
-        """
-        return "block_%s" % self.codegen.loc_key_to_jitlabel(loc_key)
-
-    def gen_c_code(self, loc_key, block):
+    def gen_c_code(self, block):
         """
         Return the C code corresponding to the @irblocks
-        @loc_key: LocKey of the block to jit
         @irblocks: list of irblocks
         """
-        f_name = self.loc_key_to_filename(loc_key)
-        f_declaration = 'int %s(block_id * BlockDst, JitCpu* jitcpu)' % f_name
+        f_declaration = 'int %s(block_id * BlockDst, JitCpu* jitcpu)' % self.FUNCNAME
         out = self.codegen.gen_c(block, log_mn=self.log_mn, log_regs=self.log_regs)
         out = [f_declaration + '{'] + out + ['}\n']
         c_code = out

--- a/miasm2/jitter/jitcore_gcc.py
+++ b/miasm2/jitter/jitcore_gcc.py
@@ -13,9 +13,9 @@ from miasm2.jitter.jitcore_cc_base import JitCore_Cc_Base, gen_core
 class JitCore_Gcc(JitCore_Cc_Base):
     "JiT management, using a C compiler as backend"
 
-    def __init__(self, ir_arch, bs=None):
-        super(JitCore_Gcc, self).__init__(ir_arch, bs)
-        self.exec_wrapper = Jitgcc.gcc_exec_bloc
+    def __init__(self, ir_arch, bin_stream):
+        super(JitCore_Gcc, self).__init__(ir_arch, bin_stream)
+        self.exec_wrapper = Jitgcc.gcc_exec_block
 
     def deleteCB(self, offset):
         """Free the state associated to @offset and delete it
@@ -29,10 +29,10 @@ class JitCore_Gcc(JitCore_Cc_Base):
         func = getattr(lib, self.FUNCNAME)
         addr = ctypes.cast(func, ctypes.c_void_p).value
         offset = self.ir_arch.symbol_pool.loc_key_to_offset(label)
-        self.loc_key_to_jit_block[offset] = addr
+        self.offset_to_jitted_func[offset] = addr
         self.states[offset] = lib
 
-    def add_bloc(self, block):
+    def add_block(self, block):
         """Add a bloc to JiT and JiT it.
         @block: block to jit
         """

--- a/miasm2/jitter/jitcore_gcc.py
+++ b/miasm2/jitter/jitcore_gcc.py
@@ -25,9 +25,8 @@ class JitCore_Gcc(JitCore_Cc_Base):
         del self.states[offset]
 
     def load_code(self, label, fname_so):
-        f_name = self.loc_key_to_filename(label)
         lib = ctypes.cdll.LoadLibrary(fname_so)
-        func = getattr(lib, f_name)
+        func = getattr(lib, self.FUNCNAME)
         addr = ctypes.cast(func, ctypes.c_void_p).value
         offset = self.ir_arch.symbol_pool.loc_key_to_offset(label)
         self.loc_key_to_jit_block[offset] = addr
@@ -41,7 +40,7 @@ class JitCore_Gcc(JitCore_Cc_Base):
         fname_out = os.path.join(self.tempdir, "%s.so" % block_hash)
 
         if not os.access(fname_out, os.R_OK | os.X_OK):
-            func_code = self.gen_c_code(block.loc_key, block)
+            func_code = self.gen_c_code(block)
 
             # Create unique C file
             fdesc, fname_in = tempfile.mkstemp(suffix=".c")

--- a/miasm2/jitter/jitcore_llvm.py
+++ b/miasm2/jitter/jitcore_llvm.py
@@ -19,8 +19,8 @@ class JitCore_LLVM(jitcore.JitCore):
                            "ppc32": "JitCore_ppc32.so",
     }
 
-    def __init__(self, ir_arch, bs=None):
-        super(JitCore_LLVM, self).__init__(ir_arch, bs)
+    def __init__(self, ir_arch, bin_stream):
+        super(JitCore_LLVM, self).__init__(ir_arch, bin_stream)
 
         self.options.update({"safe_mode": True,   # Verify each function
                              "optimise": True,     # Optimise functions
@@ -28,7 +28,7 @@ class JitCore_LLVM(jitcore.JitCore):
                              "log_assembly": False,  # Print assembly executed
                              })
 
-        self.exec_wrapper = Jitllvm.llvm_exec_bloc
+        self.exec_wrapper = Jitllvm.llvm_exec_block
         self.ir_arch = ir_arch
 
         # Cache temporary dir
@@ -73,7 +73,7 @@ class JitCore_LLVM(jitcore.JitCore):
         # Enable caching
         self.context.enable_cache()
 
-    def add_bloc(self, block):
+    def add_block(self, block):
         """Add a block to JiT and JiT it.
         @block: the block to add
         """
@@ -119,4 +119,4 @@ class JitCore_LLVM(jitcore.JitCore):
         # Store a pointer on the function jitted code
         loc_key = block.loc_key
         offset = self.ir_arch.symbol_pool.loc_key_to_offset(loc_key)
-        self.loc_key_to_jit_block[offset] = ptr
+        self.offset_to_jitted_func[offset] = ptr

--- a/miasm2/jitter/jitcore_llvm.py
+++ b/miasm2/jitter/jitcore_llvm.py
@@ -8,7 +8,6 @@ import Jitllvm
 
 
 class JitCore_LLVM(jitcore.JitCore):
-
     "JiT management, using LLVM as backend"
 
     # Architecture dependant libraries
@@ -84,7 +83,7 @@ class JitCore_LLVM(jitcore.JitCore):
 
         if not os.access(fname_out, os.R_OK):
             # Build a function in the context
-            func = LLVMFunction(self.context, block.loc_key)
+            func = LLVMFunction(self.context, self.FUNCNAME)
 
             # Set log level
             func.log_regs = self.log_regs
@@ -115,7 +114,7 @@ class JitCore_LLVM(jitcore.JitCore):
 
         else:
             # The cache file exists: function can be loaded from cache
-            ptr = self.context.get_ptr_from_cache(fname_out, block.loc_key)
+            ptr = self.context.get_ptr_from_cache(fname_out, self.FUNCNAME)
 
         # Store a pointer on the function jitted code
         loc_key = block.loc_key

--- a/miasm2/jitter/jitcore_python.py
+++ b/miasm2/jitter/jitcore_python.py
@@ -15,8 +15,8 @@ class JitCore_Python(jitcore.JitCore):
 
     SymbExecClass = EmulatedSymbExec
 
-    def __init__(self, ir_arch, bs=None):
-        super(JitCore_Python, self).__init__(ir_arch, bs)
+    def __init__(self, ir_arch, bin_stream):
+        super(JitCore_Python, self).__init__(ir_arch, bin_stream)
         self.ir_arch = ir_arch
 
         # CPU & VM (None for now) will be set later
@@ -34,10 +34,10 @@ class JitCore_Python(jitcore.JitCore):
         "Preload symbols according to current architecture"
         self.symbexec.reset_regs()
 
-    def jitirblocs(self, loc_key, irblocks):
+    def jit_irblocks(self, loc_key, irblocks):
         """Create a python function corresponding to an irblocks' group.
         @loc_key: the loc_key of the irblocks
-        @irblocks: a gorup of irblocks
+        @irblocks: a group of irblocks
         """
 
         def myfunc(cpu):
@@ -129,9 +129,9 @@ class JitCore_Python(jitcore.JitCore):
         # Associate myfunc with current loc_key
         offset = self.ir_arch.symbol_pool.loc_key_to_offset(loc_key)
         assert offset is not None
-        self.loc_key_to_jit_block[offset] = myfunc
+        self.offset_to_jitted_func[offset] = myfunc
 
-    def exec_wrapper(self, loc_key, cpu, _loc_key_to_jit_block, _breakpoints,
+    def exec_wrapper(self, loc_key, cpu, _offset_to_jitted_func, _breakpoints,
                      _max_exec_per_call):
         """Call the function @loc_key with @cpu
         @loc_key: function's loc_key
@@ -139,7 +139,7 @@ class JitCore_Python(jitcore.JitCore):
         """
 
         # Get Python function corresponding to @loc_key
-        fc_ptr = self.loc_key_to_jit_block[loc_key]
+        fc_ptr = self.offset_to_jitted_func[loc_key]
 
         # Execute the function
         return fc_ptr(cpu)

--- a/miasm2/jitter/jitcore_python.py
+++ b/miasm2/jitter/jitcore_python.py
@@ -131,7 +131,7 @@ class JitCore_Python(jitcore.JitCore):
         assert offset is not None
         self.offset_to_jitted_func[offset] = myfunc
 
-    def exec_wrapper(self, loc_key, cpu, _offset_to_jitted_func, _breakpoints,
+    def exec_wrapper(self, loc_key, cpu, _offset_to_jitted_func, _stop_offsets,
                      _max_exec_per_call):
         """Call the function @loc_key with @cpu
         @loc_key: function's loc_key

--- a/miasm2/jitter/jitload.py
+++ b/miasm2/jitter/jitload.py
@@ -303,11 +303,11 @@ class Jitter(object):
         """
         self.exceptions_handler.add_callback(flag, callback)
 
-    def runbloc(self, pc):
+    def run_at(self, pc):
         """Wrapper on JiT backend. Run the code at PC and return the next PC.
         @pc: address of code to run"""
 
-        return self.jit.runbloc(self.cpu, pc, self.breakpoints_handler.callbacks)
+        return self.jit.run_at(self.cpu, pc, self.breakpoints_handler.callbacks)
 
     def runiter_once(self, pc):
         """Iterator on callbacks results on code running from PC.
@@ -349,7 +349,7 @@ class Jitter(object):
         assert(self.get_exception() == 0)
 
         # Run the bloc at PC
-        self.pc = self.runbloc(self.pc)
+        self.pc = self.run_at(self.pc)
 
         # Check exceptions (raised by the execution of the block)
         exception_flag = self.get_exception()

--- a/miasm2/jitter/jitload.py
+++ b/miasm2/jitter/jitload.py
@@ -307,7 +307,10 @@ class Jitter(object):
         """Wrapper on JiT backend. Run the code at PC and return the next PC.
         @pc: address of code to run"""
 
-        return self.jit.run_at(self.cpu, pc, self.breakpoints_handler.callbacks)
+        return self.jit.run_at(
+            self.cpu, pc,
+            set(self.breakpoints_handler.callbacks.keys())
+        )
 
     def runiter_once(self, pc):
         """Iterator on callbacks results on code running from PC.

--- a/miasm2/jitter/llvmconvert.py
+++ b/miasm2/jitter/llvmconvert.py
@@ -75,16 +75,10 @@ class LLVMContext():
         @label: str or asmlabel instance"""
         if isinstance(label, str):
             return label
-        if not isinstance(label, LocKey):
-            raise ValueError("label must either be str or LocKey")
-
-        offset = self.ir_arch.symbol_pool.loc_key_to_offset(label)
-
-        if offset is None:
-            name = self.ir_arch.symbol_pool.loc_key_to_name(label)
-            return "%s" % name
+        elif isinstance(label, LocKey):
+            return str(label)
         else:
-            return "label_off_%X" % offset
+            raise ValueError("label must either be str or LocKey")
 
     def optimise_level(self, level=2):
         """Set the optimisation level to @level from 0 to 2
@@ -341,7 +335,6 @@ class LLVMContext_JIT(LLVMContext):
     def get_ptr_from_cache(self, file_name, func_name):
         "Load @file_name and return a pointer on the jitter @func_name"
         # We use an empty module to avoid loosing time on function building
-        func_name = self.canonize_label_name(func_name)
         empty_module = llvm.parse_assembly("")
         empty_module.fname_out = file_name
 
@@ -398,7 +391,6 @@ class LLVMFunction():
     def __init__(self, llvm_context, name="fc", new_module=True):
         "Create a new function with name @name"
         self.llvm_context = llvm_context
-        name = self.llvm_context.canonize_label_name(name)
         if new_module:
             self.llvm_context.new_module()
         self.mod = self.llvm_context.get_module()


### PR DESCRIPTION
API cleaning in jitcore (and related) & use only loc_key for basic block labeling in jitter internals