### PR TITLE
Jitter: Fix memory leak

### DIFF
--- a/miasm2/jitter/arch/JitCore_x86.c
+++ b/miasm2/jitter/arch/JitCore_x86.c
@@ -208,6 +208,7 @@ PyObject* cpu_set_gpreg(JitCpu* self, PyObject *args)
 					    bn_t bn;
 					    int j;
 					    PyObject* py_long = d_value;
+					    PyObject* py_long_new;
 					    PyObject* py_tmp;
 					    PyObject* cst_32;
 					    PyObject* cst_ffffffff;
@@ -219,6 +220,7 @@ PyObject* cpu_set_gpreg(JitCpu* self, PyObject *args)
 						    py_long = PyLong_FromLong((long)tmp);
 					    } else if (PyLong_Check(py_long)){
 						    /* Already PyLong */
+						    Py_INCREF(py_long);
 					    }
 					    else{
 						    RAISE(PyExc_TypeError,"arg must be int");
@@ -233,10 +235,18 @@ PyObject* cpu_set_gpreg(JitCpu* self, PyObject *args)
 					    for (j = 0; j < BN_BYTE_SIZE; j += 4) {
 						    py_tmp = PyObject_CallMethod(py_long, "__and__", "O", cst_ffffffff);
 						    tmp = PyLong_AsUnsignedLongMask(py_tmp);
+						    Py_DECREF(py_tmp);
 						    bn = bignum_lshift(bn, 32);
 						    bn = bignum_or(bn, bignum_from_uint64(tmp));
-						    py_long = PyObject_CallMethod(py_long, "__rshift__", "O", cst_32);
+
+						    py_long_new = PyObject_CallMethod(py_long, "__rshift__", "O", cst_32);
+						    Py_DECREF(py_long);
+						    py_long = py_long_new;
 					    }
+					    Py_DECREF(py_long);
+					    Py_DECREF(cst_32);
+					    Py_DECREF(cst_ffffffff);
+
 
 
 					    *(bn_t*)(((char*)(self->cpu)) + gpreg_dict[i].offset) = bn;


### PR DESCRIPTION
References on PyLong where lost.
Memory exhaustion may hapen in python jitter because of high usage of
get/set register.