### PR TITLE
Fix ARM C function calling

### DIFF
--- a/miasm2/arch/arm/jit.py
+++ b/miasm2/arch/arm/jit.py
@@ -90,8 +90,8 @@ class jitter_arml(Jitter):
     def func_prepare_stdcall(self, ret_addr, *args):
         for index in xrange(min(len(args), 4)):
             setattr(self.cpu, 'R%d' % index, args[index])
-        for index in xrange(4, len(args)):
-            self.vm.set_mem(self.cpu.SP + 4 * (index - 4), pck32(args[index]))
+        for index in reversed(xrange(4, len(args))):
+            self.push_uint32_t(args[index])
         self.cpu.LR = ret_addr
 
     def get_arg_n_stdcall(self, index):


### PR DESCRIPTION
Arguments were not pushed correctly on the stack (for functions with
more than four arguments)