### PR TITLE
Exprassign

### DIFF
--- a/example/expression/solve_condition_stp.py
+++ b/example/expression/solve_condition_stp.py
@@ -5,7 +5,7 @@ from pdb import pm
 
 from miasm2.analysis.machine import Machine
 from miasm2.expression.expression import ExprInt, ExprCond, ExprId, \
-    get_expr_ids, ExprAff, ExprLoc
+    get_expr_ids, ExprAssign, ExprLoc
 from miasm2.core.bin_stream import bin_stream_str
 from miasm2.ir.symbexec import SymbolicExecutionEngine, get_block
 from miasm2.expression.simplifications import expr_simp
@@ -166,7 +166,7 @@ if __name__ == '__main__':
             expr_test = ExprCond(expr,
                                  ExprInt(1, value.size),
                                  ExprInt(0, value.size))
-            cond = translator_smt2.from_expr(ExprAff(expr_test, value))
+            cond = translator_smt2.from_expr(ExprAssign(expr_test, value))
             conditions.append(cond)
 
         for name in all_ids:

--- a/example/ida/ctype_propagation.py
+++ b/example/ida/ctype_propagation.py
@@ -10,7 +10,7 @@ from miasm2.arch.x86.ctype import CTypeAMD64_unk, CTypeX86_unk
 from miasm2.arch.msp430.ctype import CTypeMSP430_unk
 from miasm2.core.objc import CTypesManagerNotPacked, ExprToAccessC, CHandler
 from miasm2.core.ctypesmngr import CAstTypes
-from miasm2.expression.expression import ExprLoc, ExprInt, ExprOp, ExprAff
+from miasm2.expression.expression import ExprLoc, ExprInt, ExprOp, ExprAssign
 from miasm2.ir.symbexec_types import SymbExecCType
 from miasm2.expression.parser import str_to_expr
 from miasm2.analysis.cst_propag import add_state, propagate_cst_expr
@@ -232,8 +232,8 @@ def get_ira_call_fixer(ira):
             print hex(stk_diff)
             call_assignblk = AssignBlock(
                 [
-                    ExprAff(self.ret_reg, ExprOp('call_func_ret', ad)),
-                    ExprAff(self.sp, self.sp + ExprInt(stk_diff, self.sp.size))
+                    ExprAssign(self.ret_reg, ExprOp('call_func_ret', ad)),
+                    ExprAssign(self.sp, self.sp + ExprInt(stk_diff, self.sp.size))
                 ],
                 instr
             )
@@ -314,8 +314,8 @@ def analyse_function():
 
     assignblk_head = AssignBlock(
         [
-            ExprAff(ir_arch.IRDst, ExprLoc(lbl_real_start, ir_arch.IRDst.size)),
-            ExprAff(ir_arch.sp, ir_arch.arch.regs.regs_init[ir_arch.sp])
+            ExprAssign(ir_arch.IRDst, ExprLoc(lbl_real_start, ir_arch.IRDst.size)),
+            ExprAssign(ir_arch.sp, ir_arch.arch.regs.regs_init[ir_arch.sp])
         ],
         first_block.lines[0]
     )

--- a/example/ida/symbol_exec.py
+++ b/example/ida/symbol_exec.py
@@ -3,7 +3,7 @@ import operator
 import idaapi
 import idc
 from miasm2.expression.expression_helper import Variables_Identifier
-from miasm2.expression.expression import ExprAff
+from miasm2.expression.expression import ExprAssign
 
 from utils import expr2colorstr, translatorForm
 
@@ -64,7 +64,7 @@ class symbolicexec_t(idaapi.simplecustviewer_t):
 
     def translate_expr(self, line_nb):
         element = self.line2eq[line_nb]
-        expr = ExprAff(*element)
+        expr = ExprAssign(*element)
         form = translatorForm(expr)
         form.Compile()
         form.Execute()

--- a/example/ida/utils.py
+++ b/example/ida/utils.py
@@ -145,7 +145,7 @@ class TranslatorIDA(Translator):
                     for arg in expr._args
                 ) + ')')
 
-    def from_ExprAff(self, expr):
+    def from_ExprAssign(self, expr):
         return "%s = %s" % tuple(map(expr.from_expr, (expr.dst, expr.src)))
 
 

--- a/example/symbol_exec/dse_strategies.py
+++ b/example/symbol_exec/dse_strategies.py
@@ -22,7 +22,7 @@ from argparse import ArgumentParser
 from miasm2.analysis.machine import Machine
 from miasm2.jitter.csts import PAGE_READ, PAGE_WRITE
 from miasm2.analysis.dse import DSEPathConstraint
-from miasm2.expression.expression import ExprMem, ExprId, ExprInt, ExprAff
+from miasm2.expression.expression import ExprMem, ExprId, ExprInt, ExprAssign
 
 # Argument handling
 parser = ArgumentParser("DSE Example")
@@ -102,7 +102,7 @@ while todo:
     jitter.init_run(run_addr)
 
     # Set the argument value in the jitter context
-    jitter.eval_expr(ExprAff(arg_addr, arg_value))
+    jitter.eval_expr(ExprAssign(arg_addr, arg_value))
 
     # Launch
     jitter.continue_run()

--- a/miasm2/analysis/depgraph.py
+++ b/miasm2/analysis/depgraph.py
@@ -1,6 +1,6 @@
 """Provide dependency graph"""
 
-from miasm2.expression.expression import ExprInt, ExprLoc, ExprAff
+from miasm2.expression.expression import ExprInt, ExprLoc, ExprAssign
 from miasm2.core.graph import DiGraph
 from miasm2.core.locationdb import LocationDB
 from miasm2.expression.simplifications import expr_simp_explicit
@@ -319,7 +319,7 @@ class DependencyResultImplicit(DependencyResult):
     # Z3 Solver instance
     _solver = None
 
-    unsat_expr = ExprAff(ExprInt(0, 1), ExprInt(1, 1))
+    unsat_expr = ExprAssign(ExprInt(0, 1), ExprInt(1, 1))
 
     def _gen_path_constraints(self, translator, expr, expected):
         """Generate path constraint from @expr. Handle special case with
@@ -341,7 +341,7 @@ class DependencyResultImplicit(DependencyResult):
                 conds = z3.And(
                     conds,
                     translator.from_expr(
-                        ExprAff(value,
+                        ExprAssign(value,
                                 expected))
                 )
             out.append(conds)

--- a/miasm2/analysis/dse.py
+++ b/miasm2/analysis/dse.py
@@ -56,7 +56,7 @@ except ImportError:
     z3 = None
 
 from miasm2.expression.expression import ExprMem, ExprInt, ExprCompose, \
-    ExprAff, ExprId, ExprLoc, LocKey
+    ExprAssign, ExprId, ExprLoc, LocKey
 from miasm2.core.bin_stream import bin_stream_vm
 from miasm2.jitter.emulatedsymbexec import EmulatedSymbExec
 from miasm2.expression.expression_helper import possible_values
@@ -626,14 +626,14 @@ class DSEPathConstraint(DSEEngine):
                 target_addr = self.ir_arch.loc_db.canonize_to_exprloc(
                     possibility.value
                 )
-                path_constraint = set() # Set of ExprAff for the possible path
+                path_constraint = set() # Set of ExprAssign for the possible path
 
                 # Get constraint associated to the possible path
                 memory_to_add = ModularIntervals(symb_pc.size)
                 for cons in possibility.constraints:
                     eaff = cons.to_constraint()
                     # eaff.get_r(mem_read=True) is not enough
-                    # ExprAff consider a Memory access in dst as a write
+                    # ExprAssign consider a Memory access in dst as a write
                     mem = eaff.dst.get_r(mem_read=True)
                     mem.update(eaff.src.get_r(mem_read=True))
                     for expr in mem:
@@ -663,7 +663,7 @@ class DSEPathConstraint(DSEEngine):
                         if not value.is_int():
                             raise TypeError("Rely on a symbolic memory case, " \
                                             "address 0x%x" % address)
-                        path_constraint.add(ExprAff(expr_mem, value))
+                        path_constraint.add(ExprAssign(expr_mem, value))
 
                 if target_addr == cur_addr:
                     # Add path constraint

--- a/miasm2/analysis/ssa.py
+++ b/miasm2/analysis/ssa.py
@@ -1,6 +1,6 @@
 from collections import deque
 
-from miasm2.expression.expression import ExprId, ExprAff, ExprOp, get_expr_ids
+from miasm2.expression.expression import ExprId, ExprAssign, ExprOp, get_expr_ids
 from miasm2.ir.ir import AssignBlock, IRBlock
 
 
@@ -185,7 +185,7 @@ class SSA(object):
         instructions = []
         for dst in assignblk:
             # dst = src
-            aff = assignblk.dst2ExprAff(dst)
+            aff = assignblk.dst2ExprAssign(dst)
             # insert memory expression into start of list
             if dst.is_mem():
                 instructions.insert(0, aff)
@@ -259,7 +259,7 @@ class SSA(object):
                 src_ssa = rhs.popleft()
 
                 # rebuild SSA expression
-                expr = ExprAff(dst_ssa, src_ssa)
+                expr = ExprAssign(dst_ssa, src_ssa)
                 self.expressions[dst_ssa] = src_ssa
                 self.ssa_to_location[dst_ssa] = (loc_key, index)
 
@@ -455,10 +455,10 @@ class SSADiGraph(SSA):
         """
         Generates an empty phi function for a variable
         :param expr: variable
-        :return: ExprAff, empty phi function for expr
+        :return: ExprAssign, empty phi function for expr
         """
         phi = ExprId(self.PHI_STR, expr.size)
-        return ExprAff(expr, phi)
+        return ExprAssign(expr, phi)
 
     def _fill_phi(self, *args):
         """

--- a/miasm2/arch/aarch64/sem.py
+++ b/miasm2/arch/aarch64/sem.py
@@ -1,5 +1,5 @@
 from miasm2.expression.expression import ExprId, ExprInt, ExprLoc, ExprMem, \
-    ExprCond, ExprCompose, ExprOp, ExprAff
+    ExprCond, ExprCompose, ExprOp, ExprAssign
 from miasm2.ir.ir import IntermediateRepresentation, IRBlock, AssignBlock
 from miasm2.arch.aarch64.arch import mn_aarch64, conds_expr, replace_regs
 from miasm2.arch.aarch64.regs import *
@@ -11,16 +11,16 @@ from miasm2.jitter.csts import EXCEPT_DIV_BY_ZERO, EXCEPT_INT_XX
 
 
 def update_flag_zf(a):
-    return [ExprAff(zf, ExprOp("FLAG_EQ", a))]
+    return [ExprAssign(zf, ExprOp("FLAG_EQ", a))]
 
 
 def update_flag_zf_eq(a, b):
-    return [ExprAff(zf, ExprOp("FLAG_EQ_CMP", a, b))]
+    return [ExprAssign(zf, ExprOp("FLAG_EQ_CMP", a, b))]
 
 
 def update_flag_nf(arg):
     return [
-        ExprAff(
+        ExprAssign(
             nf,
             ExprOp("FLAG_SIGN_SUB", arg, ExprInt(0, arg.size))
         )
@@ -41,22 +41,22 @@ def check_ops_msb(a, b, c):
 
 def update_flag_add_cf(op1, op2):
     "Compute cf in @op1 + @op2"
-    return [ExprAff(cf, ExprOp("FLAG_ADD_CF", op1, op2))]
+    return [ExprAssign(cf, ExprOp("FLAG_ADD_CF", op1, op2))]
 
 
 def update_flag_add_of(op1, op2):
     "Compute of in @op1 + @op2"
-    return [ExprAff(of, ExprOp("FLAG_ADD_OF", op1, op2))]
+    return [ExprAssign(of, ExprOp("FLAG_ADD_OF", op1, op2))]
 
 
 def update_flag_sub_cf(op1, op2):
     "Compote CF in @op1 - @op2"
-    return [ExprAff(cf, ExprOp("FLAG_SUB_CF", op1, op2) ^ ExprInt(1, 1))]
+    return [ExprAssign(cf, ExprOp("FLAG_SUB_CF", op1, op2) ^ ExprInt(1, 1))]
 
 
 def update_flag_sub_of(op1, op2):
     "Compote OF in @op1 - @op2"
-    return [ExprAff(of, ExprOp("FLAG_SUB_OF", op1, op2))]
+    return [ExprAssign(of, ExprOp("FLAG_SUB_OF", op1, op2))]
 
 
 def update_flag_arith_add_co(arg1, arg2):
@@ -72,7 +72,7 @@ def update_flag_arith_add_zn(arg1, arg2):
     """
     e = []
     e += update_flag_zf_eq(arg1, -arg2)
-    e += [ExprAff(nf, ExprOp("FLAG_SIGN_SUB", arg1, -arg2))]
+    e += [ExprAssign(nf, ExprOp("FLAG_SIGN_SUB", arg1, -arg2))]
     return e
 
 
@@ -92,17 +92,17 @@ def update_flag_arith_sub_zn(arg1, arg2):
     """
     e = []
     e += update_flag_zf_eq(arg1, arg2)
-    e += [ExprAff(nf, ExprOp("FLAG_SIGN_SUB", arg1, arg2))]
+    e += [ExprAssign(nf, ExprOp("FLAG_SIGN_SUB", arg1, arg2))]
     return e
 
 
 
 
 def update_flag_zfaddwc_eq(arg1, arg2, arg3):
-    return [ExprAff(zf, ExprOp("FLAG_EQ_ADDWC", arg1, arg2, arg3))]
+    return [ExprAssign(zf, ExprOp("FLAG_EQ_ADDWC", arg1, arg2, arg3))]
 
 def update_flag_zfsubwc_eq(arg1, arg2, arg3):
-    return [ExprAff(zf, ExprOp("FLAG_EQ_SUBWC", arg1, arg2, arg3))]
+    return [ExprAssign(zf, ExprOp("FLAG_EQ_SUBWC", arg1, arg2, arg3))]
 
 
 def update_flag_arith_addwc_zn(arg1, arg2, arg3):
@@ -111,7 +111,7 @@ def update_flag_arith_addwc_zn(arg1, arg2, arg3):
     """
     e = []
     e += update_flag_zfaddwc_eq(arg1, arg2, arg3)
-    e += [ExprAff(nf, ExprOp("FLAG_SIGN_ADDWC", arg1, arg2, arg3))]
+    e += [ExprAssign(nf, ExprOp("FLAG_SIGN_ADDWC", arg1, arg2, arg3))]
     return e
 
 
@@ -121,18 +121,18 @@ def update_flag_arith_subwc_zn(arg1, arg2, arg3):
     """
     e = []
     e += update_flag_zfsubwc_eq(arg1, arg2, arg3)
-    e += [ExprAff(nf, ExprOp("FLAG_SIGN_SUBWC", arg1, arg2, arg3))]
+    e += [ExprAssign(nf, ExprOp("FLAG_SIGN_SUBWC", arg1, arg2, arg3))]
     return e
 
 
 def update_flag_addwc_cf(op1, op2, op3):
     "Compute cf in @res = @op1 + @op2 + @op3"
-    return [ExprAff(cf, ExprOp("FLAG_ADDWC_CF", op1, op2, op3))]
+    return [ExprAssign(cf, ExprOp("FLAG_ADDWC_CF", op1, op2, op3))]
 
 
 def update_flag_addwc_of(op1, op2, op3):
     "Compute of in @res = @op1 + @op2 + @op3"
-    return [ExprAff(of, ExprOp("FLAG_ADDWC_OF", op1, op2, op3))]
+    return [ExprAssign(of, ExprOp("FLAG_ADDWC_OF", op1, op2, op3))]
 
 
 def update_flag_arith_addwc_co(arg1, arg2, arg3):
@@ -145,12 +145,12 @@ def update_flag_arith_addwc_co(arg1, arg2, arg3):
 
 def update_flag_subwc_cf(op1, op2, op3):
     "Compute cf in @res = @op1 + @op2 + @op3"
-    return [ExprAff(cf, ExprOp("FLAG_SUBWC_CF", op1, op2, op3) ^ ExprInt(1, 1))]
+    return [ExprAssign(cf, ExprOp("FLAG_SUBWC_CF", op1, op2, op3) ^ ExprInt(1, 1))]
 
 
 def update_flag_subwc_of(op1, op2, op3):
     "Compute of in @res = @op1 + @op2 + @op3"
-    return [ExprAff(of, ExprOp("FLAG_SUBWC_OF", op1, op2, op3))]
+    return [ExprAssign(of, ExprOp("FLAG_SUBWC_OF", op1, op2, op3))]
 
 
 def update_flag_arith_subwc_co(arg1, arg2, arg3):
@@ -290,10 +290,10 @@ def bics(ir, instr, arg1, arg2, arg3):
     e = []
     tmp1, tmp2 = arg2, (~extend_arg(arg2, arg3))
 
-    e += [ExprAff(zf, ExprOp('FLAG_EQ_AND', tmp1, tmp2))]
+    e += [ExprAssign(zf, ExprOp('FLAG_EQ_AND', tmp1, tmp2))]
     e += update_flag_nf(res)
 
-    e.append(ExprAff(arg1, res))
+    e.append(ExprAssign(arg1, res))
 
     e += null_flag_co()
     return e, []
@@ -312,7 +312,7 @@ def adds(ir, instr, arg1, arg2, arg3):
     e += update_flag_arith_add_zn(arg2, arg3)
     e += update_flag_arith_add_co(arg2, arg3)
 
-    e.append(ExprAff(arg1, res))
+    e.append(ExprAssign(arg1, res))
 
     return e, []
 
@@ -326,7 +326,7 @@ def subs(ir, instr, arg1, arg2, arg3):
     e += update_flag_arith_sub_zn(arg2, arg3)
     e += update_flag_arith_sub_co(arg2, arg3)
 
-    e.append(ExprAff(arg1, res))
+    e.append(ExprAssign(arg1, res))
     return e, []
 
 
@@ -355,10 +355,10 @@ def ands(ir, instr, arg1, arg2, arg3):
     arg3 = extend_arg(arg2, arg3)
     res = arg2 & arg3
 
-    e += [ExprAff(zf, ExprOp('FLAG_EQ_AND', arg2, arg3))]
+    e += [ExprAssign(zf, ExprOp('FLAG_EQ_AND', arg2, arg3))]
     e += update_flag_nf(res)
 
-    e.append(ExprAff(arg1, res))
+    e.append(ExprAssign(arg1, res))
     return e, []
 
 def tst(ir, instr, arg1, arg2):
@@ -366,7 +366,7 @@ def tst(ir, instr, arg1, arg2):
     arg2 = extend_arg(arg1, arg2)
     res = arg1 & arg2
 
-    e += [ExprAff(zf, ExprOp('FLAG_EQ_AND', arg1, arg2))]
+    e += [ExprAssign(zf, ExprOp('FLAG_EQ_AND', arg1, arg2))]
     e += update_flag_nf(res)
 
     return e, []
@@ -401,9 +401,9 @@ def movk(ir, instr, arg1, arg2):
                isinstance(arg2.args[1], ExprInt))
         value, shift = int(arg2.args[0].arg), int(arg2.args[1])
         e.append(
-            ExprAff(arg1[shift:shift + 16], ExprInt(value, 16)))
+            ExprAssign(arg1[shift:shift + 16], ExprInt(value, 16)))
     else:
-        e.append(ExprAff(arg1[:16], ExprInt(int(arg2), 16)))
+        e.append(ExprAssign(arg1[:16], ExprInt(int(arg2), 16)))
 
     return e, []
 
@@ -444,16 +444,16 @@ def ccmp(ir, instr, arg1, arg2, arg3, arg4):
     new_cf = update_flag_sub_cf(arg1, arg2).src
     new_of = update_flag_sub_of(arg1, arg2).src
 
-    e.append(ExprAff(nf, ExprCond(cond_expr,
+    e.append(ExprAssign(nf, ExprCond(cond_expr,
                                                     new_nf,
                                                     default_nf)))
-    e.append(ExprAff(zf, ExprCond(cond_expr,
+    e.append(ExprAssign(zf, ExprCond(cond_expr,
                                                     new_zf,
                                                     default_zf)))
-    e.append(ExprAff(cf, ExprCond(cond_expr,
+    e.append(ExprAssign(cf, ExprCond(cond_expr,
                                                     new_cf,
                                                     default_cf)))
-    e.append(ExprAff(of, ExprCond(cond_expr,
+    e.append(ExprAssign(of, ExprCond(cond_expr,
                                                     new_of,
                                                     default_of)))
     return e, []
@@ -463,7 +463,7 @@ def csinc(ir, instr, arg1, arg2, arg3, arg4):
     e = []
     cond_expr = cond2expr[arg4.name]
     e.append(
-        ExprAff(
+        ExprAssign(
             arg1,
             ExprCond(
                 cond_expr,
@@ -479,7 +479,7 @@ def csinv(ir, instr, arg1, arg2, arg3, arg4):
     e = []
     cond_expr = cond2expr[arg4.name]
     e.append(
-        ExprAff(
+        ExprAssign(
             arg1,
             ExprCond(
                 cond_expr,
@@ -494,7 +494,7 @@ def csneg(ir, instr, arg1, arg2, arg3, arg4):
     e = []
     cond_expr = cond2expr[arg4.name]
     e.append(
-        ExprAff(
+        ExprAssign(
             arg1,
             ExprCond(
                 cond_expr,
@@ -509,7 +509,7 @@ def cset(ir, instr, arg1, arg2):
     e = []
     cond_expr = cond2expr[arg2.name]
     e.append(
-        ExprAff(
+        ExprAssign(
             arg1,
             ExprCond(
                 cond_expr,
@@ -525,7 +525,7 @@ def csetm(ir, instr, arg1, arg2):
     e = []
     cond_expr = cond2expr[arg2.name]
     e.append(
-        ExprAff(
+        ExprAssign(
             arg1,
             ExprCond(
                 cond_expr,
@@ -562,11 +562,11 @@ def get_mem_access(mem):
                 raise NotImplementedError('bad op')
         elif mem.op == "postinc":
             addr, off = mem.args
-            updt = ExprAff(addr, addr + off)
+            updt = ExprAssign(addr, addr + off)
         elif mem.op == "preinc_wb":
             base, off = mem.args
             addr = base + off
-            updt = ExprAff(base, base + off)
+            updt = ExprAssign(base, base + off)
         else:
             raise NotImplementedError('bad op')
     else:
@@ -578,7 +578,7 @@ def get_mem_access(mem):
 def ldr(ir, instr, arg1, arg2):
     e = []
     addr, updt = get_mem_access(arg2)
-    e.append(ExprAff(arg1, ExprMem(addr, arg1.size)))
+    e.append(ExprAssign(arg1, ExprMem(addr, arg1.size)))
     if updt:
         e.append(updt)
     return e, []
@@ -588,7 +588,7 @@ def ldr_size(ir, instr, arg1, arg2, size):
     e = []
     addr, updt = get_mem_access(arg2)
     e.append(
-        ExprAff(arg1, ExprMem(addr, size).zeroExtend(arg1.size)))
+        ExprAssign(arg1, ExprMem(addr, size).zeroExtend(arg1.size)))
     if updt:
         e.append(updt)
     return e, []
@@ -606,7 +606,7 @@ def ldrs_size(ir, instr, arg1, arg2, size):
     e = []
     addr, updt = get_mem_access(arg2)
     e.append(
-        ExprAff(arg1, ExprMem(addr, size).signExtend(arg1.size)))
+        ExprAssign(arg1, ExprMem(addr, size).signExtend(arg1.size)))
     if updt:
         e.append(updt)
     return e, []
@@ -628,7 +628,7 @@ def ldrsw(ir, instr, arg1, arg2):
 def l_str(ir, instr, arg1, arg2):
     e = []
     addr, updt = get_mem_access(arg2)
-    e.append(ExprAff(ExprMem(addr, arg1.size), arg1))
+    e.append(ExprAssign(ExprMem(addr, arg1.size), arg1))
     if updt:
         e.append(updt)
     return e, []
@@ -637,7 +637,7 @@ def l_str(ir, instr, arg1, arg2):
 def strb(ir, instr, arg1, arg2):
     e = []
     addr, updt = get_mem_access(arg2)
-    e.append(ExprAff(ExprMem(addr, 8), arg1[:8]))
+    e.append(ExprAssign(ExprMem(addr, 8), arg1[:8]))
     if updt:
         e.append(updt)
     return e, []
@@ -646,7 +646,7 @@ def strb(ir, instr, arg1, arg2):
 def strh(ir, instr, arg1, arg2):
     e = []
     addr, updt = get_mem_access(arg2)
-    e.append(ExprAff(ExprMem(addr, 16), arg1[:16]))
+    e.append(ExprAssign(ExprMem(addr, 16), arg1[:16]))
     if updt:
         e.append(updt)
     return e, []
@@ -655,9 +655,9 @@ def strh(ir, instr, arg1, arg2):
 def stp(ir, instr, arg1, arg2, arg3):
     e = []
     addr, updt = get_mem_access(arg3)
-    e.append(ExprAff(ExprMem(addr, arg1.size), arg1))
+    e.append(ExprAssign(ExprMem(addr, arg1.size), arg1))
     e.append(
-        ExprAff(ExprMem(addr + ExprInt(arg1.size / 8, addr.size), arg2.size), arg2))
+        ExprAssign(ExprMem(addr + ExprInt(arg1.size / 8, addr.size), arg2.size), arg2))
     if updt:
         e.append(updt)
     return e, []
@@ -666,9 +666,9 @@ def stp(ir, instr, arg1, arg2, arg3):
 def ldp(ir, instr, arg1, arg2, arg3):
     e = []
     addr, updt = get_mem_access(arg3)
-    e.append(ExprAff(arg1, ExprMem(addr, arg1.size)))
+    e.append(ExprAssign(arg1, ExprMem(addr, arg1.size)))
     e.append(
-        ExprAff(arg2, ExprMem(addr + ExprInt(arg1.size / 8, addr.size), arg2.size)))
+        ExprAssign(arg2, ExprMem(addr + ExprInt(arg1.size / 8, addr.size), arg2.size)))
     if updt:
         e.append(updt)
     return e, []
@@ -682,7 +682,7 @@ def sbfm(ir, instr, arg1, arg2, arg3, arg4):
     else:
         shift = ExprInt(arg2.size - rim, arg2.size)
         res = (arg2[:sim].signExtend(arg1.size) << shift)
-    e.append(ExprAff(arg1, res))
+    e.append(ExprAssign(arg1, res))
     return e, []
 
 
@@ -694,7 +694,7 @@ def ubfm(ir, instr, arg1, arg2, arg3, arg4):
     else:
         shift = ExprInt(arg2.size - rim, arg2.size)
         res = (arg2[:sim].zeroExtend(arg1.size) << shift)
-    e.append(ExprAff(arg1, res))
+    e.append(ExprAssign(arg1, res))
     return e, []
 
 def bfm(ir, instr, arg1, arg2, arg3, arg4):
@@ -702,12 +702,12 @@ def bfm(ir, instr, arg1, arg2, arg3, arg4):
     rim, sim = int(arg3.arg), int(arg4) + 1
     if sim > rim:
         res = arg2[rim:sim]
-        e.append(ExprAff(arg1[:sim-rim], res))
+        e.append(ExprAssign(arg1[:sim-rim], res))
     else:
         shift_i = arg2.size - rim
         shift = ExprInt(shift_i, arg2.size)
         res = arg2[:sim]
-        e.append(ExprAff(arg1[shift_i:shift_i+sim], res))
+        e.append(ExprAssign(arg1[shift_i:shift_i+sim], res))
     return e, []
 
 
@@ -721,7 +721,7 @@ def mrs(ir, insr, arg1, arg2, arg3, arg4, arg5):
         out.append(cf)
         out.append(zf)
         out.append(nf)
-        e.append(ExprAff(arg1, ExprCompose(*out).zeroExtend(arg1.size)))
+        e.append(ExprAssign(arg1, ExprCompose(*out).zeroExtend(arg1.size)))
     else:
         raise NotImplementedError("MRS not implemented")
     return e, []
@@ -730,10 +730,10 @@ def msr(ir, instr, arg1, arg2, arg3, arg4, arg5):
 
     e = []
     if arg1.is_int(3) and arg2.is_id("c4") and arg3.is_id("c2") and arg4.is_int(0):
-        e.append(ExprAff(nf, arg5[31:32]))
-        e.append(ExprAff(zf, arg5[30:31]))
-        e.append(ExprAff(cf, arg5[29:30]))
-        e.append(ExprAff(of, arg5[28:29]))
+        e.append(ExprAssign(nf, arg5[31:32]))
+        e.append(ExprAssign(zf, arg5[30:31]))
+        e.append(ExprAssign(cf, arg5[29:30]))
+        e.append(ExprAssign(of, arg5[28:29]))
     else:
         raise NotImplementedError("MSR not implemented")
     return e, []
@@ -744,7 +744,7 @@ def adc(ir, instr, arg1, arg2, arg3):
     arg3 = extend_arg(arg2, arg3)
     e = []
     r = arg2 + arg3 + cf.zeroExtend(arg3.size)
-    e.append(ExprAff(arg1, r))
+    e.append(ExprAssign(arg1, r))
     return e, []
 
 
@@ -752,7 +752,7 @@ def adcs(ir, instr, arg1, arg2, arg3):
     arg3 = extend_arg(arg2, arg3)
     e = []
     r = arg2 + arg3 + cf.zeroExtend(arg3.size)
-    e.append(ExprAff(arg1, r))
+    e.append(ExprAssign(arg1, r))
     e += update_flag_arith_addwc_zn(arg2, arg3, cf)
     e += update_flag_arith_addwc_co(arg2, arg3, cf)
     return e, []
@@ -762,7 +762,7 @@ def sbc(ir, instr, arg1, arg2, arg3):
     arg3 = extend_arg(arg2, arg3)
     e = []
     r = arg2 - (arg3 + (~cf).zeroExtend(arg3.size))
-    e.append(ExprAff(arg1, r))
+    e.append(ExprAssign(arg1, r))
     return e, []
 
 
@@ -770,7 +770,7 @@ def sbcs(ir, instr, arg1, arg2, arg3):
     arg3 = extend_arg(arg2, arg3)
     e = []
     r = arg2 - (arg3 + (~cf).zeroExtend(arg3.size))
-    e.append(ExprAff(arg1, r))
+    e.append(ExprAssign(arg1, r))
     e += update_flag_arith_subwc_zn(arg2, arg3, ~cf)
     e += update_flag_arith_subwc_co(arg2, arg3, ~cf)
     return e, []
@@ -956,7 +956,7 @@ def rev(ir, instr, arg1, arg2):
     out.reverse()
     e = []
     result = ExprCompose(*out)
-    e.append(ExprAff(arg1, result))
+    e.append(ExprAssign(arg1, result))
     return e, []
 
 
@@ -1088,7 +1088,7 @@ class ir_aarch64l(IntermediateRepresentation):
     def expraff_fix_regs_for_mode(self, e):
         dst = self.expr_fix_regs_for_mode(e.dst)
         src = self.expr_fix_regs_for_mode(e.src)
-        return ExprAff(dst, src)
+        return ExprAssign(dst, src)
 
     def irbloc_fix_regs_for_mode(self, irblock, mode=64):
         irs = []
@@ -1119,7 +1119,7 @@ class ir_aarch64l(IntermediateRepresentation):
             if dst != self.pc:
                 dst = dst.replace_expr(pc_fixed)
             src = src.replace_expr(pc_fixed)
-            instr_ir[i] = ExprAff(dst, src)
+            instr_ir[i] = ExprAssign(dst, src)
 
         for idx, irblock in enumerate(extra_ir):
             extra_ir[idx] = irblock.modify_exprs(lambda expr: expr.replace_expr(pc_fixed) \

--- a/miasm2/arch/arm/ira.py
+++ b/miasm2/arch/arm/ira.py
@@ -3,7 +3,7 @@
 from miasm2.ir.analysis import ira
 from miasm2.ir.ir import IRBlock
 from miasm2.arch.arm.sem import ir_arml, ir_armtl, ir_armb, ir_armtb, tab_cond
-from miasm2.expression.expression import ExprAff, ExprOp, ExprLoc, ExprCond
+from miasm2.expression.expression import ExprAssign, ExprOp, ExprLoc, ExprCond
 from miasm2.ir.ir import AssignBlock
 
 class ir_a_arml_base(ir_arml, ira):
@@ -26,7 +26,7 @@ class ir_a_arml(ir_a_arml_base):
     def call_effects(self, ad, instr):
         call_assignblk = AssignBlock(
             [
-                ExprAff(
+                ExprAssign(
                     self.ret_reg,
                     ExprOp(
                         'call_func_ret',
@@ -37,7 +37,7 @@ class ir_a_arml(ir_a_arml_base):
                         self.arch.regs.R3,
                     )
                 ),
-                ExprAff(
+                ExprAssign(
                     self.sp,
                     ExprOp('call_func_stack', ad, self.sp)
                 ),
@@ -61,11 +61,11 @@ class ir_a_arml(ir_a_arml_base):
 
         call_assignblks = [
             call_assignblk,
-            AssignBlock([ExprAff(self.IRDst, loc_next_expr)], instr),
+            AssignBlock([ExprAssign(self.IRDst, loc_next_expr)], instr),
         ]
         e_do = IRBlock(loc_do, call_assignblks)
         assignblks_out = [
-            AssignBlock([ExprAff(self.IRDst, dst_cond)], instr)
+            AssignBlock([ExprAssign(self.IRDst, dst_cond)], instr)
         ]
         return assignblks_out, [e_do]
 

--- a/miasm2/arch/arm/jit.py
+++ b/miasm2/arch/arm/jit.py
@@ -5,7 +5,7 @@ from miasm2.core.locationdb import LocationDB
 from miasm2.core.utils import pck32, upck32
 from miasm2.arch.arm.sem import ir_armb, ir_arml, ir_armtl, ir_armtb, cond_dct_inv, tab_cond
 from miasm2.jitter.codegen import CGen
-from miasm2.expression.expression import ExprId, ExprAff, ExprCond
+from miasm2.expression.expression import ExprId, ExprAssign, ExprCond
 from miasm2.ir.ir import IRBlock, AssignBlock
 from miasm2.ir.translators.C import TranslatorC
 from miasm2.expression.simplifications import expr_simp_high_to_explicit

--- a/miasm2/arch/arm/sem.py
+++ b/miasm2/arch/arm/sem.py
@@ -14,16 +14,16 @@ EXCEPT_PRIV_INSN = (1 << 17)
 
 
 def update_flag_zf(a):
-    return [ExprAff(zf, ExprOp("FLAG_EQ", a))]
+    return [ExprAssign(zf, ExprOp("FLAG_EQ", a))]
 
 
 def update_flag_zf_eq(a, b):
-    return [ExprAff(zf, ExprOp("FLAG_EQ_CMP", a, b))]
+    return [ExprAssign(zf, ExprOp("FLAG_EQ_CMP", a, b))]
 
 
 def update_flag_nf(arg):
     return [
-        ExprAff(
+        ExprAssign(
             nf,
             ExprOp("FLAG_SIGN_SUB", arg, ExprInt(0, arg.size))
         )
@@ -47,22 +47,22 @@ def check_ops_msb(a, b, c):
 
 def update_flag_add_cf(op1, op2):
     "Compute cf in @op1 + @op2"
-    return [ExprAff(cf, ExprOp("FLAG_ADD_CF", op1, op2))]
+    return [ExprAssign(cf, ExprOp("FLAG_ADD_CF", op1, op2))]
 
 
 def update_flag_add_of(op1, op2):
     "Compute of in @op1 + @op2"
-    return [ExprAff(of, ExprOp("FLAG_ADD_OF", op1, op2))]
+    return [ExprAssign(of, ExprOp("FLAG_ADD_OF", op1, op2))]
 
 
 def update_flag_sub_cf(op1, op2):
     "Compote CF in @op1 - @op2"
-    return [ExprAff(cf, ExprOp("FLAG_SUB_CF", op1, op2) ^ ExprInt(1, 1))]
+    return [ExprAssign(cf, ExprOp("FLAG_SUB_CF", op1, op2) ^ ExprInt(1, 1))]
 
 
 def update_flag_sub_of(op1, op2):
     "Compote OF in @op1 - @op2"
-    return [ExprAff(of, ExprOp("FLAG_SUB_OF", op1, op2))]
+    return [ExprAssign(of, ExprOp("FLAG_SUB_OF", op1, op2))]
 
 
 def update_flag_arith_add_co(arg1, arg2):
@@ -78,7 +78,7 @@ def update_flag_arith_add_zn(arg1, arg2):
     """
     e = []
     e += update_flag_zf_eq(arg1, -arg2)
-    e += [ExprAff(nf, ExprOp("FLAG_SIGN_SUB", arg1, -arg2))]
+    e += [ExprAssign(nf, ExprOp("FLAG_SIGN_SUB", arg1, -arg2))]
     return e
 
 
@@ -98,17 +98,17 @@ def update_flag_arith_sub_zn(arg1, arg2):
     """
     e = []
     e += update_flag_zf_eq(arg1, arg2)
-    e += [ExprAff(nf, ExprOp("FLAG_SIGN_SUB", arg1, arg2))]
+    e += [ExprAssign(nf, ExprOp("FLAG_SIGN_SUB", arg1, arg2))]
     return e
 
 
 
 
 def update_flag_zfaddwc_eq(arg1, arg2, arg3):
-    return [ExprAff(zf, ExprOp("FLAG_EQ_ADDWC", arg1, arg2, arg3))]
+    return [ExprAssign(zf, ExprOp("FLAG_EQ_ADDWC", arg1, arg2, arg3))]
 
 def update_flag_zfsubwc_eq(arg1, arg2, arg3):
-    return [ExprAff(zf, ExprOp("FLAG_EQ_SUBWC", arg1, arg2, arg3))]
+    return [ExprAssign(zf, ExprOp("FLAG_EQ_SUBWC", arg1, arg2, arg3))]
 
 
 def update_flag_arith_addwc_zn(arg1, arg2, arg3):
@@ -117,7 +117,7 @@ def update_flag_arith_addwc_zn(arg1, arg2, arg3):
     """
     e = []
     e += update_flag_zfaddwc_eq(arg1, arg2, arg3)
-    e += [ExprAff(nf, ExprOp("FLAG_SIGN_ADDWC", arg1, arg2, arg3))]
+    e += [ExprAssign(nf, ExprOp("FLAG_SIGN_ADDWC", arg1, arg2, arg3))]
     return e
 
 
@@ -127,18 +127,18 @@ def update_flag_arith_subwc_zn(arg1, arg2, arg3):
     """
     e = []
     e += update_flag_zfsubwc_eq(arg1, arg2, arg3)
-    e += [ExprAff(nf, ExprOp("FLAG_SIGN_SUBWC", arg1, arg2, arg3))]
+    e += [ExprAssign(nf, ExprOp("FLAG_SIGN_SUBWC", arg1, arg2, arg3))]
     return e
 
 
 def update_flag_addwc_cf(op1, op2, op3):
     "Compute cf in @res = @op1 + @op2 + @op3"
-    return [ExprAff(cf, ExprOp("FLAG_ADDWC_CF", op1, op2, op3))]
+    return [ExprAssign(cf, ExprOp("FLAG_ADDWC_CF", op1, op2, op3))]
 
 
 def update_flag_addwc_of(op1, op2, op3):
     "Compute of in @res = @op1 + @op2 + @op3"
-    return [ExprAff(of, ExprOp("FLAG_ADDWC_OF", op1, op2, op3))]
+    return [ExprAssign(of, ExprOp("FLAG_ADDWC_OF", op1, op2, op3))]
 
 
 def update_flag_arith_addwc_co(arg1, arg2, arg3):
@@ -151,12 +151,12 @@ def update_flag_arith_addwc_co(arg1, arg2, arg3):
 
 def update_flag_subwc_cf(op1, op2, op3):
     "Compute cf in @res = @op1 + @op2 + @op3"
-    return [ExprAff(cf, ExprOp("FLAG_SUBWC_CF", op1, op2, op3) ^ ExprInt(1, 1))]
+    return [ExprAssign(cf, ExprOp("FLAG_SUBWC_CF", op1, op2, op3) ^ ExprInt(1, 1))]
 
 
 def update_flag_subwc_of(op1, op2, op3):
     "Compute of in @res = @op1 + @op2 + @op3"
-    return [ExprAff(of, ExprOp("FLAG_SUBWC_OF", op1, op2, op3))]
+    return [ExprAssign(of, ExprOp("FLAG_SUBWC_OF", op1, op2, op3))]
 
 
 def update_flag_arith_subwc_co(arg1, arg2, arg3):
@@ -184,10 +184,10 @@ def adc(ir, instr, a, b, c=None):
     if instr.name == 'ADCS' and a != PC:
         e += update_flag_arith_addwc_zn(arg1, arg2, cf)
         e += update_flag_arith_addwc_co(arg1, arg2, cf)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -200,10 +200,10 @@ def add(ir, instr, a, b, c=None):
     if instr.name == 'ADDS' and a != PC:
         e += update_flag_arith_add_zn(arg1, arg2)
         e += update_flag_arith_add_co(arg1, arg2)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -213,13 +213,13 @@ def l_and(ir, instr, a, b, c=None):
         b, c = a, b
     r = b & c
     if instr.name == 'ANDS' and a != PC:
-        e += [ExprAff(zf, ExprOp('FLAG_EQ_AND', b, c))]
+        e += [ExprAssign(zf, ExprOp('FLAG_EQ_AND', b, c))]
         e += update_flag_nf(r)
 
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -228,10 +228,10 @@ def sub(ir, instr, a, b, c=None):
     if c is None:
         b, c = a, b
     r = b - c
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -243,10 +243,10 @@ def subs(ir, instr, a, b, c=None):
     r = b - c
     e += update_flag_arith_sub_zn(arg1, arg2)
     e += update_flag_arith_sub_co(arg1, arg2)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -255,10 +255,10 @@ def eor(ir, instr, a, b, c=None):
     if c is None:
         b, c = a, b
     r = b ^ c
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -269,13 +269,13 @@ def eors(ir, instr, a, b, c=None):
     arg1, arg2 = b, c
     r = arg1 ^ arg2
 
-    e += [ExprAff(zf, ExprOp('FLAG_EQ_CMP', arg1, arg2))]
+    e += [ExprAssign(zf, ExprOp('FLAG_EQ_CMP', arg1, arg2))]
     e += update_flag_nf(r)
 
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -285,10 +285,10 @@ def rsb(ir, instr, a, b, c=None):
         b, c = a, b
     arg1, arg2 = c, b
     r = arg1 - arg2
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -300,10 +300,10 @@ def rsbs(ir, instr, a, b, c=None):
     r = arg1 - arg2
     e += update_flag_arith_sub_zn(arg1, arg2)
     e += update_flag_arith_sub_co(arg1, arg2)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -313,10 +313,10 @@ def sbc(ir, instr, a, b, c=None):
         b, c = a, b
     arg1, arg2 = b, c
     r = arg1 - (arg2 + (~cf).zeroExtend(32))
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -330,10 +330,10 @@ def sbcs(ir, instr, a, b, c=None):
     e += update_flag_arith_subwc_zn(arg1, arg2, ~cf)
     e += update_flag_arith_subwc_co(arg1, arg2, ~cf)
 
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -343,10 +343,10 @@ def rsc(ir, instr, a, b, c=None):
         b, c = a, b
     arg1, arg2 = c, b
     r = arg1 - (arg2 + (~cf).zeroExtend(32))
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -360,11 +360,11 @@ def rscs(ir, instr, a, b, c=None):
     e += update_flag_arith_subwc_zn(arg1, arg2, ~cf)
     e += update_flag_arith_subwc_co(arg1, arg2, ~cf)
 
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
 
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -373,7 +373,7 @@ def tst(ir, instr, a, b):
     arg1, arg2 = a, b
     r = arg1 & arg2
 
-    e += [ExprAff(zf, ExprOp('FLAG_EQ_AND', arg1, arg2))]
+    e += [ExprAssign(zf, ExprOp('FLAG_EQ_AND', arg1, arg2))]
     e += update_flag_nf(r)
 
     return e, []
@@ -386,7 +386,7 @@ def teq(ir, instr, a, b, c=None):
     arg1, arg2 = b, c
     r = arg1 ^ arg2
 
-    e += [ExprAff(zf, ExprOp('FLAG_EQ_CMP', arg1, arg2))]
+    e += [ExprAssign(zf, ExprOp('FLAG_EQ_CMP', arg1, arg2))]
     e += update_flag_nf(r)
 
     return e, []
@@ -417,10 +417,10 @@ def orr(ir, instr, a, b, c=None):
     if c is None:
         b, c = a, b
     r = b | c
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -429,10 +429,10 @@ def orn(ir, instr, a, b, c=None):
     if c is None:
         b, c = a, b
     r = ~(b | c)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -443,66 +443,66 @@ def orrs(ir, instr, a, b, c=None):
     arg1, arg2 = b, c
     r = arg1 | arg2
 
-    e += [ExprAff(zf, ExprOp('FLAG_EQ', r))]
+    e += [ExprAssign(zf, ExprOp('FLAG_EQ', r))]
     e += update_flag_nf(r)
 
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
 def mov(ir, instr, a, b):
-    e = [ExprAff(a, b)]
+    e = [ExprAssign(a, b)]
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, b))
+        e.append(ExprAssign(ir.IRDst, b))
     return e, []
 
 
 def movt(ir, instr, a, b):
     r = a | b << ExprInt(16, 32)
-    e = [ExprAff(a, r)]
+    e = [ExprAssign(a, r)]
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
 def movs(ir, instr, a, b):
     e = []
-    e.append(ExprAff(a, b))
+    e.append(ExprAssign(a, b))
     # XXX TODO check
-    e += [ExprAff(zf, ExprOp('FLAG_EQ', b))]
+    e += [ExprAssign(zf, ExprOp('FLAG_EQ', b))]
     e += update_flag_nf(b)
 
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, b))
+        e.append(ExprAssign(ir.IRDst, b))
     return e, []
 
 
 def mvn(ir, instr, a, b):
     r = b ^ ExprInt(-1, 32)
-    e = [ExprAff(a, r)]
+    e = [ExprAssign(a, r)]
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
 def mvns(ir, instr, a, b):
     e = []
     r = b ^ ExprInt(-1, 32)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     # XXX TODO check
-    e += [ExprAff(zf, ExprOp('FLAG_EQ', r))]
+    e += [ExprAssign(zf, ExprOp('FLAG_EQ', r))]
     e += update_flag_nf(r)
 
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -516,7 +516,7 @@ def mrs(ir, instr, a, b):
         out.append(cf)
         out.append(zf)
         out.append(nf)
-        e.append(ExprAff(a, ExprCompose(*out)))
+        e.append(ExprAssign(a, ExprCompose(*out)))
     else:
         raise NotImplementedError("MRS not implemented")
     return e, []
@@ -524,10 +524,10 @@ def mrs(ir, instr, a, b):
 def msr(ir, instr, a, b):
     e = []
     if a.is_id('CPSR_cf'):
-        e.append(ExprAff(nf, b[31:32]))
-        e.append(ExprAff(zf, b[30:31]))
-        e.append(ExprAff(cf, b[29:30]))
-        e.append(ExprAff(of, b[28:29]))
+        e.append(ExprAssign(nf, b[31:32]))
+        e.append(ExprAssign(zf, b[30:31]))
+        e.append(ExprAssign(cf, b[29:30]))
+        e.append(ExprAssign(of, b[28:29]))
     else:
         raise NotImplementedError("MSR not implemented")
     return e, []
@@ -536,10 +536,10 @@ def msr(ir, instr, a, b):
 def neg(ir, instr, a, b):
     e = []
     r = - b
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 def negs(ir, instr, a, b):
@@ -550,10 +550,10 @@ def bic(ir, instr, a, b, c=None):
     if c is None:
         b, c = a, b
     r = b & (c ^ ExprInt(-1, 32))
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -564,13 +564,13 @@ def bics(ir, instr, a, b, c=None):
     tmp1, tmp2 = b, ~c
     r = tmp1 & tmp2
 
-    e += [ExprAff(zf, ExprOp('FLAG_EQ_AND', tmp1, tmp2))]
+    e += [ExprAssign(zf, ExprOp('FLAG_EQ_AND', tmp1, tmp2))]
     e += update_flag_nf(r)
 
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -583,23 +583,23 @@ def sdiv(ir, instr, a, b, c=None):
     loc_except = ExprId(ir.loc_db.add_location(), ir.IRDst.size)
     loc_next = ExprLoc(ir.get_next_loc_key(instr), ir.IRDst.size)
 
-    e.append(ExprAff(ir.IRDst, ExprCond(c, loc_div, loc_except)))
+    e.append(ExprAssign(ir.IRDst, ExprCond(c, loc_div, loc_except)))
 
     do_except = []
-    do_except.append(ExprAff(exception_flags, ExprInt(EXCEPT_DIV_BY_ZERO, exception_flags.size)))
-    do_except.append(ExprAff(ir.IRDst, loc_next))
+    do_except.append(ExprAssign(exception_flags, ExprInt(EXCEPT_DIV_BY_ZERO, exception_flags.size)))
+    do_except.append(ExprAssign(ir.IRDst, loc_next))
     blk_except = IRBlock(loc_except.loc_key, [AssignBlock(do_except, instr)])
 
 
 
     r = ExprOp("idiv", b, c)
     do_div = []
-    do_div.append(ExprAff(a, r))
+    do_div.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        do_div.append(ExprAff(ir.IRDst, r))
+        do_div.append(ExprAssign(ir.IRDst, r))
 
-    do_div.append(ExprAff(ir.IRDst, loc_next))
+    do_div.append(ExprAssign(ir.IRDst, loc_next))
     blk_div = IRBlock(loc_div.loc_key, [AssignBlock(do_div, instr)])
 
     return e, [blk_div, blk_except]
@@ -616,22 +616,22 @@ def udiv(ir, instr, a, b, c=None):
     loc_except = ExprLoc(ir.loc_db.add_location(), ir.IRDst.size)
     loc_next = ExprLoc(ir.get_next_loc_key(instr), ir.IRDst.size)
 
-    e.append(ExprAff(ir.IRDst, ExprCond(c, loc_div, loc_except)))
+    e.append(ExprAssign(ir.IRDst, ExprCond(c, loc_div, loc_except)))
 
     do_except = []
-    do_except.append(ExprAff(exception_flags, ExprInt(EXCEPT_DIV_BY_ZERO, exception_flags.size)))
-    do_except.append(ExprAff(ir.IRDst, loc_next))
+    do_except.append(ExprAssign(exception_flags, ExprInt(EXCEPT_DIV_BY_ZERO, exception_flags.size)))
+    do_except.append(ExprAssign(ir.IRDst, loc_next))
     blk_except = IRBlock(loc_except.loc_key, [AssignBlock(do_except, instr)])
 
 
     r = ExprOp("udiv", b, c)
     do_div = []
-    do_div.append(ExprAff(a, r))
+    do_div.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        do_div.append(ExprAff(ir.IRDst, r))
+        do_div.append(ExprAssign(ir.IRDst, r))
 
-    do_div.append(ExprAff(ir.IRDst, loc_next))
+    do_div.append(ExprAssign(ir.IRDst, loc_next))
     blk_div = IRBlock(loc_div.loc_key, [AssignBlock(do_div, instr)])
 
     return e, [blk_div, blk_except]
@@ -640,10 +640,10 @@ def udiv(ir, instr, a, b, c=None):
 def mla(ir, instr, a, b, c, d):
     e = []
     r = (b * c) + d
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -651,20 +651,20 @@ def mlas(ir, instr, a, b, c, d):
     e = []
     r = (b * c) + d
     e += update_flag_zn(r)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
 def mls(ir, instr, a, b, c, d):
     e = []
     r = d - (b * c)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -673,10 +673,10 @@ def mul(ir, instr, a, b, c=None):
     if c is None:
         b, c = a, b
     r = b * c
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -686,73 +686,73 @@ def muls(ir, instr, a, b, c=None):
         b, c = a, b
     r = b * c
     e += update_flag_zn(r)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 def umull(ir, instr, a, b, c, d):
     e = []
     r = c.zeroExtend(64) * d.zeroExtend(64)
-    e.append(ExprAff(a, r[0:32]))
-    e.append(ExprAff(b, r[32:64]))
+    e.append(ExprAssign(a, r[0:32]))
+    e.append(ExprAssign(b, r[32:64]))
     # r15/IRDst not allowed as output
     return e, []
 
 def umlal(ir, instr, a, b, c, d):
     e = []
     r = c.zeroExtend(64) * d.zeroExtend(64) + ExprCompose(a, b)
-    e.append(ExprAff(a, r[0:32]))
-    e.append(ExprAff(b, r[32:64]))
+    e.append(ExprAssign(a, r[0:32]))
+    e.append(ExprAssign(b, r[32:64]))
     # r15/IRDst not allowed as output
     return e, []
 
 def smull(ir, instr, a, b, c, d):
     e = []
     r = c.signExtend(64) * d.signExtend(64)
-    e.append(ExprAff(a, r[0:32]))
-    e.append(ExprAff(b, r[32:64]))
+    e.append(ExprAssign(a, r[0:32]))
+    e.append(ExprAssign(b, r[32:64]))
     # r15/IRDst not allowed as output
     return e, []
 
 def smlal(ir, instr, a, b, c, d):
     e = []
     r = c.signExtend(64) * d.signExtend(64) + ExprCompose(a, b)
-    e.append(ExprAff(a, r[0:32]))
-    e.append(ExprAff(b, r[32:64]))
+    e.append(ExprAssign(a, r[0:32]))
+    e.append(ExprAssign(b, r[32:64]))
     # r15/IRDst not allowed as output
     return e, []
 
 def b(ir, instr, a):
     e = []
-    e.append(ExprAff(PC, a))
-    e.append(ExprAff(ir.IRDst, a))
+    e.append(ExprAssign(PC, a))
+    e.append(ExprAssign(ir.IRDst, a))
     return e, []
 
 
 def bl(ir, instr, a):
     e = []
     l = ExprInt(instr.offset + instr.l, 32)
-    e.append(ExprAff(PC, a))
-    e.append(ExprAff(ir.IRDst, a))
-    e.append(ExprAff(LR, l))
+    e.append(ExprAssign(PC, a))
+    e.append(ExprAssign(ir.IRDst, a))
+    e.append(ExprAssign(LR, l))
     return e, []
 
 
 def bx(ir, instr, a):
     e = []
-    e.append(ExprAff(PC, a))
-    e.append(ExprAff(ir.IRDst, a))
+    e.append(ExprAssign(PC, a))
+    e.append(ExprAssign(ir.IRDst, a))
     return e, []
 
 
 def blx(ir, instr, a):
     e = []
     l = ExprInt(instr.offset + instr.l, 32)
-    e.append(ExprAff(PC, a))
-    e.append(ExprAff(ir.IRDst, a))
-    e.append(ExprAff(LR, l))
+    e.append(ExprAssign(PC, a))
+    e.append(ExprAssign(ir.IRDst, a))
+    e.append(ExprAssign(LR, l))
     return e, []
 
 
@@ -804,20 +804,20 @@ def st_ld_r(ir, instr, a, a2, b, store=False, size=32, s_ext=False, z_ext=False)
     dst = None
 
     if store:
-        e.append(ExprAff(m, a))
+        e.append(ExprAssign(m, a))
         if dmem:
-            e.append(ExprAff(ExprMem(ad + ExprInt(4, 32), size=size), a2))
+            e.append(ExprAssign(ExprMem(ad + ExprInt(4, 32), size=size), a2))
     else:
         if a == PC:
             dst = PC
-            e.append(ExprAff(ir.IRDst, m))
-        e.append(ExprAff(a, m))
+            e.append(ExprAssign(ir.IRDst, m))
+        e.append(ExprAssign(a, m))
         if dmem:
-            e.append(ExprAff(a2, ExprMem(ad + ExprInt(4, 32), size=size)))
+            e.append(ExprAssign(a2, ExprMem(ad + ExprInt(4, 32), size=size)))
 
     # XXX TODO check multiple write cause by wb
     if wb or postinc:
-        e.append(ExprAff(base, base + off))
+        e.append(ExprAssign(base, base + off))
     return e, []
 
 
@@ -890,17 +890,17 @@ def st_ld_m(ir, instr, a, b, store=False, postinc=False, updown=False):
     for i, r in enumerate(regs):
         ad = base + ExprInt(i * step, 32)
         if store:
-            e.append(ExprAff(ExprMem(ad, 32), r))
+            e.append(ExprAssign(ExprMem(ad, 32), r))
         else:
-            e.append(ExprAff(r, ExprMem(ad, 32)))
+            e.append(ExprAssign(r, ExprMem(ad, 32)))
             if r == PC:
-                e.append(ExprAff(ir.IRDst, ExprMem(ad, 32)))
+                e.append(ExprAssign(ir.IRDst, ExprMem(ad, 32)))
     # XXX TODO check multiple write cause by wb
     if wb:
         if postinc:
-            e.append(ExprAff(a, base + ExprInt(len(regs) * step, 32)))
+            e.append(ExprAssign(a, base + ExprInt(len(regs) * step, 32)))
         else:
-            e.append(ExprAff(a, base + ExprInt((len(regs) - 1) * step, 32)))
+            e.append(ExprAssign(a, base + ExprInt((len(regs) - 1) * step, 32)))
     if store:
         pass
     else:
@@ -944,8 +944,8 @@ def stmdb(ir, instr, a, b):
 def svc(ir, instr, a):
     e = []
     except_int = EXCEPT_INT_XX
-    e.append(ExprAff(exception_flags, ExprInt(except_int, 32)))
-    e.append(ExprAff(interrupt_num, a))
+    e.append(ExprAssign(exception_flags, ExprInt(except_int, 32)))
+    e.append(ExprAssign(interrupt_num, a))
     return e, []
 
 
@@ -960,10 +960,10 @@ def lsr(ir, instr, a, b, c=None):
     if c is None:
         b, c = a, b
     r = b >> c
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -972,14 +972,14 @@ def lsrs(ir, instr, a, b, c=None):
     if c is None:
         b, c = a, b
     r = b >> c
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
 
-    e += [ExprAff(zf, ExprOp('FLAG_EQ', r))]
+    e += [ExprAssign(zf, ExprOp('FLAG_EQ', r))]
     e += update_flag_nf(r)
 
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 def asr(ir, instr, a, b, c=None):
@@ -987,10 +987,10 @@ def asr(ir, instr, a, b, c=None):
     if c is None:
         b, c = a, b
     r = ExprOp("a>>", b, c)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 def asrs(ir, instr, a, b, c=None):
@@ -998,14 +998,14 @@ def asrs(ir, instr, a, b, c=None):
     if c is None:
         b, c = a, b
     r = ExprOp("a>>", b, c)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
 
-    e += [ExprAff(zf, ExprOp('FLAG_EQ', r))]
+    e += [ExprAssign(zf, ExprOp('FLAG_EQ', r))]
     e += update_flag_nf(r)
 
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 def lsl(ir, instr, a, b, c=None):
@@ -1013,10 +1013,10 @@ def lsl(ir, instr, a, b, c=None):
     if c is None:
         b, c = a, b
     r = b << c
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -1025,28 +1025,28 @@ def lsls(ir, instr, a, b, c=None):
     if c is None:
         b, c = a, b
     r = b << c
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
 
-    e += [ExprAff(zf, ExprOp('FLAG_EQ', r))]
+    e += [ExprAssign(zf, ExprOp('FLAG_EQ', r))]
     e += update_flag_nf(r)
 
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
 def rors(ir, instr, a, b):
     e = []
     r = ExprOp(">>>", a, b)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
 
-    e += [ExprAff(zf, ExprOp('FLAG_EQ', r))]
+    e += [ExprAssign(zf, ExprOp('FLAG_EQ', r))]
     e += update_flag_nf(r)
 
     dst = get_dst(a)
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -1055,9 +1055,9 @@ def push(ir, instr, a):
     regs = list(a.args)
     for i in xrange(len(regs)):
         r = SP + ExprInt(-4 * len(regs) + 4 * i, 32)
-        e.append(ExprAff(ExprMem(r, 32), regs[i]))
+        e.append(ExprAssign(ExprMem(r, 32), regs[i]))
     r = SP + ExprInt(-4 * len(regs), 32)
-    e.append(ExprAff(SP, r))
+    e.append(ExprAssign(SP, r))
     return e, []
 
 
@@ -1067,13 +1067,13 @@ def pop(ir, instr, a):
     dst = None
     for i in xrange(len(regs)):
         r = SP + ExprInt(4 * i, 32)
-        e.append(ExprAff(regs[i], ExprMem(r, 32)))
+        e.append(ExprAssign(regs[i], ExprMem(r, 32)))
         if regs[i] == ir.pc:
             dst = ExprMem(r, 32)
     r = SP + ExprInt(4 * len(regs), 32)
-    e.append(ExprAff(SP, r))
+    e.append(ExprAssign(SP, r))
     if dst is not None:
-        e.append(ExprAff(ir.IRDst, dst))
+        e.append(ExprAssign(ir.IRDst, dst))
     return e, []
 
 
@@ -1081,7 +1081,7 @@ def cbz(ir, instr, a, b):
     e = []
     loc_next = ir.get_next_loc_key(instr)
     loc_next_expr = ExprLoc(loc_next, 32)
-    e.append(ExprAff(ir.IRDst, ExprCond(a, loc_next_expr, b)))
+    e.append(ExprAssign(ir.IRDst, ExprCond(a, loc_next_expr, b)))
     return e, []
 
 
@@ -1096,41 +1096,41 @@ def cbnz(ir, instr, a, b):
 def uxtb(ir, instr, a, b):
     e = []
     r = b[:8].zeroExtend(32)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = None
     if PC in a.get_r():
         dst = PC
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 def uxth(ir, instr, a, b):
     e = []
     r = b[:16].zeroExtend(32)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = None
     if PC in a.get_r():
         dst = PC
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 def sxtb(ir, instr, a, b):
     e = []
     r = b[:8].signExtend(32)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = None
     if PC in a.get_r():
         dst = PC
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 def sxth(ir, instr, a, b):
     e = []
     r = b[:16].signExtend(32)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = None
     if PC in a.get_r():
         dst = PC
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -1139,11 +1139,11 @@ def ubfx(ir, instr, a, b, c, d):
     c = int(c)
     d = int(d)
     r = b[c:c+d].zeroExtend(32)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = None
     if PC in a.get_r():
         dst = PC
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 def bfc(ir, instr, a, b, c):
@@ -1161,11 +1161,11 @@ def bfc(ir, instr, a, b, c):
     if last < 32:
         out.append(a[last:])
     r = ExprCompose(*out)
-    e.append(ExprAff(a, r))
+    e.append(ExprAssign(a, r))
     dst = None
     if PC in a.get_r():
         dst = PC
-        e.append(ExprAff(ir.IRDst, r))
+        e.append(ExprAssign(ir.IRDst, r))
     return e, []
 
 
@@ -1181,19 +1181,19 @@ def pldw(ir, instr, a):
 
 def clz(ir, instr, a, b):
     e = []
-    e.append(ExprAff(a, ExprOp('cntleadzeros', b)))
+    e.append(ExprAssign(a, ExprOp('cntleadzeros', b)))
     return e, []
 
 def uxtab(ir, instr, a, b, c):
     e = []
-    e.append(ExprAff(a, b + (c & ExprInt(0xff, 32))))
+    e.append(ExprAssign(a, b + (c & ExprInt(0xff, 32))))
     return e, []
 
 
 def bkpt(ir, instr, a):
     e = []
-    e.append(ExprAff(exception_flags, ExprInt(EXCEPT_SOFT_BP, 32)))
-    e.append(ExprAff(bp_num, a))
+    e.append(ExprAssign(exception_flags, ExprInt(EXCEPT_SOFT_BP, 32)))
+    e.append(ExprAssign(bp_num, a))
     return e, []
 
 
@@ -1206,58 +1206,58 @@ def _extract_s16(arg, part):
 
 def smul(ir, instr, a, b, c):
     e = []
-    e.append(ExprAff(a, _extract_s16(b, instr.name[4]).signExtend(32) * _extract_s16(c, instr.name[5]).signExtend(32)))
+    e.append(ExprAssign(a, _extract_s16(b, instr.name[4]).signExtend(32) * _extract_s16(c, instr.name[5]).signExtend(32)))
     return e, []
 
 
 def smulw(ir, instr, a, b, c):
     e = []
     prod = b.signExtend(48) * _extract_s16(c, instr.name[5]).signExtend(48)
-    e.append(ExprAff(a, prod[16:48]))
+    e.append(ExprAssign(a, prod[16:48]))
     return e, [] # signed most significant 32 bits of the 48-bit result
 
 
 def tbb(ir, instr, a):
     e = []
     dst = PC + ExprInt(2, 32) * a.zeroExtend(32)
-    e.append(ExprAff(PC, dst))
-    e.append(ExprAff(ir.IRDst, dst))
+    e.append(ExprAssign(PC, dst))
+    e.append(ExprAssign(ir.IRDst, dst))
     return e, []
 
 
 def tbh(ir, instr, a):
     e = []
     dst = PC + ExprInt(2, 32) * a.zeroExtend(32)
-    e.append(ExprAff(PC, dst))
-    e.append(ExprAff(ir.IRDst, dst))
+    e.append(ExprAssign(PC, dst))
+    e.append(ExprAssign(ir.IRDst, dst))
     return e, []
 
 
 def smlabb(ir, instr, a, b, c, d):
     e = []
     result = (b[:16].signExtend(32) * c[:16].signExtend(32)) + d
-    e.append(ExprAff(a, result))
+    e.append(ExprAssign(a, result))
     return e, []
 
 
 def smlabt(ir, instr, a, b, c, d):
     e = []
     result = (b[:16].signExtend(32) * c[16:32].signExtend(32)) + d
-    e.append(ExprAff(a, result))
+    e.append(ExprAssign(a, result))
     return e, []
 
 
 def smlatb(ir, instr, a, b, c, d):
     e = []
     result = (b[16:32].signExtend(32) * c[:16].signExtend(32)) + d
-    e.append(ExprAff(a, result))
+    e.append(ExprAssign(a, result))
     return e, []
 
 
 def smlatt(ir, instr, a, b, c, d):
     e = []
     result = (b[16:32].signExtend(32) * c[16:32].signExtend(32)) + d
-    e.append(ExprAff(a, result))
+    e.append(ExprAssign(a, result))
     return e, []
 
 
@@ -1269,10 +1269,10 @@ def uadd8(ir, instr, a, b, c):
         sums.append(b[i:i+8] + c[i:i+8])
         ges.append((b[i:i+8].zeroExtend(9) + c[i:i+8].zeroExtend(9))[8:9])
 
-    e.append(ExprAff(a, ExprCompose(*sums)))
+    e.append(ExprAssign(a, ExprCompose(*sums)))
 
     for i, value in enumerate(ges):
-        e.append(ExprAff(ge_regs[i], value))
+        e.append(ExprAssign(ge_regs[i], value))
     return e, []
 
 
@@ -1283,14 +1283,14 @@ def sel(ir, instr, a, b, c):
     for i in xrange(4):
         parts.append(ExprCond(ge_regs[i], b[i*8:(i+1)*8], c[i*8:(i+1)*8]))
     result = ExprCompose(*parts)
-    e.append(ExprAff(a, result))
+    e.append(ExprAssign(a, result))
     return e, []
 
 
 def rev(ir, instr, a, b):
     e = []
     result = ExprCompose(b[24:32], b[16:24], b[8:16], b[:8])
-    e.append(ExprAff(a, result))
+    e.append(ExprAssign(a, result))
     return e, []
 
 
@@ -1438,9 +1438,9 @@ def add_condition_expr(ir, instr, cond, instr_ir, extra_ir):
             has_irdst = True
             break
     if not has_irdst:
-        instr_ir.append(ExprAff(ir.IRDst, loc_next_expr))
+        instr_ir.append(ExprAssign(ir.IRDst, loc_next_expr))
     e_do = IRBlock(loc_do, [AssignBlock(instr_ir, instr)])
-    e = [ExprAff(ir.IRDst, dst_cond)]
+    e = [ExprAssign(ir.IRDst, dst_cond)]
     return e, [e_do] + extra_ir
 
 mnemo_func = {}
@@ -1656,7 +1656,7 @@ class ir_arml(IntermediateRepresentation):
             if dst != self.pc:
                 dst = dst.replace_expr(pc_fixed)
             src = src.replace_expr(pc_fixed)
-            instr_ir[i] = ExprAff(dst, src)
+            instr_ir[i] = ExprAssign(dst, src)
 
         for idx, irblock in enumerate(extra_ir):
             extra_ir[idx] = irblock.modify_exprs(lambda expr: expr.replace_expr(pc_fixed) \
@@ -1706,7 +1706,7 @@ class ir_arml(IntermediateRepresentation):
 
         # Gen dummy irblock for IT instr
         loc_next = self.get_next_loc_key(instr)
-        dst = ExprAff(self.IRDst, ExprId(loc_next, 32))
+        dst = ExprAssign(self.IRDst, ExprId(loc_next, 32))
         dst_blk = AssignBlock([dst], instr)
         assignments.append(dst_blk)
         irblock = IRBlock(loc, assignments)
@@ -1727,7 +1727,7 @@ class ir_arml(IntermediateRepresentation):
                 local_cond = ~cond_eq
             else:
                 local_cond = cond_eq
-            dst = ExprAff(self.IRDst, ExprCond(local_cond, ExprLoc(loc_do, 32), ExprLoc(loc_next, 32)))
+            dst = ExprAssign(self.IRDst, ExprCond(local_cond, ExprLoc(loc_do, 32), ExprLoc(loc_next, 32)))
             dst_blk = AssignBlock([dst], instr)
             assignments.append(dst_blk)
             irblock = IRBlock(loc, assignments)
@@ -1743,7 +1743,7 @@ class ir_arml(IntermediateRepresentation):
             if split:
                 raise NotImplementedError("Unsupported instr in IT block (%s)" % instr)
 
-            dst = ExprAff(self.IRDst, ExprId(loc_next, 32))
+            dst = ExprAssign(self.IRDst, ExprId(loc_next, 32))
             dst_blk = AssignBlock([dst], instr)
             assignments.append(dst_blk)
             irblock = IRBlock(loc, assignments)
@@ -1824,7 +1824,7 @@ class ir_armtl(ir_arml):
             if dst != self.pc:
                 dst = dst.replace_expr(pc_fixed)
             src = src.replace_expr(pc_fixed)
-            instr_ir[i] = ExprAff(dst, src)
+            instr_ir[i] = ExprAssign(dst, src)
 
         for idx, irblock in enumerate(extra_ir):
             extra_ir[idx] = irblock.modify_exprs(lambda expr: expr.replace_expr(pc_fixed) \

--- a/miasm2/arch/mep/sem.py
+++ b/miasm2/arch/mep/sem.py
@@ -8,7 +8,7 @@ from miasm2.arch.mep.regs import PC, SP, LP, SAR, TP, RPB, RPE, RPC, EPC, NPC, \
     take_jmp, in_erepeat
 from miasm2.arch.mep.regs import EXC, HI, LO, PSW, DEPC, DBG
 from miasm2.expression.expression import ExprId, ExprInt, ExprOp
-from miasm2.expression.expression import ExprAff, ExprCond, ExprMem
+from miasm2.expression.expression import ExprAssign, ExprCond, ExprMem
 from miasm2.core.cpu import sign_ext
 from miasm2.jitter.csts import EXCEPT_DIV_BY_ZERO
 
@@ -105,7 +105,7 @@ def sw(reg_src, deref_dst):
 #        imm = deref_reg_or_imm.zeroExtend(32)
 #        dst = ExprMem(ExprOp("+", imm, deref_reg.arg))
 #
-#    return [ExprAff(dst, reg_src)], []
+#    return [ExprAssign(dst, reg_src)], []
 
 
 @sbuild.parse
@@ -242,7 +242,7 @@ def add3(ir, instr, reg_dst, reg_src, reg_or_imm):
         value = int(reg_or_imm.arg)
         result = ExprOp("+", reg_src, ExprInt(value, 32))
 
-    return [ExprAff(reg_dst, result)], []
+    return [ExprAssign(reg_dst, result)], []
 
 manual_functions["add3"] = add3
 
@@ -287,7 +287,7 @@ def sbvck3(ir, instr, r0, rn, rm):
 
     # Return the result
     condition = ExprCond(overflow_test, ExprInt(1, 32), ExprInt(0, 32))
-    return [ExprAff(r0, condition)], []
+    return [ExprAssign(r0, condition)], []
 
 manual_functions["sbvck3"] = sbvck3
 
@@ -602,12 +602,12 @@ def jmp(ir, instr, reg_or_imm):
 
     if isinstance(reg_or_imm, ExprId):
         # PC <- Rm31..1||0
-        new_PC = ExprAff(PC, reg_or_imm)
+        new_PC = ExprAssign(PC, reg_or_imm)
     else:
         # PC <- PC31..28||0000||(target24)23..1||0
-        new_PC = ExprAff(PC, ExprOp("+", ExprOp("&", PC, ExprInt(0xF0000000, 32)), reg_or_imm))
+        new_PC = ExprAssign(PC, ExprOp("+", ExprOp("&", PC, ExprInt(0xF0000000, 32)), reg_or_imm))
 
-    return [new_PC, ExprAff(ir.IRDst, new_PC)], []
+    return [new_PC, ExprAssign(ir.IRDst, new_PC)], []
 
 manual_functions["jmp"] = jmp
 

--- a/miasm2/arch/mips32/ira.py
+++ b/miasm2/arch/mips32/ira.py
@@ -1,6 +1,6 @@
 #-*- coding:utf-8 -*-
 
-from miasm2.expression.expression import ExprAff, ExprOp
+from miasm2.expression.expression import ExprAssign, ExprOp
 from miasm2.ir.ir import IRBlock, AssignBlock
 from miasm2.ir.analysis import ira
 from miasm2.arch.mips32.sem import ir_mips32l, ir_mips32b
@@ -13,7 +13,7 @@ class ir_a_mips32l(ir_mips32l, ira):
     def call_effects(self, ad, instr):
         call_assignblk = AssignBlock(
             [
-                ExprAff(
+                ExprAssign(
                     self.ret_reg,
                     ExprOp(
                         'call_func_ret',

--- a/miasm2/arch/mips32/sem.py
+++ b/miasm2/arch/mips32/sem.py
@@ -333,7 +333,7 @@ def ins(ir, instr, a, b, c, d):
     if pos + l != 32:
         my_slices.append((a[pos+l:], pos+l, 32))
     r = m2_expr.ExprCompose(my_slices)
-    e.append(m2_expr.ExprAff(a, r))
+    e.append(m2_expr.ExprAssign(a, r))
     return e, []
 
 
@@ -433,16 +433,16 @@ def teq(ir, instr, arg1, arg2):
     loc_next_expr = m2_expr.ExprLoc(loc_next, ir.IRDst.size)
 
     do_except = []
-    do_except.append(m2_expr.ExprAff(exception_flags, m2_expr.ExprInt(
+    do_except.append(m2_expr.ExprAssign(exception_flags, m2_expr.ExprInt(
         EXCEPT_DIV_BY_ZERO, exception_flags.size)))
-    do_except.append(m2_expr.ExprAff(ir.IRDst, loc_next_expr))
+    do_except.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
     blk_except = IRBlock(loc_except.index, [AssignBlock(do_except, instr)])
 
     cond = arg1 - arg2
 
 
     e = []
-    e.append(m2_expr.ExprAff(ir.IRDst,
+    e.append(m2_expr.ExprAssign(ir.IRDst,
                              m2_expr.ExprCond(cond, loc_next_expr, loc_except_expr)))
 
     return e, [blk_except]
@@ -498,7 +498,7 @@ class ir_mips32l(IntermediateRepresentation):
             ZERO: m2_expr.ExprInt(0, 32)
         }
 
-        instr_ir = [m2_expr.ExprAff(expr.dst, expr.src.replace_expr(fixed_regs))
+        instr_ir = [m2_expr.ExprAssign(expr.dst, expr.src.replace_expr(fixed_regs))
                     for expr in instr_ir]
 
         new_extra_ir = [irblock.modify_exprs(mod_src=lambda expr: expr.replace_expr(fixed_regs))

--- a/miasm2/arch/ppc/ira.py
+++ b/miasm2/arch/ppc/ira.py
@@ -1,4 +1,4 @@
-from miasm2.expression.expression import ExprAff, ExprOp
+from miasm2.expression.expression import ExprAssign, ExprOp
 from miasm2.ir.ir import AssignBlock
 from miasm2.ir.analysis import ira
 from miasm2.arch.ppc.sem import ir_ppc32b
@@ -25,7 +25,7 @@ class ir_a_ppc32b(ir_ppc32b, ira):
     def call_effects(self, ad, instr):
         call_assignblks = AssignBlock(
             [
-                ExprAff(
+                ExprAssign(
                     self.ret_reg,
                     ExprOp(
                         'call_func_ret',
@@ -36,7 +36,7 @@ class ir_a_ppc32b(ir_ppc32b, ira):
                         self.arch.regs.R5,
                     )
                 ),
-                ExprAff(self.sp, ExprOp('call_func_stack', ad, self.sp)),
+                ExprAssign(self.sp, ExprOp('call_func_stack', ad, self.sp)),
             ],
             instr
         )

--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -881,7 +881,7 @@ class mn_x86(cls_mn):
         raise NotImplementedError('not fully functional')
 
     def ir_pre_instruction(self):
-        return [ExprAff(mRIP[self.mode],
+        return [ExprAssign(mRIP[self.mode],
             ExprInt(self.offset + self.l, mRIP[self.mode].size))]
 
     @classmethod

--- a/miasm2/arch/x86/ira.py
+++ b/miasm2/arch/x86/ira.py
@@ -1,6 +1,6 @@
 #-*- coding:utf-8 -*-
 
-from miasm2.expression.expression import ExprAff, ExprOp
+from miasm2.expression.expression import ExprAssign, ExprOp
 from miasm2.ir.ir import AssignBlock
 from miasm2.ir.analysis import ira
 from miasm2.arch.x86.sem import ir_x86_16, ir_x86_32, ir_x86_64
@@ -46,7 +46,7 @@ class ir_a_x86_64(ir_x86_64, ir_a_x86_16):
     def call_effects(self, ad, instr):
         call_assignblk = AssignBlock(
             [
-                ExprAff(
+                ExprAssign(
                     self.ret_reg,
                     ExprOp(
                         'call_func_ret',
@@ -58,7 +58,7 @@ class ir_a_x86_64(ir_x86_64, ir_a_x86_16):
                         self.arch.regs.R9,
                     )
                 ),
-                ExprAff(self.sp, ExprOp('call_func_stack', ad, self.sp)),
+                ExprAssign(self.sp, ExprOp('call_func_stack', ad, self.sp)),
             ],
             instr
         )

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -60,12 +60,12 @@ OF(A-B) = ((A XOR D) AND (A XOR B)) < 0
 
 # XXX TODO make default check against 0 or not 0 (same eq as in C)
 def update_flag_zf_eq(a, b):
-    return [m2_expr.ExprAff(zf, m2_expr.ExprOp("FLAG_EQ_CMP", a, b))]
+    return [m2_expr.ExprAssign(zf, m2_expr.ExprOp("FLAG_EQ_CMP", a, b))]
 
 
 def update_flag_zf(a):
     return [
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             zf,
             m2_expr.ExprCond(
                 a,
@@ -78,7 +78,7 @@ def update_flag_zf(a):
 
 def update_flag_nf(arg):
     return [
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             nf,
             m2_expr.ExprOp("FLAG_SIGN_SUB", arg, m2_expr.ExprInt(0, arg.size))
         )
@@ -86,13 +86,13 @@ def update_flag_nf(arg):
 
 
 def update_flag_pf(a):
-    return [m2_expr.ExprAff(pf,
+    return [m2_expr.ExprAssign(pf,
                             m2_expr.ExprOp('parity',
                                            a & m2_expr.ExprInt(0xFF, a.size)))]
 
 
 def update_flag_af(op1, op2, res):
-    return [m2_expr.ExprAff(af, (op1 ^ op2 ^ res)[4:5])]
+    return [m2_expr.ExprAssign(af, (op1 ^ op2 ^ res)[4:5])]
 
 
 def update_flag_znp(a):
@@ -112,8 +112,8 @@ def update_flag_np(result):
 
 def null_flag_co():
     e = []
-    e.append(m2_expr.ExprAff(of, m2_expr.ExprInt(0, of.size)))
-    e.append(m2_expr.ExprAff(cf, m2_expr.ExprInt(0, cf.size)))
+    e.append(m2_expr.ExprAssign(of, m2_expr.ExprInt(0, of.size)))
+    e.append(m2_expr.ExprAssign(cf, m2_expr.ExprInt(0, cf.size)))
     return e
 
 
@@ -124,10 +124,10 @@ def update_flag_arith(a):
 
 
 def update_flag_zfaddwc_eq(arg1, arg2, arg3):
-    return [m2_expr.ExprAff(zf, m2_expr.ExprOp("FLAG_EQ_ADDWC", arg1, arg2, arg3))]
+    return [m2_expr.ExprAssign(zf, m2_expr.ExprOp("FLAG_EQ_ADDWC", arg1, arg2, arg3))]
 
 def update_flag_zfsubwc_eq(arg1, arg2, arg3):
-    return [m2_expr.ExprAff(zf, m2_expr.ExprOp("FLAG_EQ_SUBWC", arg1, arg2, arg3))]
+    return [m2_expr.ExprAssign(zf, m2_expr.ExprOp("FLAG_EQ_SUBWC", arg1, arg2, arg3))]
 
 
 def update_flag_arith_add_znp(arg1, arg2):
@@ -136,7 +136,7 @@ def update_flag_arith_add_znp(arg1, arg2):
     """
     e = []
     e += update_flag_zf_eq(arg1, -arg2)
-    e += [m2_expr.ExprAff(nf, m2_expr.ExprOp("FLAG_SIGN_SUB", arg1, -arg2))]
+    e += [m2_expr.ExprAssign(nf, m2_expr.ExprOp("FLAG_SIGN_SUB", arg1, -arg2))]
     e += update_flag_pf(arg1+arg2)
     return e
 
@@ -147,7 +147,7 @@ def update_flag_arith_addwc_znp(arg1, arg2, arg3):
     """
     e = []
     e += update_flag_zfaddwc_eq(arg1, arg2, arg3)
-    e += [m2_expr.ExprAff(nf, m2_expr.ExprOp("FLAG_SIGN_ADDWC", arg1, arg2, arg3))]
+    e += [m2_expr.ExprAssign(nf, m2_expr.ExprOp("FLAG_SIGN_ADDWC", arg1, arg2, arg3))]
     e += update_flag_pf(arg1+arg2+arg3.zeroExtend(arg2.size))
     return e
 
@@ -160,7 +160,7 @@ def update_flag_arith_sub_znp(arg1, arg2):
     """
     e = []
     e += update_flag_zf_eq(arg1, arg2)
-    e += [m2_expr.ExprAff(nf, m2_expr.ExprOp("FLAG_SIGN_SUB", arg1, arg2))]
+    e += [m2_expr.ExprAssign(nf, m2_expr.ExprOp("FLAG_SIGN_SUB", arg1, arg2))]
     e += update_flag_pf(arg1 - arg2)
     return e
 
@@ -171,7 +171,7 @@ def update_flag_arith_subwc_znp(arg1, arg2, arg3):
     """
     e = []
     e += update_flag_zfsubwc_eq(arg1, arg2, arg3)
-    e += [m2_expr.ExprAff(nf, m2_expr.ExprOp("FLAG_SIGN_SUBWC", arg1, arg2, arg3))]
+    e += [m2_expr.ExprAssign(nf, m2_expr.ExprOp("FLAG_SIGN_SUBWC", arg1, arg2, arg3))]
     e += update_flag_pf(arg1 - (arg2+arg3.zeroExtend(arg2.size)))
     return e
 
@@ -192,45 +192,45 @@ def arith_flag(a, b, c):
 
 def update_flag_add_cf(op1, op2, res):
     "Compute cf in @res = @op1 + @op2"
-    #return [m2_expr.ExprAff(cf, m2_expr.ExprOp("FLAG_SUB_CF", op1, -op2))]
-    return [m2_expr.ExprAff(cf, m2_expr.ExprOp("FLAG_ADD_CF", op1, op2))]
+    #return [m2_expr.ExprAssign(cf, m2_expr.ExprOp("FLAG_SUB_CF", op1, -op2))]
+    return [m2_expr.ExprAssign(cf, m2_expr.ExprOp("FLAG_ADD_CF", op1, op2))]
 
 
 def update_flag_add_of(op1, op2, res):
     "Compute of in @res = @op1 + @op2"
-    return [m2_expr.ExprAff(of, m2_expr.ExprOp("FLAG_ADD_OF", op1, op2))]
+    return [m2_expr.ExprAssign(of, m2_expr.ExprOp("FLAG_ADD_OF", op1, op2))]
 
 
 # checked: ok for sbb add because b & c before +cf
 def update_flag_sub_cf(op1, op2, res):
     "Compote CF in @res = @op1 - @op2"
-    return [m2_expr.ExprAff(cf, m2_expr.ExprOp("FLAG_SUB_CF", op1, op2))]
+    return [m2_expr.ExprAssign(cf, m2_expr.ExprOp("FLAG_SUB_CF", op1, op2))]
 
 
 def update_flag_sub_of(op1, op2, res):
     "Compote OF in @res = @op1 - @op2"
-    return [m2_expr.ExprAff(of, m2_expr.ExprOp("FLAG_SUB_OF", op1, op2))]
+    return [m2_expr.ExprAssign(of, m2_expr.ExprOp("FLAG_SUB_OF", op1, op2))]
 
 
 def update_flag_addwc_cf(op1, op2, op3):
     "Compute cf in @res = @op1 + @op2 + @op3"
-    return [m2_expr.ExprAff(cf, m2_expr.ExprOp("FLAG_ADDWC_CF", op1, op2, op3))]
+    return [m2_expr.ExprAssign(cf, m2_expr.ExprOp("FLAG_ADDWC_CF", op1, op2, op3))]
 
 
 def update_flag_addwc_of(op1, op2, op3):
     "Compute of in @res = @op1 + @op2 + @op3"
-    return [m2_expr.ExprAff(of, m2_expr.ExprOp("FLAG_ADDWC_OF", op1, op2, op3))]
+    return [m2_expr.ExprAssign(of, m2_expr.ExprOp("FLAG_ADDWC_OF", op1, op2, op3))]
 
 
 
 def update_flag_subwc_cf(op1, op2, op3):
     "Compute cf in @res = @op1 + @op2 + @op3"
-    return [m2_expr.ExprAff(cf, m2_expr.ExprOp("FLAG_SUBWC_CF", op1, op2, op3))]
+    return [m2_expr.ExprAssign(cf, m2_expr.ExprOp("FLAG_SUBWC_CF", op1, op2, op3))]
 
 
 def update_flag_subwc_of(op1, op2, op3):
     "Compute of in @res = @op1 + @op2 + @op3"
-    return [m2_expr.ExprAff(of, m2_expr.ExprOp("FLAG_SUBWC_OF", op1, op2, op3))]
+    return [m2_expr.ExprAssign(of, m2_expr.ExprOp("FLAG_SUBWC_OF", op1, op2, op3))]
 
 
 
@@ -269,9 +269,9 @@ def update_flag_arith_subwc_co(arg1, arg2, arg3):
 def set_float_cs_eip(instr):
     e = []
     # XXX TODO check float updt
-    e.append(m2_expr.ExprAff(float_eip,
+    e.append(m2_expr.ExprAssign(float_eip,
                              m2_expr.ExprInt(instr.offset, float_eip.size)))
-    e.append(m2_expr.ExprAff(float_cs, CS))
+    e.append(m2_expr.ExprAssign(float_cs, CS))
     return e
 
 
@@ -358,8 +358,8 @@ def gen_jcc(ir, instr, cond, dst, jmp_if):
     mn_dst = m2_expr.ExprCond(cond,
                               dstA.zeroExtend(ir.IRDst.size),
                               dstB.zeroExtend(ir.IRDst.size))
-    e.append(m2_expr.ExprAff(meip, mn_dst))
-    e.append(m2_expr.ExprAff(ir.IRDst, mn_dst))
+    e.append(m2_expr.ExprAssign(meip, mn_dst))
+    e.append(m2_expr.ExprAssign(ir.IRDst, mn_dst))
     return e, []
 
 
@@ -378,9 +378,9 @@ def gen_fcmov(ir, instr, cond, arg1, arg2, mov_if):
     else:
         dstA, dstB = loc_skip_expr, loc_do_expr
     e = []
-    e_do, extra_irs = [m2_expr.ExprAff(arg1, arg2)], []
-    e_do.append(m2_expr.ExprAff(ir.IRDst, loc_skip_expr))
-    e.append(m2_expr.ExprAff(ir.IRDst, m2_expr.ExprCond(cond, dstA, dstB)))
+    e_do, extra_irs = [m2_expr.ExprAssign(arg1, arg2)], []
+    e_do.append(m2_expr.ExprAssign(ir.IRDst, loc_skip_expr))
+    e.append(m2_expr.ExprAssign(ir.IRDst, m2_expr.ExprCond(cond, dstA, dstB)))
     return e, [IRBlock(loc_do, [AssignBlock(e_do, instr)])]
 
 
@@ -400,8 +400,8 @@ def gen_cmov(ir, instr, cond, dst, src, mov_if):
         dstA, dstB = loc_skip_expr, loc_do_expr
     e = []
     e_do, extra_irs = mov(ir, instr, dst, src)
-    e_do.append(m2_expr.ExprAff(ir.IRDst, loc_skip_expr))
-    e.append(m2_expr.ExprAff(ir.IRDst, m2_expr.ExprCond(cond, dstA, dstB)))
+    e_do.append(m2_expr.ExprAssign(ir.IRDst, loc_skip_expr))
+    e.append(m2_expr.ExprAssign(ir.IRDst, m2_expr.ExprCond(cond, dstA, dstB)))
     return e, [IRBlock(loc_do, [AssignBlock(e_do, instr)])]
 
 
@@ -410,7 +410,7 @@ def mov(_, instr, dst, src):
         src = src[:dst.size]
     if src in [ES, CS, SS, DS, FS, GS]:
         src = src.zeroExtend(dst.size)
-    e = [m2_expr.ExprAff(dst, src)]
+    e = [m2_expr.ExprAssign(dst, src)]
     return e, []
 
 
@@ -418,7 +418,7 @@ def movq(_, instr, dst, src):
     src_final = (src.zeroExtend(dst.size)
                  if dst.size >= src.size else
                  src[:dst.size])
-    return [m2_expr.ExprAff(dst, src_final)], []
+    return [m2_expr.ExprAssign(dst, src_final)], []
 
 
 @sbuild.parse
@@ -429,12 +429,12 @@ def xchg(arg1, arg2):
 
 
 def movzx(_, instr, dst, src):
-    e = [m2_expr.ExprAff(dst, src.zeroExtend(dst.size))]
+    e = [m2_expr.ExprAssign(dst, src.zeroExtend(dst.size))]
     return e, []
 
 
 def movsx(_, instr, dst, src):
-    e = [m2_expr.ExprAff(dst, src.signExtend(dst.size))]
+    e = [m2_expr.ExprAssign(dst, src.signExtend(dst.size))]
     return e, []
 
 
@@ -446,7 +446,7 @@ def lea(_, instr, dst, src):
 
     if ptr.size > dst.size:
         ptr = ptr[:dst.size]
-    e = [m2_expr.ExprAff(dst, ptr.zeroExtend(dst.size))]
+    e = [m2_expr.ExprAssign(dst, ptr.zeroExtend(dst.size))]
     return e, []
 
 
@@ -458,7 +458,7 @@ def add(_, instr, dst, src):
     e += update_flag_arith_add_znp(dst, src)
     e += update_flag_arith_add_co(dst, src, result)
     e += update_flag_af(dst, src, result)
-    e.append(m2_expr.ExprAff(dst, result))
+    e.append(m2_expr.ExprAssign(dst, result))
     return e, []
 
 
@@ -470,8 +470,8 @@ def xadd(_, instr, dst, src):
     e += update_flag_arith_add_co(src, dst, result)
     e += update_flag_af(dst, src, result)
     if dst != src:
-        e.append(m2_expr.ExprAff(src, dst))
-    e.append(m2_expr.ExprAff(dst, result))
+        e.append(m2_expr.ExprAssign(src, dst))
+    e.append(m2_expr.ExprAssign(dst, result))
     return e, []
 
 
@@ -485,7 +485,7 @@ def adc(_, instr, dst, src):
     e += update_flag_arith_addwc_znp(arg1, arg2, cf)
     e += update_flag_arith_addwc_co(arg1, arg2, cf)
     e += update_flag_af(arg1, arg2, result)
-    e.append(m2_expr.ExprAff(dst, result))
+    e.append(m2_expr.ExprAssign(dst, result))
     return e, []
 
 
@@ -498,7 +498,7 @@ def sub(_, instr, dst, src):
     e += update_flag_arith_sub_co(arg1, arg2, result)
     e += update_flag_af(dst, src, result)
 
-    e.append(m2_expr.ExprAff(dst, result))
+    e.append(m2_expr.ExprAssign(dst, result))
     return e, []
 
 # a-(b+cf)
@@ -513,7 +513,7 @@ def sbb(_, instr, dst, src):
     e += update_flag_arith_subwc_znp(arg1, arg2, cf)
     e += update_flag_af(arg1, arg2, result)
     e += update_flag_arith_subwc_co(arg1, arg2, cf)
-    e.append(m2_expr.ExprAff(dst, result))
+    e.append(m2_expr.ExprAssign(dst, result))
     return e, []
 
 
@@ -526,14 +526,14 @@ def neg(_, instr, src):
     e += update_flag_arith_sub_znp(arg1, arg2)
     e += update_flag_arith_sub_co(arg1, arg2, result)
     e += update_flag_af(arg1, arg2, result)
-    e.append(m2_expr.ExprAff(src, result))
+    e.append(m2_expr.ExprAssign(src, result))
     return (e, [])
 
 
 def l_not(_, instr, dst):
     e = []
     result = (~dst)
-    e.append(m2_expr.ExprAff(dst, result))
+    e.append(m2_expr.ExprAssign(dst, result))
     return (e, [])
 
 
@@ -551,38 +551,38 @@ def l_cmp(_, instr, dst, src):
 def xor(_, instr, dst, src):
     e = []
     result = dst ^ src
-    e += [m2_expr.ExprAff(zf, m2_expr.ExprOp('FLAG_EQ_CMP', dst, src))]
+    e += [m2_expr.ExprAssign(zf, m2_expr.ExprOp('FLAG_EQ_CMP', dst, src))]
     e += update_flag_np(result)
     e += null_flag_co()
-    e.append(m2_expr.ExprAff(dst, result))
+    e.append(m2_expr.ExprAssign(dst, result))
     return (e, [])
 
 
 def pxor(_, instr, dst, src):
     e = []
     result = dst ^ src
-    e.append(m2_expr.ExprAff(dst, result))
+    e.append(m2_expr.ExprAssign(dst, result))
     return (e, [])
 
 
 def l_or(_, instr, dst, src):
     e = []
     result = dst | src
-    e += [m2_expr.ExprAff(zf, m2_expr.ExprOp('FLAG_EQ', dst | src))]
+    e += [m2_expr.ExprAssign(zf, m2_expr.ExprOp('FLAG_EQ', dst | src))]
     e += update_flag_np(result)
     e += null_flag_co()
-    e.append(m2_expr.ExprAff(dst, result))
+    e.append(m2_expr.ExprAssign(dst, result))
     return (e, [])
 
 
 def l_and(_, instr, dst, src):
     e = []
     result = dst & src
-    e += [m2_expr.ExprAff(zf, m2_expr.ExprOp('FLAG_EQ_AND', dst, src))]
+    e += [m2_expr.ExprAssign(zf, m2_expr.ExprOp('FLAG_EQ_AND', dst, src))]
     e += update_flag_np(result)
     e += null_flag_co()
 
-    e.append(m2_expr.ExprAff(dst, result))
+    e.append(m2_expr.ExprAssign(dst, result))
     return (e, [])
 
 
@@ -590,8 +590,8 @@ def l_test(_, instr, dst, src):
     e = []
     result = dst & src
 
-    e += [m2_expr.ExprAff(zf, m2_expr.ExprOp('FLAG_EQ_CMP', result, m2_expr.ExprInt(0, result.size)))]
-    e += [m2_expr.ExprAff(nf, m2_expr.ExprOp("FLAG_SIGN_SUB", result, m2_expr.ExprInt(0, result.size)))]
+    e += [m2_expr.ExprAssign(zf, m2_expr.ExprOp('FLAG_EQ_CMP', result, m2_expr.ExprInt(0, result.size)))]
+    e += [m2_expr.ExprAssign(nf, m2_expr.ExprOp("FLAG_SIGN_SUB", result, m2_expr.ExprInt(0, result.size)))]
     e += update_flag_pf(result)
     e += null_flag_co()
 
@@ -632,9 +632,9 @@ def _rotate_tpl(ir, instr, dst, src, op, left=False):
                               res.msb() ^ new_cf if left else (dst ^ res).msb())
 
     # Build basic blocks
-    e_do = [m2_expr.ExprAff(cf, new_cf),
-            m2_expr.ExprAff(of, new_of),
-            m2_expr.ExprAff(dst, res)
+    e_do = [m2_expr.ExprAssign(cf, new_cf),
+            m2_expr.ExprAssign(of, new_of),
+            m2_expr.ExprAssign(dst, res)
             ]
     # Don't generate conditional shifter on constant
     if isinstance(shifter, m2_expr.ExprInt):
@@ -647,8 +647,8 @@ def _rotate_tpl(ir, instr, dst, src, op, left=False):
     loc_skip = ir.get_next_loc_key(instr)
     loc_skip_expr = m2_expr.ExprLoc(loc_skip, ir.IRDst.size)
 
-    e_do.append(m2_expr.ExprAff(ir.IRDst, loc_skip_expr))
-    e.append(m2_expr.ExprAff(
+    e_do.append(m2_expr.ExprAssign(ir.IRDst, loc_skip_expr))
+    e.append(m2_expr.ExprAssign(
         ir.IRDst, m2_expr.ExprCond(shifter, loc_do_expr, loc_skip_expr)))
     return (e, [IRBlock(loc_do, [AssignBlock(e_do, instr)])])
 
@@ -681,9 +681,9 @@ def rotate_with_carry_tpl(ir, instr, op, dst, src):
 
 
     # Build basic blocks
-    e_do = [m2_expr.ExprAff(cf, new_cf),
-            m2_expr.ExprAff(of, new_of),
-            m2_expr.ExprAff(dst, new_dst)
+    e_do = [m2_expr.ExprAssign(cf, new_cf),
+            m2_expr.ExprAssign(of, new_of),
+            m2_expr.ExprAssign(dst, new_dst)
             ]
     # Don't generate conditional shifter on constant
     if isinstance(shifter, m2_expr.ExprInt):
@@ -696,8 +696,8 @@ def rotate_with_carry_tpl(ir, instr, op, dst, src):
     loc_skip = ir.get_next_loc_key(instr)
     loc_skip_expr = m2_expr.ExprLoc(loc_skip, ir.IRDst.size)
 
-    e_do.append(m2_expr.ExprAff(ir.IRDst, loc_skip_expr))
-    e.append(m2_expr.ExprAff(
+    e_do.append(m2_expr.ExprAssign(ir.IRDst, loc_skip_expr))
+    e.append(m2_expr.ExprAssign(
         ir.IRDst, m2_expr.ExprCond(shifter, loc_do_expr, loc_skip_expr)))
     return (e, [IRBlock(loc_do, [AssignBlock(e_do, instr)])])
 
@@ -765,11 +765,11 @@ def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None, left=False,
 
     # Build basic blocks
     e_do = [
-        m2_expr.ExprAff(cf, new_cf),
-        m2_expr.ExprAff(of, m2_expr.ExprCond(shifter - i1,
+        m2_expr.ExprAssign(cf, new_cf),
+        m2_expr.ExprAssign(of, m2_expr.ExprCond(shifter - i1,
                                              m2_expr.ExprInt(0, of.size),
                                              value_of)),
-        m2_expr.ExprAff(a, res),
+        m2_expr.ExprAssign(a, res),
     ]
     e_do += update_flag_znp(res)
 
@@ -784,8 +784,8 @@ def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None, left=False,
     loc_do, loc_do_expr = ir.gen_loc_key_and_expr(ir.IRDst.size)
     loc_skip = ir.get_next_loc_key(instr)
     loc_skip_expr = m2_expr.ExprLoc(loc_skip, ir.IRDst.size)
-    e_do.append(m2_expr.ExprAff(ir.IRDst, loc_skip_expr))
-    e.append(m2_expr.ExprAff(ir.IRDst, m2_expr.ExprCond(shifter, loc_do_expr,
+    e_do.append(m2_expr.ExprAssign(ir.IRDst, loc_skip_expr))
+    e.append(m2_expr.ExprAssign(ir.IRDst, m2_expr.ExprCond(shifter, loc_do_expr,
                                                         loc_skip_expr)))
     return e, [IRBlock(loc_do, [AssignBlock(e_do, instr)])]
 
@@ -814,38 +814,38 @@ def shld(ir, instr, dst, src1, src2):
 
 # XXX todo ###
 def cmc(_, instr):
-    e = [m2_expr.ExprAff(cf, m2_expr.ExprCond(cf, m2_expr.ExprInt(0, cf.size),
+    e = [m2_expr.ExprAssign(cf, m2_expr.ExprCond(cf, m2_expr.ExprInt(0, cf.size),
                                               m2_expr.ExprInt(1, cf.size)))]
     return e, []
 
 
 def clc(_, instr):
-    e = [m2_expr.ExprAff(cf, m2_expr.ExprInt(0, cf.size))]
+    e = [m2_expr.ExprAssign(cf, m2_expr.ExprInt(0, cf.size))]
     return e, []
 
 
 def stc(_, instr):
-    e = [m2_expr.ExprAff(cf, m2_expr.ExprInt(1, cf.size))]
+    e = [m2_expr.ExprAssign(cf, m2_expr.ExprInt(1, cf.size))]
     return e, []
 
 
 def cld(_, instr):
-    e = [m2_expr.ExprAff(df, m2_expr.ExprInt(0, df.size))]
+    e = [m2_expr.ExprAssign(df, m2_expr.ExprInt(0, df.size))]
     return e, []
 
 
 def std(_, instr):
-    e = [m2_expr.ExprAff(df, m2_expr.ExprInt(1, df.size))]
+    e = [m2_expr.ExprAssign(df, m2_expr.ExprInt(1, df.size))]
     return e, []
 
 
 def cli(_, instr):
-    e = [m2_expr.ExprAff(i_f, m2_expr.ExprInt(0, i_f.size))]
+    e = [m2_expr.ExprAssign(i_f, m2_expr.ExprInt(0, i_f.size))]
     return e, []
 
 
 def sti(_, instr):
-    e = [m2_expr.ExprAff(exception_flags, m2_expr.ExprInt(EXCEPT_PRIV_INSN, 32))]
+    e = [m2_expr.ExprAssign(exception_flags, m2_expr.ExprInt(EXCEPT_PRIV_INSN, 32))]
     return e, []
 
 
@@ -859,7 +859,7 @@ def inc(_, instr, dst):
     e += update_flag_af(arg1, arg2, result)
     e += update_flag_add_of(arg1, arg2, result)
 
-    e.append(m2_expr.ExprAff(dst, result))
+    e.append(m2_expr.ExprAssign(dst, result))
     return e, []
 
 
@@ -873,7 +873,7 @@ def dec(_, instr, dst):
     e += update_flag_af(arg1, arg2, result)
     e += update_flag_sub_of(arg1, arg2, result)
 
-    e.append(m2_expr.ExprAff(dst, result))
+    e.append(m2_expr.ExprAssign(dst, result))
     return e, []
 
 
@@ -887,10 +887,10 @@ def push_gen(ir, instr, src, size):
 
     sp = mRSP[instr.mode]
     new_sp = sp - m2_expr.ExprInt(off_size / 8, sp.size)
-    e.append(m2_expr.ExprAff(sp, new_sp))
+    e.append(m2_expr.ExprAssign(sp, new_sp))
     if ir.do_stk_segm:
         new_sp = ir.gen_segm_expr(SS, new_sp)
-    e.append(m2_expr.ExprAff(ir.ExprMem(new_sp, off_size),
+    e.append(m2_expr.ExprAssign(ir.ExprMem(new_sp, off_size),
                              src))
     return e, []
 
@@ -912,7 +912,7 @@ def pop_gen(ir, instr, src, size):
     new_sp = sp + m2_expr.ExprInt(src.size / 8, sp.size)
     # don't generate ESP incrementation on POP ESP
     if src != ir.sp:
-        e.append(m2_expr.ExprAff(sp, new_sp))
+        e.append(m2_expr.ExprAssign(sp, new_sp))
     # XXX FIX XXX for pop [esp]
     if isinstance(src, m2_expr.ExprMem):
         src = expr_simp(src.replace_expr({sp: new_sp}))
@@ -920,7 +920,7 @@ def pop_gen(ir, instr, src, size):
     if ir.do_stk_segm:
         result = ir.gen_segm_expr(SS, result)
 
-    e.append(m2_expr.ExprAff(src, ir.ExprMem(result, src.size)))
+    e.append(m2_expr.ExprAssign(src, ir.ExprMem(result, src.size)))
     return e, []
 
 
@@ -935,7 +935,7 @@ def popw(ir, instr, src):
 def sete(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprOp("CC_EQ", zf).zeroExtend(dst.size),
         )
@@ -946,7 +946,7 @@ def sete(_, instr, dst):
 def setnz(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprOp("CC_EQ", ~zf).zeroExtend(dst.size),
         )
@@ -957,7 +957,7 @@ def setnz(_, instr, dst):
 def setl(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprOp("CC_S<", nf, of).zeroExtend(dst.size),
         )
@@ -968,7 +968,7 @@ def setl(_, instr, dst):
 def setg(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprOp("CC_S>", nf, of, zf).zeroExtend(dst.size),
         )
@@ -979,7 +979,7 @@ def setg(_, instr, dst):
 def setge(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprOp("CC_S>=", nf, of).zeroExtend(dst.size),
         )
@@ -990,7 +990,7 @@ def setge(_, instr, dst):
 def seta(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprOp("CC_U>", cf, zf).zeroExtend(dst.size),
         )
@@ -1001,7 +1001,7 @@ def seta(_, instr, dst):
 def setae(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprOp("CC_U>=", cf).zeroExtend(dst.size),
         )
@@ -1012,7 +1012,7 @@ def setae(_, instr, dst):
 def setb(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprOp("CC_U<", cf).zeroExtend(dst.size),
         )
@@ -1023,7 +1023,7 @@ def setb(_, instr, dst):
 def setbe(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprOp("CC_U<=", cf, zf).zeroExtend(dst.size),
         )
@@ -1034,7 +1034,7 @@ def setbe(_, instr, dst):
 def setns(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprOp("CC_NEG", ~nf).zeroExtend(dst.size),
         )
@@ -1045,7 +1045,7 @@ def setns(_, instr, dst):
 def sets(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprOp("CC_NEG", nf).zeroExtend(dst.size),
         )
@@ -1056,7 +1056,7 @@ def sets(_, instr, dst):
 def seto(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             of.zeroExtend(dst.size)
         )
@@ -1067,7 +1067,7 @@ def seto(_, instr, dst):
 def setp(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             pf.zeroExtend(dst.size)
         )
@@ -1078,7 +1078,7 @@ def setp(_, instr, dst):
 def setnp(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprCond(
                 pf,
@@ -1093,7 +1093,7 @@ def setnp(_, instr, dst):
 def setle(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprOp("CC_S<=", nf, of, zf).zeroExtend(dst.size),
         )
@@ -1104,7 +1104,7 @@ def setle(_, instr, dst):
 def setna(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprOp("CC_U<=", cf, zf).zeroExtend(dst.size),
         )
@@ -1115,7 +1115,7 @@ def setna(_, instr, dst):
 def setnbe(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprOp("CC_U>", cf, zf).zeroExtend(dst.size),
         )
@@ -1126,7 +1126,7 @@ def setnbe(_, instr, dst):
 def setno(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprCond(
                 of,
@@ -1141,7 +1141,7 @@ def setno(_, instr, dst):
 def setnb(_, instr, dst):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst,
             m2_expr.ExprOp("CC_U>=", cf).zeroExtend(dst.size),
         )
@@ -1153,7 +1153,7 @@ def setalc(_, instr):
     dst = mRAX[instr.mode][0:8]
     e = []
     e.append(
-        m2_expr.ExprAff(dst, m2_expr.ExprCond(cf, m2_expr.ExprInt(0xff, dst.size),
+        m2_expr.ExprAssign(dst, m2_expr.ExprCond(cf, m2_expr.ExprInt(0xff, dst.size),
                                               m2_expr.ExprInt(0, dst.size))))
     return e, []
 
@@ -1170,7 +1170,7 @@ def bswap(_, instr, dst):
                                      dst[24:32], dst[16:24], dst[8:16], dst[:8])
     else:
         raise ValueError('the size DOES matter')
-    e.append(m2_expr.ExprAff(dst, result))
+    e.append(m2_expr.ExprAssign(dst, result))
     return e, []
 
 
@@ -1199,18 +1199,18 @@ def cmps(ir, instr, size):
 
 
     e0 = []
-    e0.append(m2_expr.ExprAff(src1, src1 + offset))
-    e0.append(m2_expr.ExprAff(src2, src2 + offset))
-    e0.append(m2_expr.ExprAff(ir.IRDst, loc_next_expr))
+    e0.append(m2_expr.ExprAssign(src1, src1 + offset))
+    e0.append(m2_expr.ExprAssign(src2, src2 + offset))
+    e0.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
     e0 = IRBlock(loc_df_0, [AssignBlock(e0, instr)])
 
     e1 = []
-    e1.append(m2_expr.ExprAff(src1, src1 - offset))
-    e1.append(m2_expr.ExprAff(src2, src2 - offset))
-    e1.append(m2_expr.ExprAff(ir.IRDst, loc_next_expr))
+    e1.append(m2_expr.ExprAssign(src1, src1 - offset))
+    e1.append(m2_expr.ExprAssign(src2, src2 - offset))
+    e1.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
     e1 = IRBlock(loc_df_1, [AssignBlock(e1, instr)])
 
-    e.append(m2_expr.ExprAff(ir.IRDst,
+    e.append(m2_expr.ExprAssign(ir.IRDst,
                              m2_expr.ExprCond(df, loc_df_1_expr, loc_df_0_expr)))
     return e, [e0, e1]
 
@@ -1236,17 +1236,17 @@ def scas(ir, instr, size):
                      ir.ExprMem(src_sgm, size))
 
     e0 = []
-    e0.append(m2_expr.ExprAff(src, src + offset))
+    e0.append(m2_expr.ExprAssign(src, src + offset))
 
-    e0.append(m2_expr.ExprAff(ir.IRDst, loc_next_expr))
+    e0.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
     e0 = IRBlock(loc_df_0, [AssignBlock(e0, instr)])
 
     e1 = []
-    e1.append(m2_expr.ExprAff(src, src - offset))
-    e1.append(m2_expr.ExprAff(ir.IRDst, loc_next_expr))
+    e1.append(m2_expr.ExprAssign(src, src - offset))
+    e1.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
     e1 = IRBlock(loc_df_1, [AssignBlock(e1, instr)])
 
-    e.append(m2_expr.ExprAff(ir.IRDst,
+    e.append(m2_expr.ExprAssign(ir.IRDst,
                              m2_expr.ExprCond(df, loc_df_1_expr, loc_df_0_expr)))
 
     return e, [e0, e1]
@@ -1284,26 +1284,26 @@ def pushfw(ir, instr):
 def popfd(ir, instr):
     tmp = ir.ExprMem(mRSP[instr.mode], 32)
     e = []
-    e.append(m2_expr.ExprAff(cf, m2_expr.ExprSlice(tmp, 0, 1)))
-    e.append(m2_expr.ExprAff(pf, m2_expr.ExprSlice(tmp, 2, 3)))
-    e.append(m2_expr.ExprAff(af, m2_expr.ExprSlice(tmp, 4, 5)))
-    e.append(m2_expr.ExprAff(zf, m2_expr.ExprSlice(tmp, 6, 7)))
-    e.append(m2_expr.ExprAff(nf, m2_expr.ExprSlice(tmp, 7, 8)))
-    e.append(m2_expr.ExprAff(tf, m2_expr.ExprSlice(tmp, 8, 9)))
-    e.append(m2_expr.ExprAff(i_f, m2_expr.ExprSlice(tmp, 9, 10)))
-    e.append(m2_expr.ExprAff(df, m2_expr.ExprSlice(tmp, 10, 11)))
-    e.append(m2_expr.ExprAff(of, m2_expr.ExprSlice(tmp, 11, 12)))
-    e.append(m2_expr.ExprAff(iopl, m2_expr.ExprSlice(tmp, 12, 14)))
-    e.append(m2_expr.ExprAff(nt, m2_expr.ExprSlice(tmp, 14, 15)))
-    e.append(m2_expr.ExprAff(rf, m2_expr.ExprSlice(tmp, 16, 17)))
-    e.append(m2_expr.ExprAff(vm, m2_expr.ExprSlice(tmp, 17, 18)))
-    e.append(m2_expr.ExprAff(ac, m2_expr.ExprSlice(tmp, 18, 19)))
-    e.append(m2_expr.ExprAff(vif, m2_expr.ExprSlice(tmp, 19, 20)))
-    e.append(m2_expr.ExprAff(vip, m2_expr.ExprSlice(tmp, 20, 21)))
-    e.append(m2_expr.ExprAff(i_d, m2_expr.ExprSlice(tmp, 21, 22)))
-    e.append(m2_expr.ExprAff(mRSP[instr.mode],
+    e.append(m2_expr.ExprAssign(cf, m2_expr.ExprSlice(tmp, 0, 1)))
+    e.append(m2_expr.ExprAssign(pf, m2_expr.ExprSlice(tmp, 2, 3)))
+    e.append(m2_expr.ExprAssign(af, m2_expr.ExprSlice(tmp, 4, 5)))
+    e.append(m2_expr.ExprAssign(zf, m2_expr.ExprSlice(tmp, 6, 7)))
+    e.append(m2_expr.ExprAssign(nf, m2_expr.ExprSlice(tmp, 7, 8)))
+    e.append(m2_expr.ExprAssign(tf, m2_expr.ExprSlice(tmp, 8, 9)))
+    e.append(m2_expr.ExprAssign(i_f, m2_expr.ExprSlice(tmp, 9, 10)))
+    e.append(m2_expr.ExprAssign(df, m2_expr.ExprSlice(tmp, 10, 11)))
+    e.append(m2_expr.ExprAssign(of, m2_expr.ExprSlice(tmp, 11, 12)))
+    e.append(m2_expr.ExprAssign(iopl, m2_expr.ExprSlice(tmp, 12, 14)))
+    e.append(m2_expr.ExprAssign(nt, m2_expr.ExprSlice(tmp, 14, 15)))
+    e.append(m2_expr.ExprAssign(rf, m2_expr.ExprSlice(tmp, 16, 17)))
+    e.append(m2_expr.ExprAssign(vm, m2_expr.ExprSlice(tmp, 17, 18)))
+    e.append(m2_expr.ExprAssign(ac, m2_expr.ExprSlice(tmp, 18, 19)))
+    e.append(m2_expr.ExprAssign(vif, m2_expr.ExprSlice(tmp, 19, 20)))
+    e.append(m2_expr.ExprAssign(vip, m2_expr.ExprSlice(tmp, 20, 21)))
+    e.append(m2_expr.ExprAssign(i_d, m2_expr.ExprSlice(tmp, 21, 22)))
+    e.append(m2_expr.ExprAssign(mRSP[instr.mode],
                              mRSP[instr.mode] + m2_expr.ExprInt(instr.mode / 8, mRSP[instr.mode].size)))
-    e.append(m2_expr.ExprAff(exception_flags,
+    e.append(m2_expr.ExprAssign(exception_flags,
                              m2_expr.ExprCond(m2_expr.ExprSlice(tmp, 8, 9),
                                               m2_expr.ExprInt(
                                                   EXCEPT_SOFT_BP, 32),
@@ -1318,7 +1318,7 @@ def _tpl_eflags(tmp):
     """Extract eflags from @tmp
     @tmp: Expr instance with a size >= 16
     """
-    return [m2_expr.ExprAff(dest, tmp[base:base + dest.size])
+    return [m2_expr.ExprAssign(dest, tmp[base:base + dest.size])
             for base, dest in ((0, cf), (2, pf), (4, af), (6, zf), (7, nf),
                                (8, tf), (9, i_f), (10, df), (11, of),
                                (12, iopl), (14, nt))]
@@ -1328,7 +1328,7 @@ def popfw(ir, instr):
     tmp = ir.ExprMem(mRSP[instr.mode], 32)
     e = _tpl_eflags(tmp)
     e.append(
-        m2_expr.ExprAff(mRSP[instr.mode], mRSP[instr.mode] + m2_expr.ExprInt(2, mRSP[instr.mode].size)))
+        m2_expr.ExprAssign(mRSP[instr.mode], mRSP[instr.mode] + m2_expr.ExprInt(2, mRSP[instr.mode].size)))
     return e, []
 
 pa_regs = [
@@ -1344,8 +1344,8 @@ def pusha_gen(ir, instr, size):
     cur_sp = mRSP[instr.mode]
     for i, reg in enumerate(pa_regs):
         stk_ptr = cur_sp + m2_expr.ExprInt(-(size / 8) * (i + 1), instr.mode)
-        e.append(m2_expr.ExprAff(ir.ExprMem(stk_ptr, size), reg[size]))
-    e.append(m2_expr.ExprAff(cur_sp, stk_ptr))
+        e.append(m2_expr.ExprAssign(ir.ExprMem(stk_ptr, size), reg[size]))
+    e.append(m2_expr.ExprAssign(cur_sp, stk_ptr))
     return e, []
 
 
@@ -1364,10 +1364,10 @@ def popa_gen(ir, instr, size):
         if reg == mRSP:
             continue
         stk_ptr = cur_sp + m2_expr.ExprInt((size / 8) * i, instr.mode)
-        e.append(m2_expr.ExprAff(reg[size], ir.ExprMem(stk_ptr, size)))
+        e.append(m2_expr.ExprAssign(reg[size], ir.ExprMem(stk_ptr, size)))
 
     stk_ptr = cur_sp + m2_expr.ExprInt((size / 8) * (i + 1), instr.mode)
-    e.append(m2_expr.ExprAff(cur_sp, stk_ptr))
+    e.append(m2_expr.ExprAssign(cur_sp, stk_ptr))
 
     return e, []
 
@@ -1406,31 +1406,31 @@ def call(ir, instr, dst):
         else:
             raise RuntimeError("bad call operator")
 
-        e.append(m2_expr.ExprAff(CS, m1))
-        e.append(m2_expr.ExprAff(meip, m2))
+        e.append(m2_expr.ExprAssign(CS, m1))
+        e.append(m2_expr.ExprAssign(meip, m2))
 
-        e.append(m2_expr.ExprAff(ir.IRDst, m2))
+        e.append(m2_expr.ExprAssign(ir.IRDst, m2))
 
         c = myesp + m2_expr.ExprInt(-s / 8, s)
-        e.append(m2_expr.ExprAff(ir.ExprMem(c, size=s).zeroExtend(s),
+        e.append(m2_expr.ExprAssign(ir.ExprMem(c, size=s).zeroExtend(s),
                                  CS.zeroExtend(s)))
 
         c = myesp + m2_expr.ExprInt(-2 * s / 8, s)
-        e.append(m2_expr.ExprAff(ir.ExprMem(c, size=s).zeroExtend(s),
+        e.append(m2_expr.ExprAssign(ir.ExprMem(c, size=s).zeroExtend(s),
                                  meip.zeroExtend(s)))
 
         c = myesp + m2_expr.ExprInt((-2 * s) / 8, s)
-        e.append(m2_expr.ExprAff(myesp, c))
+        e.append(m2_expr.ExprAssign(myesp, c))
         return e, []
 
     c = myesp + m2_expr.ExprInt((-s / 8), s)
-    e.append(m2_expr.ExprAff(myesp, c))
+    e.append(m2_expr.ExprAssign(myesp, c))
     if ir.do_stk_segm:
         c = ir.gen_segm_expr(SS, c)
 
-    e.append(m2_expr.ExprAff(ir.ExprMem(c, size=s), n))
-    e.append(m2_expr.ExprAff(meip, dst.zeroExtend(ir.IRDst.size)))
-    e.append(m2_expr.ExprAff(ir.IRDst, dst.zeroExtend(ir.IRDst.size)))
+    e.append(m2_expr.ExprAssign(ir.ExprMem(c, size=s), n))
+    e.append(m2_expr.ExprAssign(meip, dst.zeroExtend(ir.IRDst.size)))
+    e.append(m2_expr.ExprAssign(ir.IRDst, dst.zeroExtend(ir.IRDst.size)))
     return e, []
 
 
@@ -1446,14 +1446,14 @@ def ret(ir, instr, src=None):
         src = m2_expr.ExprInt(int(src), size)
         value = (myesp + (m2_expr.ExprInt((size / 8), size) + src))
 
-    e.append(m2_expr.ExprAff(myesp, value))
+    e.append(m2_expr.ExprAssign(myesp, value))
     result = myesp
     if ir.do_stk_segm:
         result = ir.gen_segm_expr(SS, result)
 
-    e.append(m2_expr.ExprAff(meip, ir.ExprMem(
+    e.append(m2_expr.ExprAssign(meip, ir.ExprMem(
         result, size=size).zeroExtend(size)))
-    e.append(m2_expr.ExprAff(ir.IRDst,
+    e.append(m2_expr.ExprAssign(ir.IRDst,
                              ir.ExprMem(result, size=size).zeroExtend(size)))
     return e, []
 
@@ -1472,19 +1472,19 @@ def retf(ir, instr, src=None):
     if ir.do_stk_segm:
         result = ir.gen_segm_expr(SS, result)
 
-    e.append(m2_expr.ExprAff(meip, ir.ExprMem(
+    e.append(m2_expr.ExprAssign(meip, ir.ExprMem(
         result, size=size).zeroExtend(size)))
-    e.append(m2_expr.ExprAff(ir.IRDst,
+    e.append(m2_expr.ExprAssign(ir.IRDst,
                              ir.ExprMem(result, size=size).zeroExtend(size)))
-    # e.append(m2_expr.ExprAff(meip, ir.ExprMem(c, size = s)))
+    # e.append(m2_expr.ExprAssign(meip, ir.ExprMem(c, size = s)))
     result = myesp + m2_expr.ExprInt(size / 8, size)
     if ir.do_stk_segm:
         result = ir.gen_segm_expr(SS, result)
 
-    e.append(m2_expr.ExprAff(CS, ir.ExprMem(result, size=16)))
+    e.append(m2_expr.ExprAssign(CS, ir.ExprMem(result, size=16)))
 
     value = myesp + (m2_expr.ExprInt((2 * size) / 8, size) + src)
-    e.append(m2_expr.ExprAff(myesp, value))
+    e.append(m2_expr.ExprAssign(myesp, value))
     return e, []
 
 
@@ -1492,8 +1492,8 @@ def leave(ir, instr):
     size = instr.mode
     myesp = mRSP[size]
     e = []
-    e.append(m2_expr.ExprAff(mRBP[size], ir.ExprMem(mRBP[size], size=size)))
-    e.append(m2_expr.ExprAff(myesp,
+    e.append(m2_expr.ExprAssign(mRBP[size], ir.ExprMem(mRBP[size], size=size)))
+    e.append(m2_expr.ExprAssign(myesp,
                              m2_expr.ExprInt(size / 8, size) + mRBP[size]))
     return e, []
 
@@ -1507,10 +1507,10 @@ def enter(ir, instr, src1, src2):
 
     e = []
     esp_tmp = myesp - m2_expr.ExprInt(size / 8, size)
-    e.append(m2_expr.ExprAff(ir.ExprMem(esp_tmp, size=size),
+    e.append(m2_expr.ExprAssign(ir.ExprMem(esp_tmp, size=size),
                              myebp))
-    e.append(m2_expr.ExprAff(myebp, esp_tmp))
-    e.append(m2_expr.ExprAff(myesp,
+    e.append(m2_expr.ExprAssign(myebp, esp_tmp))
+    e.append(m2_expr.ExprAssign(myesp,
                              myesp - (src1 + m2_expr.ExprInt(size / 8, size))))
     return e, []
 
@@ -1534,14 +1534,14 @@ def jmp(ir, instr, dst):
         else:
             raise RuntimeError("bad jmp operator")
 
-        e.append(m2_expr.ExprAff(CS, m1))
-        e.append(m2_expr.ExprAff(meip, m2))
-        e.append(m2_expr.ExprAff(ir.IRDst, m2))
+        e.append(m2_expr.ExprAssign(CS, m1))
+        e.append(m2_expr.ExprAssign(meip, m2))
+        e.append(m2_expr.ExprAssign(ir.IRDst, m2))
 
     else:
         # Classic jmp
-        e.append(m2_expr.ExprAff(meip, dst))
-        e.append(m2_expr.ExprAff(ir.IRDst, dst))
+        e.append(m2_expr.ExprAssign(meip, dst))
+        e.append(m2_expr.ExprAssign(ir.IRDst, dst))
 
         if isinstance(dst, m2_expr.ExprMem):
             dst = meip
@@ -1650,9 +1650,9 @@ def loop(ir, instr, dst):
     dst_o = m2_expr.ExprCond(c,
                              dst.zeroExtend(ir.IRDst.size),
                              n.zeroExtend(ir.IRDst.size))
-    e.append(m2_expr.ExprAff(myecx, c))
-    e.append(m2_expr.ExprAff(meip, dst_o))
-    e.append(m2_expr.ExprAff(ir.IRDst, dst_o))
+    e.append(m2_expr.ExprAssign(myecx, c))
+    e.append(m2_expr.ExprAssign(meip, dst_o))
+    e.append(m2_expr.ExprAssign(ir.IRDst, dst_o))
     return e, []
 
 
@@ -1669,12 +1669,12 @@ def loopne(ir, instr, dst):
                          m2_expr.ExprInt(0, 1))
     c &= zf ^ m2_expr.ExprInt(1, 1)
 
-    e.append(m2_expr.ExprAff(myecx, myecx - m2_expr.ExprInt(1, myecx.size)))
+    e.append(m2_expr.ExprAssign(myecx, myecx - m2_expr.ExprInt(1, myecx.size)))
     dst_o = m2_expr.ExprCond(c,
                              dst.zeroExtend(ir.IRDst.size),
                              n.zeroExtend(ir.IRDst.size))
-    e.append(m2_expr.ExprAff(meip, dst_o))
-    e.append(m2_expr.ExprAff(ir.IRDst, dst_o))
+    e.append(m2_expr.ExprAssign(meip, dst_o))
+    e.append(m2_expr.ExprAssign(ir.IRDst, dst_o))
     return e, []
 
 
@@ -1689,12 +1689,12 @@ def loope(ir, instr, dst):
                          m2_expr.ExprInt(1, 1),
                          m2_expr.ExprInt(0, 1))
     c &= zf
-    e.append(m2_expr.ExprAff(myecx, myecx - m2_expr.ExprInt(1, myecx.size)))
+    e.append(m2_expr.ExprAssign(myecx, myecx - m2_expr.ExprInt(1, myecx.size)))
     dst_o = m2_expr.ExprCond(c,
                              dst.zeroExtend(ir.IRDst.size),
                              n.zeroExtend(ir.IRDst.size))
-    e.append(m2_expr.ExprAff(meip, dst_o))
-    e.append(m2_expr.ExprAff(ir.IRDst, dst_o))
+    e.append(m2_expr.ExprAssign(meip, dst_o))
+    e.append(m2_expr.ExprAssign(ir.IRDst, dst_o))
     return e, []
 
 # XXX size to do; eflag
@@ -1716,10 +1716,10 @@ def div(ir, instr, src1):
 
     # if 8 bit div, only ax is affected
     if size == 8:
-        e.append(m2_expr.ExprAff(src2, m2_expr.ExprCompose(c_d[:8], c_r[:8])))
+        e.append(m2_expr.ExprAssign(src2, m2_expr.ExprCompose(c_d[:8], c_r[:8])))
     else:
-        e.append(m2_expr.ExprAff(s1, c_r[:size]))
-        e.append(m2_expr.ExprAff(s2, c_d[:size]))
+        e.append(m2_expr.ExprAssign(s1, c_r[:size]))
+        e.append(m2_expr.ExprAssign(s2, c_d[:size]))
 
     loc_div, loc_div_expr = ir.gen_loc_key_and_expr(ir.IRDst.size)
     loc_except, loc_except_expr = ir.gen_loc_key_and_expr(ir.IRDst.size)
@@ -1728,17 +1728,17 @@ def div(ir, instr, src1):
 
     do_div = []
     do_div += e
-    do_div.append(m2_expr.ExprAff(ir.IRDst, loc_next_expr))
+    do_div.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
     blk_div = IRBlock(loc_div, [AssignBlock(do_div, instr)])
 
     do_except = []
-    do_except.append(m2_expr.ExprAff(exception_flags, m2_expr.ExprInt(
+    do_except.append(m2_expr.ExprAssign(exception_flags, m2_expr.ExprInt(
         EXCEPT_DIV_BY_ZERO, exception_flags.size)))
-    do_except.append(m2_expr.ExprAff(ir.IRDst, loc_next_expr))
+    do_except.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
     blk_except = IRBlock(loc_except, [AssignBlock(do_except, instr)])
 
     e = []
-    e.append(m2_expr.ExprAff(ir.IRDst,
+    e.append(m2_expr.ExprAssign(ir.IRDst,
                              m2_expr.ExprCond(src1, loc_div_expr, loc_except_expr)))
 
     return e, [blk_div, blk_except]
@@ -1763,10 +1763,10 @@ def idiv(ir, instr, src1):
 
     # if 8 bit div, only ax is affected
     if size == 8:
-        e.append(m2_expr.ExprAff(src2, m2_expr.ExprCompose(c_d[:8], c_r[:8])))
+        e.append(m2_expr.ExprAssign(src2, m2_expr.ExprCompose(c_d[:8], c_r[:8])))
     else:
-        e.append(m2_expr.ExprAff(s1, c_r[:size]))
-        e.append(m2_expr.ExprAff(s2, c_d[:size]))
+        e.append(m2_expr.ExprAssign(s1, c_r[:size]))
+        e.append(m2_expr.ExprAssign(s2, c_d[:size]))
 
     loc_div, loc_div_expr = ir.gen_loc_key_and_expr(ir.IRDst.size)
     loc_except, loc_except_expr = ir.gen_loc_key_and_expr(ir.IRDst.size)
@@ -1775,17 +1775,17 @@ def idiv(ir, instr, src1):
 
     do_div = []
     do_div += e
-    do_div.append(m2_expr.ExprAff(ir.IRDst, loc_next_expr))
+    do_div.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
     blk_div = IRBlock(loc_div, [AssignBlock(do_div, instr)])
 
     do_except = []
-    do_except.append(m2_expr.ExprAff(exception_flags, m2_expr.ExprInt(
+    do_except.append(m2_expr.ExprAssign(exception_flags, m2_expr.ExprInt(
         EXCEPT_DIV_BY_ZERO, exception_flags.size)))
-    do_except.append(m2_expr.ExprAff(ir.IRDst, loc_next_expr))
+    do_except.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
     blk_except = IRBlock(loc_except, [AssignBlock(do_except, instr)])
 
     e = []
-    e.append(m2_expr.ExprAff(ir.IRDst,
+    e.append(m2_expr.ExprAssign(ir.IRDst,
                              m2_expr.ExprCond(src1, loc_div_expr, loc_except_expr)))
 
     return e, [blk_div, blk_except]
@@ -1801,21 +1801,21 @@ def mul(_, instr, src1):
         result = m2_expr.ExprOp('*',
                                 mRAX[size].zeroExtend(size * 2),
                                 src1.zeroExtend(size * 2))
-        e.append(m2_expr.ExprAff(mRAX[size], result[:size]))
-        e.append(m2_expr.ExprAff(mRDX[size], result[size:size * 2]))
+        e.append(m2_expr.ExprAssign(mRAX[size], result[:size]))
+        e.append(m2_expr.ExprAssign(mRDX[size], result[size:size * 2]))
 
     elif src1.size == 8:
         result = m2_expr.ExprOp('*',
                                 mRAX[instr.mode][:8].zeroExtend(16),
                                 src1.zeroExtend(16))
-        e.append(m2_expr.ExprAff(mRAX[instr.mode][:16], result))
+        e.append(m2_expr.ExprAssign(mRAX[instr.mode][:16], result))
     else:
         raise ValueError('unknow size')
 
-    e.append(m2_expr.ExprAff(of, m2_expr.ExprCond(result[size:size * 2],
+    e.append(m2_expr.ExprAssign(of, m2_expr.ExprCond(result[size:size * 2],
                                                   m2_expr.ExprInt(1, 1),
                                                   m2_expr.ExprInt(0, 1))))
-    e.append(m2_expr.ExprAff(cf, m2_expr.ExprCond(result[size:size * 2],
+    e.append(m2_expr.ExprAssign(cf, m2_expr.ExprCond(result[size:size * 2],
                                                   m2_expr.ExprInt(1, 1),
                                                   m2_expr.ExprInt(0, 1))))
 
@@ -1830,23 +1830,23 @@ def imul(_, instr, src1, src2=None, src3=None):
             result = m2_expr.ExprOp('*',
                                     mRAX[size].signExtend(size * 2),
                                     src1.signExtend(size * 2))
-            e.append(m2_expr.ExprAff(mRAX[size], result[:size]))
-            e.append(m2_expr.ExprAff(mRDX[size], result[size:size * 2]))
+            e.append(m2_expr.ExprAssign(mRAX[size], result[:size]))
+            e.append(m2_expr.ExprAssign(mRDX[size], result[size:size * 2]))
         elif size == 8:
             dst = mRAX[instr.mode][:16]
             result = m2_expr.ExprOp('*',
                                     mRAX[instr.mode][:8].signExtend(16),
                                     src1.signExtend(16))
 
-            e.append(m2_expr.ExprAff(dst, result))
+            e.append(m2_expr.ExprAssign(dst, result))
         value = m2_expr.ExprCond(result - result[:size].signExtend(size * 2),
                                  m2_expr.ExprInt(1, 1),
                                  m2_expr.ExprInt(0, 1))
-        e.append(m2_expr.ExprAff(cf, value))
+        e.append(m2_expr.ExprAssign(cf, value))
         value = m2_expr.ExprCond(result - result[:size].signExtend(size * 2),
                                  m2_expr.ExprInt(1, 1),
                                  m2_expr.ExprInt(0, 1))
-        e.append(m2_expr.ExprAff(of, value))
+        e.append(m2_expr.ExprAssign(of, value))
 
     else:
         if src3 is None:
@@ -1855,16 +1855,16 @@ def imul(_, instr, src1, src2=None, src3=None):
         result = m2_expr.ExprOp('*',
                                 src2.signExtend(size * 2),
                                 src3.signExtend(size * 2))
-        e.append(m2_expr.ExprAff(src1, result[:size]))
+        e.append(m2_expr.ExprAssign(src1, result[:size]))
 
         value = m2_expr.ExprCond(result - result[:size].signExtend(size * 2),
                                  m2_expr.ExprInt(1, 1),
                                  m2_expr.ExprInt(0, 1))
-        e.append(m2_expr.ExprAff(cf, value))
+        e.append(m2_expr.ExprAssign(cf, value))
         value = m2_expr.ExprCond(result - result[:size].signExtend(size * 2),
                                  m2_expr.ExprInt(1, 1),
                                  m2_expr.ExprInt(0, 1))
-        e.append(m2_expr.ExprAff(of, value))
+        e.append(m2_expr.ExprAssign(of, value))
     return e, []
 
 
@@ -1873,7 +1873,7 @@ def cbw(_, instr):
     e = []
     tempAL = mRAX[instr.v_opmode()][:8]
     tempAX = mRAX[instr.v_opmode()][:16]
-    e.append(m2_expr.ExprAff(tempAX, tempAL.signExtend(16)))
+    e.append(m2_expr.ExprAssign(tempAX, tempAL.signExtend(16)))
     return e, []
 
 
@@ -1882,7 +1882,7 @@ def cwde(_, instr):
     e = []
     tempAX = mRAX[instr.v_opmode()][:16]
     tempEAX = mRAX[instr.v_opmode()][:32]
-    e.append(m2_expr.ExprAff(tempEAX, tempAX.signExtend(32)))
+    e.append(m2_expr.ExprAssign(tempEAX, tempAX.signExtend(32)))
     return e, []
 
 
@@ -1891,7 +1891,7 @@ def cdqe(_, instr):
     e = []
     tempEAX = mRAX[instr.mode][:32]
     tempRAX = mRAX[instr.mode][:64]
-    e.append(m2_expr.ExprAff(tempRAX, tempEAX.signExtend(64)))
+    e.append(m2_expr.ExprAssign(tempRAX, tempEAX.signExtend(64)))
     return e, []
 
 
@@ -1901,8 +1901,8 @@ def cwd(_, instr):
     tempAX = mRAX[instr.mode][:16]
     tempDX = mRDX[instr.mode][:16]
     result = tempAX.signExtend(32)
-    e.append(m2_expr.ExprAff(tempAX, result[:16]))
-    e.append(m2_expr.ExprAff(tempDX, result[16:32]))
+    e.append(m2_expr.ExprAssign(tempAX, result[:16]))
+    e.append(m2_expr.ExprAssign(tempDX, result[16:32]))
     return e, []
 
 
@@ -1912,7 +1912,7 @@ def cdq(_, instr):
     tempEAX = mRAX[instr.v_opmode()]
     tempEDX = mRDX[instr.v_opmode()]
     result = tempEAX.signExtend(64)
-    e.append(m2_expr.ExprAff(tempEDX, result[32:64]))
+    e.append(m2_expr.ExprAssign(tempEDX, result[32:64]))
     return e, []
 
 
@@ -1922,8 +1922,8 @@ def cqo(_, instr):
     tempRAX = mRAX[instr.mode][:64]
     tempRDX = mRDX[instr.mode][:64]
     result = tempRAX.signExtend(128)
-    e.append(m2_expr.ExprAff(tempRAX, result[:64]))
-    e.append(m2_expr.ExprAff(tempRDX, result[64:128]))
+    e.append(m2_expr.ExprAssign(tempRAX, result[:64]))
+    e.append(m2_expr.ExprAssign(tempRDX, result[64:128]))
     return e, []
 
 
@@ -1946,18 +1946,18 @@ def stos(ir, instr, size):
     b = mRAX[instr.mode][:size]
 
     e0 = []
-    e0.append(m2_expr.ExprAff(addr_o, addr_p))
-    e0.append(m2_expr.ExprAff(ir.IRDst, loc_next_expr))
+    e0.append(m2_expr.ExprAssign(addr_o, addr_p))
+    e0.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
     e0 = IRBlock(loc_df_0, [AssignBlock(e0, instr)])
 
     e1 = []
-    e1.append(m2_expr.ExprAff(addr_o, addr_m))
-    e1.append(m2_expr.ExprAff(ir.IRDst, loc_next_expr))
+    e1.append(m2_expr.ExprAssign(addr_o, addr_m))
+    e1.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
     e1 = IRBlock(loc_df_1, [AssignBlock(e1, instr)])
 
     e = []
-    e.append(m2_expr.ExprAff(ir.ExprMem(addr, size), b))
-    e.append(m2_expr.ExprAff(ir.IRDst,
+    e.append(m2_expr.ExprAssign(ir.ExprMem(addr, size), b))
+    e.append(m2_expr.ExprAssign(ir.IRDst,
                              m2_expr.ExprCond(df, loc_df_1_expr, loc_df_0_expr)))
     return e, [e0, e1]
 
@@ -1982,23 +1982,23 @@ def lods(ir, instr, size):
     b = mRAX[instr.mode][:size]
 
     e0 = []
-    e0.append(m2_expr.ExprAff(addr_o, addr_p))
-    e0.append(m2_expr.ExprAff(ir.IRDst, loc_next_expr))
+    e0.append(m2_expr.ExprAssign(addr_o, addr_p))
+    e0.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
     e0 = IRBlock(loc_df_0, [AssignBlock(e0, instr)])
 
     e1 = []
-    e1.append(m2_expr.ExprAff(addr_o, addr_m))
-    e1.append(m2_expr.ExprAff(ir.IRDst, loc_next_expr))
+    e1.append(m2_expr.ExprAssign(addr_o, addr_m))
+    e1.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
     e1 = IRBlock(loc_df_1, [AssignBlock(e1, instr)])
 
     e = []
     if instr.mode == 64 and b.size == 32:
-        e.append(m2_expr.ExprAff(mRAX[instr.mode],
+        e.append(m2_expr.ExprAssign(mRAX[instr.mode],
                                  ir.ExprMem(addr, size).zeroExtend(64)))
     else:
-        e.append(m2_expr.ExprAff(b, ir.ExprMem(addr, size)))
+        e.append(m2_expr.ExprAssign(b, ir.ExprMem(addr, size)))
 
-    e.append(m2_expr.ExprAff(ir.IRDst,
+    e.append(m2_expr.ExprAssign(ir.IRDst,
                              m2_expr.ExprCond(df, loc_df_1_expr, loc_df_0_expr)))
     return e, [e0, e1]
 
@@ -2024,22 +2024,22 @@ def movs(ir, instr, size):
 
     offset = m2_expr.ExprInt(size / 8, src.size)
 
-    e.append(m2_expr.ExprAff(ir.ExprMem(dst_sgm, size),
+    e.append(m2_expr.ExprAssign(ir.ExprMem(dst_sgm, size),
                              ir.ExprMem(src_sgm, size)))
 
     e0 = []
-    e0.append(m2_expr.ExprAff(src, src + offset))
-    e0.append(m2_expr.ExprAff(dst, dst + offset))
-    e0.append(m2_expr.ExprAff(ir.IRDst, loc_next_expr))
+    e0.append(m2_expr.ExprAssign(src, src + offset))
+    e0.append(m2_expr.ExprAssign(dst, dst + offset))
+    e0.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
     e0 = IRBlock(loc_df_0, [AssignBlock(e0, instr)])
 
     e1 = []
-    e1.append(m2_expr.ExprAff(src, src - offset))
-    e1.append(m2_expr.ExprAff(dst, dst - offset))
-    e1.append(m2_expr.ExprAff(ir.IRDst, loc_next_expr))
+    e1.append(m2_expr.ExprAssign(src, src - offset))
+    e1.append(m2_expr.ExprAssign(dst, dst - offset))
+    e1.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
     e1 = IRBlock(loc_df_1, [AssignBlock(e1, instr)])
 
-    e.append(m2_expr.ExprAff(ir.IRDst,
+    e.append(m2_expr.ExprAssign(ir.IRDst,
                              m2_expr.ExprCond(df, loc_df_1_expr, loc_df_0_expr)))
     return e, [e0, e1]
 
@@ -2056,7 +2056,7 @@ def movsd(_, instr, dst, src):
         src = m2_expr.ExprMem(src.arg, 64)
         # Erase dst high bits
         src = src.zeroExtend(dst.size)
-    return [m2_expr.ExprAff(dst, src)], []
+    return [m2_expr.ExprAssign(dst, src)], []
 
 
 def movsd_dispatch(ir, instr, dst=None, src=None):
@@ -2087,14 +2087,14 @@ def float_pop(avoid_flt=None, popcount=1):
     e = []
     for i in xrange(8 - popcount):
         if avoid_flt != float_list[i]:
-            e.append(m2_expr.ExprAff(float_list[i],
+            e.append(m2_expr.ExprAssign(float_list[i],
                                      float_list[i + popcount]))
     fill_value = m2_expr.ExprOp("sint_to_fp", m2_expr.ExprInt(0, 64))
     for i in xrange(8 - popcount, 8):
-        e.append(m2_expr.ExprAff(float_list[i],
+        e.append(m2_expr.ExprAssign(float_list[i],
                                  fill_value))
     e.append(
-        m2_expr.ExprAff(float_stack_ptr,
+        m2_expr.ExprAssign(float_stack_ptr,
                         float_stack_ptr - m2_expr.ExprInt(popcount, 3)))
     return e
 
@@ -2111,10 +2111,10 @@ def fcom(_, instr, dst=None, src=None):
 
     e = []
 
-    e.append(m2_expr.ExprAff(float_c0, m2_expr.ExprOp('fcom_c0', dst, src)))
-    e.append(m2_expr.ExprAff(float_c1, m2_expr.ExprOp('fcom_c1', dst, src)))
-    e.append(m2_expr.ExprAff(float_c2, m2_expr.ExprOp('fcom_c2', dst, src)))
-    e.append(m2_expr.ExprAff(float_c3, m2_expr.ExprOp('fcom_c3', dst, src)))
+    e.append(m2_expr.ExprAssign(float_c0, m2_expr.ExprOp('fcom_c0', dst, src)))
+    e.append(m2_expr.ExprAssign(float_c1, m2_expr.ExprOp('fcom_c1', dst, src)))
+    e.append(m2_expr.ExprAssign(float_c2, m2_expr.ExprOp('fcom_c2', dst, src)))
+    e.append(m2_expr.ExprAssign(float_c3, m2_expr.ExprOp('fcom_c3', dst, src)))
 
     e += set_float_cs_eip(instr)
     return e, []
@@ -2125,10 +2125,10 @@ def ftst(_, instr):
 
     e = []
     src = m2_expr.ExprOp('sint_to_fp', m2_expr.ExprInt(0, 64))
-    e.append(m2_expr.ExprAff(float_c0, m2_expr.ExprOp('fcom_c0', dst, src)))
-    e.append(m2_expr.ExprAff(float_c1, m2_expr.ExprOp('fcom_c1', dst, src)))
-    e.append(m2_expr.ExprAff(float_c2, m2_expr.ExprOp('fcom_c2', dst, src)))
-    e.append(m2_expr.ExprAff(float_c3, m2_expr.ExprOp('fcom_c3', dst, src)))
+    e.append(m2_expr.ExprAssign(float_c0, m2_expr.ExprOp('fcom_c0', dst, src)))
+    e.append(m2_expr.ExprAssign(float_c1, m2_expr.ExprOp('fcom_c1', dst, src)))
+    e.append(m2_expr.ExprAssign(float_c2, m2_expr.ExprOp('fcom_c2', dst, src)))
+    e.append(m2_expr.ExprAssign(float_c3, m2_expr.ExprOp('fcom_c3', dst, src)))
 
     e += set_float_cs_eip(instr)
     return e, []
@@ -2188,8 +2188,8 @@ def fxam(ir, instr):
                  )
         )
     )
-    base = [m2_expr.ExprAff(ir.IRDst, irdst),
-         m2_expr.ExprAff(float_c1, dst.msb())
+    base = [m2_expr.ExprAssign(ir.IRDst, irdst),
+         m2_expr.ExprAssign(float_c1, dst.msb())
     ]
     base += set_float_cs_eip(instr)
 
@@ -2234,16 +2234,16 @@ def ficom(_, instr, dst, src=None):
 
     e = []
 
-    e.append(m2_expr.ExprAff(float_c0,
+    e.append(m2_expr.ExprAssign(float_c0,
                              m2_expr.ExprOp('fcom_c0', dst,
                                             src.zeroExtend(dst.size))))
-    e.append(m2_expr.ExprAff(float_c1,
+    e.append(m2_expr.ExprAssign(float_c1,
                              m2_expr.ExprOp('fcom_c1', dst,
                                             src.zeroExtend(dst.size))))
-    e.append(m2_expr.ExprAff(float_c2,
+    e.append(m2_expr.ExprAssign(float_c2,
                              m2_expr.ExprOp('fcom_c2', dst,
                                             src.zeroExtend(dst.size))))
-    e.append(m2_expr.ExprAff(float_c3,
+    e.append(m2_expr.ExprAssign(float_c3,
                              m2_expr.ExprOp('fcom_c3', dst,
                                             src.zeroExtend(dst.size))))
 
@@ -2261,13 +2261,13 @@ def fcomi(_, instr, dst=None, src=None):
 
     e = []
 
-    e.append(m2_expr.ExprAff(cf, m2_expr.ExprOp('fcom_c0', dst, src)))
-    e.append(m2_expr.ExprAff(pf, m2_expr.ExprOp('fcom_c2', dst, src)))
-    e.append(m2_expr.ExprAff(zf, m2_expr.ExprOp('fcom_c3', dst, src)))
+    e.append(m2_expr.ExprAssign(cf, m2_expr.ExprOp('fcom_c0', dst, src)))
+    e.append(m2_expr.ExprAssign(pf, m2_expr.ExprOp('fcom_c2', dst, src)))
+    e.append(m2_expr.ExprAssign(zf, m2_expr.ExprOp('fcom_c3', dst, src)))
 
-    e.append(m2_expr.ExprAff(of, m2_expr.ExprInt(0, 1)))
-    e.append(m2_expr.ExprAff(nf, m2_expr.ExprInt(0, 1)))
-    e.append(m2_expr.ExprAff(af, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(of, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(nf, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(af, m2_expr.ExprInt(0, 1)))
 
     e += set_float_cs_eip(instr)
     return e, []
@@ -2334,13 +2334,13 @@ def comiss(_, instr, dst, src):
     dst = m2_expr.ExprOp('sint_to_fp', dst[:32])
     src = m2_expr.ExprOp('sint_to_fp', src[:32])
 
-    e.append(m2_expr.ExprAff(cf, m2_expr.ExprOp('fcom_c0', dst, src)))
-    e.append(m2_expr.ExprAff(pf, m2_expr.ExprOp('fcom_c2', dst, src)))
-    e.append(m2_expr.ExprAff(zf, m2_expr.ExprOp('fcom_c3', dst, src)))
+    e.append(m2_expr.ExprAssign(cf, m2_expr.ExprOp('fcom_c0', dst, src)))
+    e.append(m2_expr.ExprAssign(pf, m2_expr.ExprOp('fcom_c2', dst, src)))
+    e.append(m2_expr.ExprAssign(zf, m2_expr.ExprOp('fcom_c3', dst, src)))
 
-    e.append(m2_expr.ExprAff(of, m2_expr.ExprInt(0, 1)))
-    e.append(m2_expr.ExprAff(nf, m2_expr.ExprInt(0, 1)))
-    e.append(m2_expr.ExprAff(af, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(of, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(nf, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(af, m2_expr.ExprInt(0, 1)))
 
     e += set_float_cs_eip(instr)
     return e, []
@@ -2354,13 +2354,13 @@ def comisd(_, instr, dst, src):
     dst = m2_expr.ExprOp('sint_to_fp', dst[:64])
     src = m2_expr.ExprOp('sint_to_fp', src[:64])
 
-    e.append(m2_expr.ExprAff(cf, m2_expr.ExprOp('fcom_c0', dst, src)))
-    e.append(m2_expr.ExprAff(pf, m2_expr.ExprOp('fcom_c2', dst, src)))
-    e.append(m2_expr.ExprAff(zf, m2_expr.ExprOp('fcom_c3', dst, src)))
+    e.append(m2_expr.ExprAssign(cf, m2_expr.ExprOp('fcom_c0', dst, src)))
+    e.append(m2_expr.ExprAssign(pf, m2_expr.ExprOp('fcom_c2', dst, src)))
+    e.append(m2_expr.ExprAssign(zf, m2_expr.ExprOp('fcom_c3', dst, src)))
 
-    e.append(m2_expr.ExprAff(of, m2_expr.ExprInt(0, 1)))
-    e.append(m2_expr.ExprAff(nf, m2_expr.ExprInt(0, 1)))
-    e.append(m2_expr.ExprAff(af, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(of, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(nf, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(af, m2_expr.ExprInt(0, 1)))
 
     e += set_float_cs_eip(instr)
     return e, []
@@ -2374,16 +2374,16 @@ def fld(_, instr, src):
         raise NotImplementedError('convert from 80bits')
 
     e = []
-    e.append(m2_expr.ExprAff(float_st7, float_st6))
-    e.append(m2_expr.ExprAff(float_st6, float_st5))
-    e.append(m2_expr.ExprAff(float_st5, float_st4))
-    e.append(m2_expr.ExprAff(float_st4, float_st3))
-    e.append(m2_expr.ExprAff(float_st3, float_st2))
-    e.append(m2_expr.ExprAff(float_st2, float_st1))
-    e.append(m2_expr.ExprAff(float_st1, float_st0))
-    e.append(m2_expr.ExprAff(float_st0, src))
+    e.append(m2_expr.ExprAssign(float_st7, float_st6))
+    e.append(m2_expr.ExprAssign(float_st6, float_st5))
+    e.append(m2_expr.ExprAssign(float_st5, float_st4))
+    e.append(m2_expr.ExprAssign(float_st4, float_st3))
+    e.append(m2_expr.ExprAssign(float_st3, float_st2))
+    e.append(m2_expr.ExprAssign(float_st2, float_st1))
+    e.append(m2_expr.ExprAssign(float_st1, float_st0))
+    e.append(m2_expr.ExprAssign(float_st0, src))
     e.append(
-        m2_expr.ExprAff(float_stack_ptr,
+        m2_expr.ExprAssign(float_stack_ptr,
                         float_stack_ptr + m2_expr.ExprInt(1, 3)))
 
     e += set_float_cs_eip(instr)
@@ -2399,7 +2399,7 @@ def fst(_, instr, dst):
 
     if dst.size == 32:
         src = m2_expr.ExprOp("fpconvert_fp32", src)
-    e.append(m2_expr.ExprAff(dst, src))
+    e.append(m2_expr.ExprAssign(dst, src))
     e += set_float_cs_eip(instr)
     return e, []
 
@@ -2414,13 +2414,13 @@ def fstp(ir, instr, dst):
         src = float_st0
         if dst.size == 32:
             src = m2_expr.ExprOp("fpconvert_fp32", src)
-        e.append(m2_expr.ExprAff(dst, src))
+        e.append(m2_expr.ExprAssign(dst, src))
     else:
         src = float_st0
         if float_list.index(dst) > 1:
             # a = st0 -> st0 is dropped
             # a = st1 -> st0 = st0, useless
-            e.append(m2_expr.ExprAff(float_prev(dst), src))
+            e.append(m2_expr.ExprAssign(float_prev(dst), src))
 
     e += set_float_cs_eip(instr)
     e += float_pop(dst)
@@ -2429,7 +2429,7 @@ def fstp(ir, instr, dst):
 
 def fist(_, instr, dst):
     e = []
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('fp_to_sint%d' % dst.size,
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('fp_to_sint%d' % dst.size,
                                                  float_st0)))
 
     e += set_float_cs_eip(instr)
@@ -2444,7 +2444,7 @@ def fistp(ir, instr, dst):
 
 def fisttp(_, instr, dst):
     e = []
-    e.append(m2_expr.ExprAff(
+    e.append(m2_expr.ExprAssign(
         dst,
         m2_expr.ExprOp('fp_to_sint%d' % dst.size,
                        m2_expr.ExprOp('fpround_towardszero', float_st0)
@@ -2516,7 +2516,7 @@ def fadd(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('fadd', dst, src)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('fadd', dst, src)))
 
     e += set_float_cs_eip(instr)
     return e, []
@@ -2526,7 +2526,7 @@ def fiadd(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('fiadd', dst, src)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('fiadd', dst, src)))
     e += set_float_cs_eip(instr)
     return e, []
 
@@ -2535,7 +2535,7 @@ def fisub(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('fisub', dst, src)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('fisub', dst, src)))
     e += set_float_cs_eip(instr)
     return e, []
 
@@ -2544,7 +2544,7 @@ def fisubr(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('fisub', src, dst)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('fisub', src, dst)))
     e += set_float_cs_eip(instr)
     return e, []
 
@@ -2552,7 +2552,7 @@ def fisubr(_, instr, dst, src=None):
 def fpatan(_, instr):
     e = []
     a = float_st1
-    e.append(m2_expr.ExprAff(float_prev(a),
+    e.append(m2_expr.ExprAssign(float_prev(a),
                              m2_expr.ExprOp('fpatan', float_st0, float_st1)))
     e += set_float_cs_eip(instr)
     e += float_pop(a)
@@ -2562,14 +2562,14 @@ def fpatan(_, instr):
 def fprem(_, instr):
     e = []
     e.append(
-        m2_expr.ExprAff(float_st0, m2_expr.ExprOp('fprem', float_st0, float_st1)))
+        m2_expr.ExprAssign(float_st0, m2_expr.ExprOp('fprem', float_st0, float_st1)))
     # Remaining bits (ex: used in argument reduction in tan)
     quotient = m2_expr.ExprOp('fp_to_sint32', m2_expr.ExprOp('fpround_towardszero', m2_expr.ExprOp('fdiv', float_st0, float_st1)))
-    e += [m2_expr.ExprAff(float_c0, quotient[2:3]),
-          m2_expr.ExprAff(float_c3, quotient[1:2]),
-          m2_expr.ExprAff(float_c1, quotient[0:1]),
+    e += [m2_expr.ExprAssign(float_c0, quotient[2:3]),
+          m2_expr.ExprAssign(float_c3, quotient[1:2]),
+          m2_expr.ExprAssign(float_c1, quotient[0:1]),
           # Consider the reduction is always completed
-          m2_expr.ExprAff(float_c2, m2_expr.ExprInt(0, 1)),
+          m2_expr.ExprAssign(float_c2, m2_expr.ExprInt(0, 1)),
           ]
     e += set_float_cs_eip(instr)
     return e, []
@@ -2578,7 +2578,7 @@ def fprem(_, instr):
 def fprem1(_, instr):
     e = []
     e.append(
-        m2_expr.ExprAff(float_st0, m2_expr.ExprOp('fprem1', float_st0, float_st1)))
+        m2_expr.ExprAssign(float_st0, m2_expr.ExprOp('fprem1', float_st0, float_st1)))
     e += set_float_cs_eip(instr)
     return e, []
 
@@ -2587,7 +2587,7 @@ def faddp(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(float_prev(dst), m2_expr.ExprOp('fadd', dst, src)))
+    e.append(m2_expr.ExprAssign(float_prev(dst), m2_expr.ExprOp('fadd', dst, src)))
     e += set_float_cs_eip(instr)
     e += float_pop(dst)
     return e, []
@@ -2603,7 +2603,7 @@ def fyl2x(_, instr):
     e = []
     a = float_st1
     e.append(
-        m2_expr.ExprAff(float_prev(a), m2_expr.ExprOp('fyl2x', float_st0, float_st1)))
+        m2_expr.ExprAssign(float_prev(a), m2_expr.ExprOp('fyl2x', float_st0, float_st1)))
     e += set_float_cs_eip(instr)
     e += float_pop(a)
     return e, []
@@ -2622,22 +2622,22 @@ def fnstenv(ir, instr, dst):
     # This will truncate addresses
     size = min(32, s)
     ad = ir.ExprMem(dst.arg, size=16)
-    e.append(m2_expr.ExprAff(ad, float_control))
+    e.append(m2_expr.ExprAssign(ad, float_control))
     ad = ir.ExprMem(dst.arg + m2_expr.ExprInt(size /
                                               8 * 1, dst.arg.size), size=16)
-    e.append(m2_expr.ExprAff(ad, status_word))
+    e.append(m2_expr.ExprAssign(ad, status_word))
     ad = ir.ExprMem(dst.arg + m2_expr.ExprInt(size /
                                               8 * 3, dst.arg.size), size=size)
-    e.append(m2_expr.ExprAff(ad, float_eip[:size]))
+    e.append(m2_expr.ExprAssign(ad, float_eip[:size]))
     ad = ir.ExprMem(dst.arg + m2_expr.ExprInt(size /
                                               8 * 4, dst.arg.size), size=16)
-    e.append(m2_expr.ExprAff(ad, float_cs))
+    e.append(m2_expr.ExprAssign(ad, float_cs))
     ad = ir.ExprMem(dst.arg + m2_expr.ExprInt(size /
                                               8 * 5, dst.arg.size), size=size)
-    e.append(m2_expr.ExprAff(ad, float_address[:size]))
+    e.append(m2_expr.ExprAssign(ad, float_address[:size]))
     ad = ir.ExprMem(dst.arg + m2_expr.ExprInt(size /
                                               8 * 6, dst.arg.size), size=16)
-    e.append(m2_expr.ExprAff(ad, float_ds))
+    e.append(m2_expr.ExprAssign(ad, float_ds))
     return e, []
 
 
@@ -2652,12 +2652,12 @@ def fldenv(ir, instr, src):
 
     # Float control
     ad = ir.ExprMem(src.arg, size=16)
-    e.append(m2_expr.ExprAff(float_control, ad))
+    e.append(m2_expr.ExprAssign(float_control, ad))
 
     # Status word
     ad = ir.ExprMem(src.arg + m2_expr.ExprInt(size / 8 * 1, size=src.arg.size),
                     size=16)
-    e += [m2_expr.ExprAff(x, y) for x, y in ((float_c0, ad[8:9]),
+    e += [m2_expr.ExprAssign(x, y) for x, y in ((float_c0, ad[8:9]),
                                              (float_c1, ad[9:10]),
                                              (float_c2, ad[10:11]),
                                              (float_stack_ptr, ad[11:14]),
@@ -2672,7 +2672,7 @@ def fldenv(ir, instr, src):
         ad = ir.ExprMem(src.arg + m2_expr.ExprInt(size / 8 * offset,
                                                   size=src.arg.size),
                         size=target.size)
-        e.append(m2_expr.ExprAff(target, ad))
+        e.append(m2_expr.ExprAssign(target, ad))
 
     return e, []
 
@@ -2681,7 +2681,7 @@ def fsub(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('fsub', dst, src)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('fsub', dst, src)))
     e += set_float_cs_eip(instr)
     return e, []
 
@@ -2690,7 +2690,7 @@ def fsubp(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(float_prev(dst), m2_expr.ExprOp('fsub', dst, src)))
+    e.append(m2_expr.ExprAssign(float_prev(dst), m2_expr.ExprOp('fsub', dst, src)))
     e += set_float_cs_eip(instr)
     e += float_pop(dst)
     return e, []
@@ -2700,7 +2700,7 @@ def fsubr(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('fsub', src, dst)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('fsub', src, dst)))
     e += set_float_cs_eip(instr)
     return e, []
 
@@ -2709,7 +2709,7 @@ def fsubrp(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(float_prev(dst), m2_expr.ExprOp('fsub', src, dst)))
+    e.append(m2_expr.ExprAssign(float_prev(dst), m2_expr.ExprOp('fsub', src, dst)))
     e += set_float_cs_eip(instr)
     e += float_pop(dst)
     return e, []
@@ -2719,7 +2719,7 @@ def fmul(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('fmul', dst, src)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('fmul', dst, src)))
     e += set_float_cs_eip(instr)
     return e, []
 
@@ -2728,7 +2728,7 @@ def fimul(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('fimul', dst, src)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('fimul', dst, src)))
     e += set_float_cs_eip(instr)
     return e, []
 
@@ -2737,7 +2737,7 @@ def fdiv(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('fdiv', dst, src)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('fdiv', dst, src)))
     e += set_float_cs_eip(instr)
     return e, []
 
@@ -2746,7 +2746,7 @@ def fdivr(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('fdiv', src, dst)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('fdiv', src, dst)))
     e += set_float_cs_eip(instr)
     return e, []
 
@@ -2755,7 +2755,7 @@ def fdivrp(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(float_prev(dst), m2_expr.ExprOp('fdiv', src, dst)))
+    e.append(m2_expr.ExprAssign(float_prev(dst), m2_expr.ExprOp('fdiv', src, dst)))
     e += set_float_cs_eip(instr)
     e += float_pop(dst)
     return e, []
@@ -2765,7 +2765,7 @@ def fidiv(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('fidiv', dst, src)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('fidiv', dst, src)))
     e += set_float_cs_eip(instr)
     return e, []
 
@@ -2774,7 +2774,7 @@ def fidivr(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('fidiv', src, dst)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('fidiv', src, dst)))
     e += set_float_cs_eip(instr)
     return e, []
 
@@ -2784,7 +2784,7 @@ def fdivp(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(float_prev(dst), m2_expr.ExprOp('fdiv', dst, src)))
+    e.append(m2_expr.ExprAssign(float_prev(dst), m2_expr.ExprOp('fdiv', dst, src)))
     e += set_float_cs_eip(instr)
     e += float_pop(dst)
     return e, []
@@ -2795,7 +2795,7 @@ def fmulp(_, instr, dst, src=None):
     dst, src = float_implicit_st0(dst, src)
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(float_prev(dst), m2_expr.ExprOp('fmul', dst, src)))
+    e.append(m2_expr.ExprAssign(float_prev(dst), m2_expr.ExprOp('fmul', dst, src)))
     e += set_float_cs_eip(instr)
     e += float_pop(dst)
     return e, []
@@ -2804,7 +2804,7 @@ def fmulp(_, instr, dst, src=None):
 def ftan(_, instr, src):
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(float_st0, m2_expr.ExprOp('ftan', src)))
+    e.append(m2_expr.ExprAssign(float_st0, m2_expr.ExprOp('ftan', src)))
     e += set_float_cs_eip(instr)
     return e, []
 
@@ -2812,23 +2812,23 @@ def ftan(_, instr, src):
 def fxch(_, instr, src):
     e = []
     src = mem2double(instr, src)
-    e.append(m2_expr.ExprAff(float_st0, src))
-    e.append(m2_expr.ExprAff(src, float_st0))
+    e.append(m2_expr.ExprAssign(float_st0, src))
+    e.append(m2_expr.ExprAssign(src, float_st0))
     e += set_float_cs_eip(instr)
     return e, []
 
 
 def fptan(_, instr):
     e = []
-    e.append(m2_expr.ExprAff(float_st7, float_st6))
-    e.append(m2_expr.ExprAff(float_st6, float_st5))
-    e.append(m2_expr.ExprAff(float_st5, float_st4))
-    e.append(m2_expr.ExprAff(float_st4, float_st3))
-    e.append(m2_expr.ExprAff(float_st3, float_st2))
-    e.append(m2_expr.ExprAff(float_st2, float_st1))
-    e.append(m2_expr.ExprAff(float_st1, m2_expr.ExprOp('ftan', float_st0)))
+    e.append(m2_expr.ExprAssign(float_st7, float_st6))
+    e.append(m2_expr.ExprAssign(float_st6, float_st5))
+    e.append(m2_expr.ExprAssign(float_st5, float_st4))
+    e.append(m2_expr.ExprAssign(float_st4, float_st3))
+    e.append(m2_expr.ExprAssign(float_st3, float_st2))
+    e.append(m2_expr.ExprAssign(float_st2, float_st1))
+    e.append(m2_expr.ExprAssign(float_st1, m2_expr.ExprOp('ftan', float_st0)))
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             float_st0,
             m2_expr.ExprOp(
                 'sint_to_fp',
@@ -2837,51 +2837,51 @@ def fptan(_, instr):
         )
     )
     e.append(
-        m2_expr.ExprAff(float_stack_ptr,
+        m2_expr.ExprAssign(float_stack_ptr,
                         float_stack_ptr + m2_expr.ExprInt(1, 3)))
     return e, []
 
 
 def frndint(_, instr):
     e = []
-    e.append(m2_expr.ExprAff(float_st0, m2_expr.ExprOp('frndint', float_st0)))
+    e.append(m2_expr.ExprAssign(float_st0, m2_expr.ExprOp('frndint', float_st0)))
     e += set_float_cs_eip(instr)
     return e, []
 
 
 def fsin(_, instr):
     e = []
-    e.append(m2_expr.ExprAff(float_st0, m2_expr.ExprOp('fsin', float_st0)))
+    e.append(m2_expr.ExprAssign(float_st0, m2_expr.ExprOp('fsin', float_st0)))
     e += set_float_cs_eip(instr)
     return e, []
 
 
 def fcos(_, instr):
     e = []
-    e.append(m2_expr.ExprAff(float_st0, m2_expr.ExprOp('fcos', float_st0)))
+    e.append(m2_expr.ExprAssign(float_st0, m2_expr.ExprOp('fcos', float_st0)))
     e += set_float_cs_eip(instr)
     return e, []
 
 
 def fsincos(_, instr):
     e = []
-    e.append(m2_expr.ExprAff(float_st7, float_st6))
-    e.append(m2_expr.ExprAff(float_st6, float_st5))
-    e.append(m2_expr.ExprAff(float_st5, float_st4))
-    e.append(m2_expr.ExprAff(float_st4, float_st3))
-    e.append(m2_expr.ExprAff(float_st3, float_st2))
-    e.append(m2_expr.ExprAff(float_st2, float_st1))
-    e.append(m2_expr.ExprAff(float_st1, m2_expr.ExprOp('fsin', float_st0)))
-    e.append(m2_expr.ExprAff(float_st0, m2_expr.ExprOp('fcos', float_st0)))
+    e.append(m2_expr.ExprAssign(float_st7, float_st6))
+    e.append(m2_expr.ExprAssign(float_st6, float_st5))
+    e.append(m2_expr.ExprAssign(float_st5, float_st4))
+    e.append(m2_expr.ExprAssign(float_st4, float_st3))
+    e.append(m2_expr.ExprAssign(float_st3, float_st2))
+    e.append(m2_expr.ExprAssign(float_st2, float_st1))
+    e.append(m2_expr.ExprAssign(float_st1, m2_expr.ExprOp('fsin', float_st0)))
+    e.append(m2_expr.ExprAssign(float_st0, m2_expr.ExprOp('fcos', float_st0)))
     e.append(
-        m2_expr.ExprAff(float_stack_ptr,
+        m2_expr.ExprAssign(float_stack_ptr,
                         float_stack_ptr + m2_expr.ExprInt(1, 3)))
     return e, []
 
 
 def fscale(_, instr):
     e = []
-    e.append(m2_expr.ExprAff(float_st0, m2_expr.ExprOp('fscale', float_st0,
+    e.append(m2_expr.ExprAssign(float_st0, m2_expr.ExprOp('fscale', float_st0,
                                                        float_st1)))
     e += set_float_cs_eip(instr)
     return e, []
@@ -2889,28 +2889,28 @@ def fscale(_, instr):
 
 def f2xm1(_, instr):
     e = []
-    e.append(m2_expr.ExprAff(float_st0, m2_expr.ExprOp('f2xm1', float_st0)))
+    e.append(m2_expr.ExprAssign(float_st0, m2_expr.ExprOp('f2xm1', float_st0)))
     e += set_float_cs_eip(instr)
     return e, []
 
 
 def fchs(_, instr):
     e = []
-    e.append(m2_expr.ExprAff(float_st0, m2_expr.ExprOp('fchs', float_st0)))
+    e.append(m2_expr.ExprAssign(float_st0, m2_expr.ExprOp('fchs', float_st0)))
     e += set_float_cs_eip(instr)
     return e, []
 
 
 def fsqrt(_, instr):
     e = []
-    e.append(m2_expr.ExprAff(float_st0, m2_expr.ExprOp('fsqrt', float_st0)))
+    e.append(m2_expr.ExprAssign(float_st0, m2_expr.ExprOp('fsqrt', float_st0)))
     e += set_float_cs_eip(instr)
     return e, []
 
 
 def fabs(_, instr):
     e = []
-    e.append(m2_expr.ExprAff(float_st0, m2_expr.ExprOp('fabs', float_st0)))
+    e.append(m2_expr.ExprAssign(float_st0, m2_expr.ExprOp('fabs', float_st0)))
     e += set_float_cs_eip(instr)
     return e, []
 
@@ -2926,19 +2926,19 @@ def fnstsw(_, instr, dst):
         float_c3,
         # B: FPU is not busy -> 0
         m2_expr.ExprInt(0, 1)]
-    e = [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*args))]
+    e = [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*args))]
     return e, []
 
 
 def fnstcw(_, instr, dst):
     e = []
-    e.append(m2_expr.ExprAff(dst, float_control))
+    e.append(m2_expr.ExprAssign(dst, float_control))
     return e, []
 
 
 def fldcw(_, instr, src):
     e = []
-    e.append(m2_expr.ExprAff(float_control, src))
+    e.append(m2_expr.ExprAssign(float_control, src))
     return e, []
 
 
@@ -3030,7 +3030,7 @@ def sfence(_, instr, src=None):
 
 
 def ud2(_, instr, src=None):
-    e = [m2_expr.ExprAff(exception_flags, m2_expr.ExprInt(
+    e = [m2_expr.ExprAssign(exception_flags, m2_expr.ExprInt(
         EXCEPT_ILLEGAL_INSN, exception_flags.size))]
     return e, []
 
@@ -3038,18 +3038,18 @@ def ud2(_, instr, src=None):
 def hlt(_, instr):
     e = []
     except_int = EXCEPT_PRIV_INSN
-    e.append(m2_expr.ExprAff(exception_flags, m2_expr.ExprInt(except_int, 32)))
+    e.append(m2_expr.ExprAssign(exception_flags, m2_expr.ExprInt(except_int, 32)))
     return e, []
 
 
 def rdtsc(_, instr):
     e = []
-    e.append(m2_expr.ExprAff(tsc1, tsc1 + m2_expr.ExprInt(1, 32)))
-    e.append(m2_expr.ExprAff(tsc2, tsc2 + m2_expr.ExprCond(tsc1 - tsc1.mask,
+    e.append(m2_expr.ExprAssign(tsc1, tsc1 + m2_expr.ExprInt(1, 32)))
+    e.append(m2_expr.ExprAssign(tsc2, tsc2 + m2_expr.ExprCond(tsc1 - tsc1.mask,
                                                            m2_expr.ExprInt(0, 32),
                                                            m2_expr.ExprInt(1, 32))))
-    e.append(m2_expr.ExprAff(mRAX[32], tsc1))
-    e.append(m2_expr.ExprAff(mRDX[32], tsc2))
+    e.append(m2_expr.ExprAssign(mRAX[32], tsc1))
+    e.append(m2_expr.ExprAssign(mRDX[32], tsc2))
     return e, []
 
 
@@ -3058,7 +3058,7 @@ def daa(_, instr):
     r_al = mRAX[instr.mode][:8]
 
     cond1 = m2_expr.expr_is_unsigned_greater(r_al[:4], m2_expr.ExprInt(0x9, 4)) | af
-    e.append(m2_expr.ExprAff(af, cond1))
+    e.append(m2_expr.ExprAssign(af, cond1))
 
     cond2 = m2_expr.expr_is_unsigned_greater(m2_expr.ExprInt(6, 8), r_al)
     cond3 = m2_expr.expr_is_unsigned_greater(r_al, m2_expr.ExprInt(0x99, 8)) | cf
@@ -3069,7 +3069,7 @@ def daa(_, instr):
     new_cf = m2_expr.ExprCond(cond3,
                               m2_expr.ExprInt(1, 1),
                               m2_expr.ExprInt(0, 1))
-    e.append(m2_expr.ExprAff(cf, new_cf))
+    e.append(m2_expr.ExprAssign(cf, new_cf))
 
     al_c1 = m2_expr.ExprCond(cond1,
                              r_al + m2_expr.ExprInt(6, 8),
@@ -3078,7 +3078,7 @@ def daa(_, instr):
     new_al = m2_expr.ExprCond(cond3,
                               al_c1 + m2_expr.ExprInt(0x60, 8),
                               al_c1)
-    e.append(m2_expr.ExprAff(r_al, new_al))
+    e.append(m2_expr.ExprAssign(r_al, new_al))
     e += update_flag_znp(new_al)
     return e, []
 
@@ -3088,7 +3088,7 @@ def das(_, instr):
     r_al = mRAX[instr.mode][:8]
 
     cond1 = m2_expr.expr_is_unsigned_greater(r_al[:4], m2_expr.ExprInt(0x9, 4)) | af
-    e.append(m2_expr.ExprAff(af, cond1))
+    e.append(m2_expr.ExprAssign(af, cond1))
 
     cond2 = m2_expr.expr_is_unsigned_greater(m2_expr.ExprInt(6, 8), r_al)
     cond3 = m2_expr.expr_is_unsigned_greater(r_al, m2_expr.ExprInt(0x99, 8)) | cf
@@ -3099,7 +3099,7 @@ def das(_, instr):
     new_cf = m2_expr.ExprCond(cond3,
                               m2_expr.ExprInt(1, 1),
                               cf_c1)
-    e.append(m2_expr.ExprAff(cf, new_cf))
+    e.append(m2_expr.ExprAssign(cf, new_cf))
 
     al_c1 = m2_expr.ExprCond(cond1,
                              r_al - m2_expr.ExprInt(6, 8),
@@ -3108,7 +3108,7 @@ def das(_, instr):
     new_al = m2_expr.ExprCond(cond3,
                               al_c1 - m2_expr.ExprInt(0x60, 8),
                               al_c1)
-    e.append(m2_expr.ExprAff(r_al, new_al))
+    e.append(m2_expr.ExprAssign(r_al, new_al))
     e += update_flag_znp(new_al)
     return e, []
 
@@ -3125,12 +3125,12 @@ def aam(ir, instr, src):
             m2_expr.ExprOp("udiv", tempAL, src),
             mRAX[instr.mode][16:]
         )
-        e += [m2_expr.ExprAff(mRAX[instr.mode], newEAX)]
+        e += [m2_expr.ExprAssign(mRAX[instr.mode], newEAX)]
         e += update_flag_arith(newEAX)
-        e.append(m2_expr.ExprAff(af, m2_expr.ExprInt(0, 1)))
+        e.append(m2_expr.ExprAssign(af, m2_expr.ExprInt(0, 1)))
     else:
         e.append(
-            m2_expr.ExprAff(
+            m2_expr.ExprAssign(
                 exception_flags,
                 m2_expr.ExprInt(EXCEPT_DIV_BY_ZERO, exception_flags.size)
             )
@@ -3145,9 +3145,9 @@ def aad(_, instr, src):
     newEAX = m2_expr.ExprCompose((tempAL + (tempAH * src)) & m2_expr.ExprInt(0xFF, 8),
                                  m2_expr.ExprInt(0, 8),
                                  mRAX[instr.mode][16:])
-    e += [m2_expr.ExprAff(mRAX[instr.mode], newEAX)]
+    e += [m2_expr.ExprAssign(mRAX[instr.mode], newEAX)]
     e += update_flag_arith(newEAX)
-    e.append(m2_expr.ExprAff(af, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(af, m2_expr.ExprInt(0, 1)))
     return e, []
 
 
@@ -3175,9 +3175,9 @@ def _tpl_aaa(_, instr, op):
     new_ax = first_part & m2_expr.ExprInt(0xff0f,
                                           size=r_ax.size)
     # set AL
-    e.append(m2_expr.ExprAff(r_ax, m2_expr.ExprCond(cond, new_ax, r_ax)))
-    e.append(m2_expr.ExprAff(af, cond))
-    e.append(m2_expr.ExprAff(cf, cond))
+    e.append(m2_expr.ExprAssign(r_ax, m2_expr.ExprCond(cond, new_ax, r_ax)))
+    e.append(m2_expr.ExprAssign(af, cond))
+    e.append(m2_expr.ExprAssign(cf, cond))
     return e, []
 
 
@@ -3203,18 +3203,18 @@ def bsr_bsf(ir, instr, dst, src, op_func):
     loc_next = ir.get_next_loc_key(instr)
     loc_next_expr = m2_expr.ExprLoc(loc_next, ir.IRDst.size)
 
-    aff_dst = m2_expr.ExprAff(ir.IRDst, loc_next_expr)
-    e = [m2_expr.ExprAff(ir.IRDst, m2_expr.ExprCond(src,
+    aff_dst = m2_expr.ExprAssign(ir.IRDst, loc_next_expr)
+    e = [m2_expr.ExprAssign(ir.IRDst, m2_expr.ExprCond(src,
                                                     loc_src_not_null_expr,
                                                     loc_src_null_expr))]
     e_src_null = []
-    e_src_null.append(m2_expr.ExprAff(zf, m2_expr.ExprInt(1, zf.size)))
+    e_src_null.append(m2_expr.ExprAssign(zf, m2_expr.ExprInt(1, zf.size)))
     # XXX destination is undefined
     e_src_null.append(aff_dst)
 
     e_src_not_null = []
-    e_src_not_null.append(m2_expr.ExprAff(zf, m2_expr.ExprInt(0, zf.size)))
-    e_src_not_null.append(m2_expr.ExprAff(dst, op_func(src)))
+    e_src_not_null.append(m2_expr.ExprAssign(zf, m2_expr.ExprInt(0, zf.size)))
+    e_src_not_null.append(m2_expr.ExprAssign(dst, op_func(src)))
     e_src_not_null.append(aff_dst)
 
     return e, [IRBlock(loc_src_null, [AssignBlock(e_src_null, instr)]),
@@ -3235,13 +3235,13 @@ def bsr(ir, instr, dst, src):
 
 def arpl(_, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(exception_flags, m2_expr.ExprInt(1 << 7, 32)))
+    e.append(m2_expr.ExprAssign(exception_flags, m2_expr.ExprInt(1 << 7, 32)))
     return e, []
 
 
 def ins(_, instr, size):
     e = []
-    e.append(m2_expr.ExprAff(exception_flags, m2_expr.ExprInt(1 << 7, 32)))
+    e.append(m2_expr.ExprAssign(exception_flags, m2_expr.ExprInt(1 << 7, 32)))
     return e, []
 
 
@@ -3251,17 +3251,17 @@ def sidt(ir, instr, dst):
         raise ValueError('not exprmem 32bit instance!!')
     ptr = dst.arg
     LOG_X86_SEM.warning("DEFAULT SIDT ADDRESS %s!!", str(dst))
-    e.append(m2_expr.ExprAff(ir.ExprMem(ptr, 32),
+    e.append(m2_expr.ExprAssign(ir.ExprMem(ptr, 32),
                              m2_expr.ExprInt(0xe40007ff, 32)))
     e.append(
-        m2_expr.ExprAff(ir.ExprMem(ptr + m2_expr.ExprInt(4, ptr.size), 16),
+        m2_expr.ExprAssign(ir.ExprMem(ptr + m2_expr.ExprInt(4, ptr.size), 16),
                         m2_expr.ExprInt(0x8245, 16)))
     return e, []
 
 
 def sldt(_, instr, dst):
     LOG_X86_SEM.warning("DEFAULT SLDT ADDRESS %s!!", str(dst))
-    e = [m2_expr.ExprAff(dst, m2_expr.ExprInt(0, dst.size))]
+    e = [m2_expr.ExprAssign(dst, m2_expr.ExprInt(0, dst.size))]
     return e, []
 
 
@@ -3343,7 +3343,7 @@ def cmovns(ir, instr, dst, src):
 
 def icebp(_, instr):
     e = []
-    e.append(m2_expr.ExprAff(exception_flags,
+    e.append(m2_expr.ExprAssign(exception_flags,
                              m2_expr.ExprInt(EXCEPT_SOFT_BP, 32)))
     return e, []
 # XXX
@@ -3356,22 +3356,22 @@ def l_int(_, instr, src):
         except_int = EXCEPT_SOFT_BP
     else:
         except_int = EXCEPT_INT_XX
-    e.append(m2_expr.ExprAff(exception_flags,
+    e.append(m2_expr.ExprAssign(exception_flags,
                              m2_expr.ExprInt(except_int, 32)))
-    e.append(m2_expr.ExprAff(interrupt_num, src))
+    e.append(m2_expr.ExprAssign(interrupt_num, src))
     return e, []
 
 
 def l_sysenter(_, instr):
     e = []
-    e.append(m2_expr.ExprAff(exception_flags,
+    e.append(m2_expr.ExprAssign(exception_flags,
                              m2_expr.ExprInt(EXCEPT_PRIV_INSN, 32)))
     return e, []
 
 
 def l_syscall(_, instr):
     e = []
-    e.append(m2_expr.ExprAff(exception_flags,
+    e.append(m2_expr.ExprAssign(exception_flags,
                              m2_expr.ExprInt(EXCEPT_PRIV_INSN, 32)))
     return e, []
 
@@ -3380,7 +3380,7 @@ def l_syscall(_, instr):
 
 def l_out(_, instr, src1, src2):
     e = []
-    e.append(m2_expr.ExprAff(exception_flags,
+    e.append(m2_expr.ExprAssign(exception_flags,
                              m2_expr.ExprInt(EXCEPT_PRIV_INSN, 32)))
     return e, []
 
@@ -3389,7 +3389,7 @@ def l_out(_, instr, src1, src2):
 
 def l_outs(_, instr, size):
     e = []
-    e.append(m2_expr.ExprAff(exception_flags,
+    e.append(m2_expr.ExprAssign(exception_flags,
                              m2_expr.ExprInt(EXCEPT_PRIV_INSN, 32)))
     return e, []
 
@@ -3400,23 +3400,23 @@ def xlat(ir, instr):
     e = []
     ptr = mRAX[instr.mode][0:8].zeroExtend(mRBX[instr.mode].size)
     src = ir.ExprMem(mRBX[instr.mode] + ptr, 8)
-    e.append(m2_expr.ExprAff(mRAX[instr.mode][0:8], src))
+    e.append(m2_expr.ExprAssign(mRAX[instr.mode][0:8], src))
     return e, []
 
 
 def cpuid(_, instr):
     e = []
     e.append(
-        m2_expr.ExprAff(mRAX[instr.mode],
+        m2_expr.ExprAssign(mRAX[instr.mode],
                         m2_expr.ExprOp('x86_cpuid', mRAX[instr.mode], m2_expr.ExprInt(0, instr.mode))))
     e.append(
-        m2_expr.ExprAff(mRBX[instr.mode],
+        m2_expr.ExprAssign(mRBX[instr.mode],
                         m2_expr.ExprOp('x86_cpuid', mRAX[instr.mode], m2_expr.ExprInt(1, instr.mode))))
     e.append(
-        m2_expr.ExprAff(mRCX[instr.mode],
+        m2_expr.ExprAssign(mRCX[instr.mode],
                         m2_expr.ExprOp('x86_cpuid', mRAX[instr.mode], m2_expr.ExprInt(2, instr.mode))))
     e.append(
-        m2_expr.ExprAff(mRDX[instr.mode],
+        m2_expr.ExprAssign(mRDX[instr.mode],
                         m2_expr.ExprOp('x86_cpuid', mRAX[instr.mode], m2_expr.ExprInt(3, instr.mode))))
     return e, []
 
@@ -3454,17 +3454,17 @@ def bt(ir, instr, src, index):
     index = index.zeroExtend(src.size)
     d, off_bit = bittest_get(ir, instr, src, index)
     d = d >> off_bit
-    e.append(m2_expr.ExprAff(cf, d[:1]))
+    e.append(m2_expr.ExprAssign(cf, d[:1]))
     return e, []
 
 
 def btc(ir, instr, src, index):
     e = []
     d, off_bit = bittest_get(ir, instr, src, index)
-    e.append(m2_expr.ExprAff(cf, (d >> off_bit)[:1]))
+    e.append(m2_expr.ExprAssign(cf, (d >> off_bit)[:1]))
 
     m = m2_expr.ExprInt(1, src.size) << off_bit
-    e.append(m2_expr.ExprAff(d, d ^ m))
+    e.append(m2_expr.ExprAssign(d, d ^ m))
 
     return e, []
 
@@ -3472,9 +3472,9 @@ def btc(ir, instr, src, index):
 def bts(ir, instr, src, index):
     e = []
     d, off_bit = bittest_get(ir, instr, src, index)
-    e.append(m2_expr.ExprAff(cf, (d >> off_bit)[:1]))
+    e.append(m2_expr.ExprAssign(cf, (d >> off_bit)[:1]))
     m = m2_expr.ExprInt(1, src.size) << off_bit
-    e.append(m2_expr.ExprAff(d, d | m))
+    e.append(m2_expr.ExprAssign(d, d | m))
 
     return e, []
 
@@ -3482,9 +3482,9 @@ def bts(ir, instr, src, index):
 def btr(ir, instr, src, index):
     e = []
     d, off_bit = bittest_get(ir, instr, src, index)
-    e.append(m2_expr.ExprAff(cf, (d >> off_bit)[:1]))
+    e.append(m2_expr.ExprAssign(cf, (d >> off_bit)[:1]))
     m = ~(m2_expr.ExprInt(1, src.size) << off_bit)
-    e.append(m2_expr.ExprAff(d, d & m))
+    e.append(m2_expr.ExprAssign(d, d & m))
 
     return e, []
 
@@ -3495,7 +3495,7 @@ def into(_, instr):
 
 def l_in(_, instr, src1, src2):
     e = []
-    e.append(m2_expr.ExprAff(exception_flags,
+    e.append(m2_expr.ExprAssign(exception_flags,
                              m2_expr.ExprInt(EXCEPT_PRIV_INSN, 32)))
     return e, []
 
@@ -3537,46 +3537,46 @@ def cmpxchg16b(arg1):
 
 def lds(ir, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst, ir.ExprMem(src.arg, size=dst.size)))
+    e.append(m2_expr.ExprAssign(dst, ir.ExprMem(src.arg, size=dst.size)))
     DS_value = ir.ExprMem(src.arg + m2_expr.ExprInt(dst.size / 8, src.arg.size),
                           size=16)
-    e.append(m2_expr.ExprAff(DS, DS_value))
+    e.append(m2_expr.ExprAssign(DS, DS_value))
     return e, []
 
 
 def les(ir, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst, ir.ExprMem(src.arg, size=dst.size)))
+    e.append(m2_expr.ExprAssign(dst, ir.ExprMem(src.arg, size=dst.size)))
     ES_value = ir.ExprMem(src.arg + m2_expr.ExprInt(dst.size / 8, src.arg.size),
                           size=16)
-    e.append(m2_expr.ExprAff(ES, ES_value))
+    e.append(m2_expr.ExprAssign(ES, ES_value))
     return e, []
 
 
 def lss(ir, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst, ir.ExprMem(src.arg, size=dst.size)))
+    e.append(m2_expr.ExprAssign(dst, ir.ExprMem(src.arg, size=dst.size)))
     SS_value = ir.ExprMem(src.arg + m2_expr.ExprInt(dst.size / 8, src.arg.size),
                           size=16)
-    e.append(m2_expr.ExprAff(SS, SS_value))
+    e.append(m2_expr.ExprAssign(SS, SS_value))
     return e, []
 
 
 def lfs(ir, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst, ir.ExprMem(src.arg, size=dst.size)))
+    e.append(m2_expr.ExprAssign(dst, ir.ExprMem(src.arg, size=dst.size)))
     FS_value = ir.ExprMem(src.arg + m2_expr.ExprInt(dst.size / 8, src.arg.size),
                           size=16)
-    e.append(m2_expr.ExprAff(FS, FS_value))
+    e.append(m2_expr.ExprAssign(FS, FS_value))
     return e, []
 
 
 def lgs(ir, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst, ir.ExprMem(src.arg, size=dst.size)))
+    e.append(m2_expr.ExprAssign(dst, ir.ExprMem(src.arg, size=dst.size)))
     GS_value = ir.ExprMem(src.arg + m2_expr.ExprInt(dst.size / 8, src.arg.size),
                           size=16)
-    e.append(m2_expr.ExprAff(GS, GS_value))
+    e.append(m2_expr.ExprAssign(GS, GS_value))
     return e, []
 
 
@@ -3585,32 +3585,32 @@ def lahf(_, instr):
     args = [cf, m2_expr.ExprInt(1, 1), pf, m2_expr.ExprInt(0, 1), af,
             m2_expr.ExprInt(0, 1), zf, nf]
     e.append(
-        m2_expr.ExprAff(mRAX[instr.mode][8:16], m2_expr.ExprCompose(*args)))
+        m2_expr.ExprAssign(mRAX[instr.mode][8:16], m2_expr.ExprCompose(*args)))
     return e, []
 
 
 def sahf(_, instr):
     tmp = mRAX[instr.mode][8:16]
     e = []
-    e.append(m2_expr.ExprAff(cf, tmp[0:1]))
-    e.append(m2_expr.ExprAff(pf, tmp[2:3]))
-    e.append(m2_expr.ExprAff(af, tmp[4:5]))
-    e.append(m2_expr.ExprAff(zf, tmp[6:7]))
-    e.append(m2_expr.ExprAff(nf, tmp[7:8]))
+    e.append(m2_expr.ExprAssign(cf, tmp[0:1]))
+    e.append(m2_expr.ExprAssign(pf, tmp[2:3]))
+    e.append(m2_expr.ExprAssign(af, tmp[4:5]))
+    e.append(m2_expr.ExprAssign(zf, tmp[6:7]))
+    e.append(m2_expr.ExprAssign(nf, tmp[7:8]))
     return e, []
 
 
 def lar(_, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('access_segment', src)))
-    e.append(m2_expr.ExprAff(zf, m2_expr.ExprOp('access_segment_ok', src)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('access_segment', src)))
+    e.append(m2_expr.ExprAssign(zf, m2_expr.ExprOp('access_segment_ok', src)))
     return e, []
 
 
 def lsl(_, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('load_segment_limit', src)))
-    e.append(m2_expr.ExprAff(zf, m2_expr.ExprOp('load_segment_limit_ok', src)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('load_segment_limit', src)))
+    e.append(m2_expr.ExprAssign(zf, m2_expr.ExprOp('load_segment_limit_ok', src)))
     return e, []
 
 
@@ -3626,7 +3626,7 @@ def fnclex(_, instr):
 
 def l_str(_, instr, dst):
     e = []
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('load_tr_segment_selector',
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('load_tr_segment_selector',
                                                  m2_expr.ExprInt(0, 32))))
     return e, []
 
@@ -3634,57 +3634,57 @@ def l_str(_, instr, dst):
 def movd(_, instr, dst, src):
     e = []
     if dst in regs_mm_expr:
-        e.append(m2_expr.ExprAff(
+        e.append(m2_expr.ExprAssign(
             dst, m2_expr.ExprCompose(src, m2_expr.ExprInt(0, 32))))
     elif dst in regs_xmm_expr:
-        e.append(m2_expr.ExprAff(
+        e.append(m2_expr.ExprAssign(
             dst, m2_expr.ExprCompose(src, m2_expr.ExprInt(0, 96))))
     else:
-        e.append(m2_expr.ExprAff(dst, src[:32]))
+        e.append(m2_expr.ExprAssign(dst, src[:32]))
     return e, []
 
 
 def movdqu(_, instr, dst, src):
     # XXX TODO alignement check
-    return [m2_expr.ExprAff(dst, src)], []
+    return [m2_expr.ExprAssign(dst, src)], []
 
 
 def movapd(_, instr, dst, src):
     # XXX TODO alignement check
-    return [m2_expr.ExprAff(dst, src)], []
+    return [m2_expr.ExprAssign(dst, src)], []
 
 
 def andps(_, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('&', dst, src)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('&', dst, src)))
     return e, []
 
 
 def andnps(_, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('&', dst ^ dst.mask, src)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('&', dst ^ dst.mask, src)))
     return e, []
 
 
 def orps(_, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('|', dst, src)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('|', dst, src)))
     return e, []
 
 
 def xorps(_, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprOp('^', dst, src)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprOp('^', dst, src)))
     return e, []
 
 
 def rdmsr(ir, instr):
-    e = [m2_expr.ExprAff(exception_flags,m2_expr.ExprInt(EXCEPT_PRIV_INSN, 32))]
+    e = [m2_expr.ExprAssign(exception_flags,m2_expr.ExprInt(EXCEPT_PRIV_INSN, 32))]
     return e, []
 
 
 def wrmsr(ir, instr):
-    e = [m2_expr.ExprAff(exception_flags,m2_expr.ExprInt(EXCEPT_PRIV_INSN, 32))]
+    e = [m2_expr.ExprAssign(exception_flags,m2_expr.ExprInt(EXCEPT_PRIV_INSN, 32))]
     return e, []
 
 # MMX/SSE/AVX operations
@@ -3703,7 +3703,7 @@ def vec_op_clip(op, size, callback=None):
             result = m2_expr.ExprOp(op, dst[:size], src[:size])
         if callback is not None:
             result = callback(result)
-        return [m2_expr.ExprAff(dst[:size], result)], []
+        return [m2_expr.ExprAssign(dst[:size], result)], []
     return vec_op_clip_instr
 
 # Generic vertical operation
@@ -3734,7 +3734,7 @@ def __vec_vertical_instr_gen(op, elt_size, sem, apply_on_output):
         if isinstance(src, m2_expr.ExprMem):
             src = ir.ExprMem(src.arg, dst.size)
         reg_size = dst.size
-        e.append(m2_expr.ExprAff(dst, sem(op, elt_size, reg_size, dst, src,
+        e.append(m2_expr.ExprAssign(dst, sem(op, elt_size, reg_size, dst, src,
                                           apply_on_output)))
         return e, []
     return vec_instr
@@ -3839,16 +3839,16 @@ pmulhq = vec_vertical_instr('*', 64, lambda x: _keep_mul_high(x, signed=True))
 def pmuludq(ir, instr, dst, src):
     e = []
     if dst.size == 64:
-        e.append(m2_expr.ExprAff(
+        e.append(m2_expr.ExprAssign(
             dst,
             src[:32].zeroExtend(64) * dst[:32].zeroExtend(64)
         ))
     elif dst.size == 128:
-        e.append(m2_expr.ExprAff(
+        e.append(m2_expr.ExprAssign(
             dst[:64],
             src[:32].zeroExtend(64) * dst[:32].zeroExtend(64)
         ))
-        e.append(m2_expr.ExprAff(
+        e.append(m2_expr.ExprAssign(
             dst[64:],
             src[64:96].zeroExtend(64) * dst[64:96].zeroExtend(64)
         ))
@@ -3870,7 +3870,7 @@ def pmaddwd(ir, instr, dst, src):
         base += sizesrc
         mul2 = src[base: base + sizesrc].signExtend(sizedst) * dst[base: base + sizesrc].signExtend(sizedst)
         out.append(mul1 + mul2)
-    return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out))], []
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out))], []
 
 
 def _absolute(expr):
@@ -3895,7 +3895,7 @@ def psadbw(ir, instr, dst, src):
         out_dst.append(m2_expr.ExprOp("+", *out))
         out_dst.append(m2_expr.ExprInt(0, 64 - sizedst))
 
-    return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out_dst))], []
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out_dst))], []
 
 def _average(expr):
     assert expr.is_op("avg") and len(expr.args) == 2
@@ -4031,7 +4031,7 @@ def pand(_, instr, dst, src):
     e = []
     result = dst & src
     # No flag affected
-    e.append(m2_expr.ExprAff(dst, result))
+    e.append(m2_expr.ExprAssign(dst, result))
     return e, []
 
 
@@ -4039,21 +4039,21 @@ def pandn(_, instr, dst, src):
     e = []
     result = (dst ^ dst.mask) & src
     # No flag affected
-    e.append(m2_expr.ExprAff(dst, result))
+    e.append(m2_expr.ExprAssign(dst, result))
     return e, []
 
 
 def por(_, instr, dst, src):
     e = []
     result = dst | src
-    e.append(m2_expr.ExprAff(dst, result))
+    e.append(m2_expr.ExprAssign(dst, result))
     return e, []
 
 
 def cvtdq2pd(_, instr, dst, src):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst[:64],
             m2_expr.ExprOp(
                 'sint_to_fp',
@@ -4062,7 +4062,7 @@ def cvtdq2pd(_, instr, dst, src):
         )
     )
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst[64:128],
             m2_expr.ExprOp(
                 'sint_to_fp',
@@ -4076,49 +4076,49 @@ def cvtdq2pd(_, instr, dst, src):
 def cvtdq2ps(_, instr, dst, src):
     e = []
     e.append(
-        m2_expr.ExprAff(dst[:32], m2_expr.ExprOp('sint_to_fp', src[:32])))
+        m2_expr.ExprAssign(dst[:32], m2_expr.ExprOp('sint_to_fp', src[:32])))
     e.append(
-        m2_expr.ExprAff(dst[32:64], m2_expr.ExprOp('sint_to_fp', src[32:64])))
+        m2_expr.ExprAssign(dst[32:64], m2_expr.ExprOp('sint_to_fp', src[32:64])))
     e.append(
-        m2_expr.ExprAff(dst[64:96], m2_expr.ExprOp('sint_to_fp', src[64:96])))
+        m2_expr.ExprAssign(dst[64:96], m2_expr.ExprOp('sint_to_fp', src[64:96])))
     e.append(
-        m2_expr.ExprAff(dst[96:128], m2_expr.ExprOp('sint_to_fp', src[96:128])))
+        m2_expr.ExprAssign(dst[96:128], m2_expr.ExprOp('sint_to_fp', src[96:128])))
     return e, []
 
 
 def cvtpd2dq(_, instr, dst, src):
     e = []
     e.append(
-        m2_expr.ExprAff(dst[:32], m2_expr.ExprOp('fp_to_sint32', src[:64])))
+        m2_expr.ExprAssign(dst[:32], m2_expr.ExprOp('fp_to_sint32', src[:64])))
     e.append(
-        m2_expr.ExprAff(dst[32:64], m2_expr.ExprOp('fp_to_sint32', src[64:128])))
-    e.append(m2_expr.ExprAff(dst[64:128], m2_expr.ExprInt(0, 64)))
+        m2_expr.ExprAssign(dst[32:64], m2_expr.ExprOp('fp_to_sint32', src[64:128])))
+    e.append(m2_expr.ExprAssign(dst[64:128], m2_expr.ExprInt(0, 64)))
     return e, []
 
 
 def cvtpd2pi(_, instr, dst, src):
     e = []
     e.append(
-        m2_expr.ExprAff(dst[:32], m2_expr.ExprOp('fp_to_sint32', src[:64])))
+        m2_expr.ExprAssign(dst[:32], m2_expr.ExprOp('fp_to_sint32', src[:64])))
     e.append(
-        m2_expr.ExprAff(dst[32:64], m2_expr.ExprOp('fp_to_sint32', src[64:128])))
+        m2_expr.ExprAssign(dst[32:64], m2_expr.ExprOp('fp_to_sint32', src[64:128])))
     return e, []
 
 
 def cvtpd2ps(_, instr, dst, src):
     e = []
     e.append(
-        m2_expr.ExprAff(dst[:32], m2_expr.ExprOp('fpconvert_fp32', src[:64])))
+        m2_expr.ExprAssign(dst[:32], m2_expr.ExprOp('fpconvert_fp32', src[:64])))
     e.append(
-        m2_expr.ExprAff(dst[32:64], m2_expr.ExprOp('fpconvert_fp32', src[64:128])))
-    e.append(m2_expr.ExprAff(dst[64:128], m2_expr.ExprInt(0, 64)))
+        m2_expr.ExprAssign(dst[32:64], m2_expr.ExprOp('fpconvert_fp32', src[64:128])))
+    e.append(m2_expr.ExprAssign(dst[64:128], m2_expr.ExprInt(0, 64)))
     return e, []
 
 
 def cvtpi2pd(_, instr, dst, src):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst[:64],
             m2_expr.ExprOp(
                 'sint_to_fp',
@@ -4127,7 +4127,7 @@ def cvtpi2pd(_, instr, dst, src):
         )
     )
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst[64:128],
             m2_expr.ExprOp(
                 'sint_to_fp',
@@ -4140,61 +4140,61 @@ def cvtpi2pd(_, instr, dst, src):
 def cvtpi2ps(_, instr, dst, src):
     e = []
     e.append(
-        m2_expr.ExprAff(dst[:32], m2_expr.ExprOp('sint_to_fp', src[:32])))
+        m2_expr.ExprAssign(dst[:32], m2_expr.ExprOp('sint_to_fp', src[:32])))
     e.append(
-        m2_expr.ExprAff(dst[32:64], m2_expr.ExprOp('sint_to_fp', src[32:64])))
+        m2_expr.ExprAssign(dst[32:64], m2_expr.ExprOp('sint_to_fp', src[32:64])))
     return e, []
 
 
 def cvtps2dq(_, instr, dst, src):
     e = []
     e.append(
-        m2_expr.ExprAff(dst[:32], m2_expr.ExprOp('fp_to_sint32', src[:32])))
+        m2_expr.ExprAssign(dst[:32], m2_expr.ExprOp('fp_to_sint32', src[:32])))
     e.append(
-        m2_expr.ExprAff(dst[32:64], m2_expr.ExprOp('fp_to_sint32', src[32:64])))
+        m2_expr.ExprAssign(dst[32:64], m2_expr.ExprOp('fp_to_sint32', src[32:64])))
     e.append(
-        m2_expr.ExprAff(dst[64:96], m2_expr.ExprOp('fp_to_sint32', src[64:96])))
+        m2_expr.ExprAssign(dst[64:96], m2_expr.ExprOp('fp_to_sint32', src[64:96])))
     e.append(
-        m2_expr.ExprAff(dst[96:128], m2_expr.ExprOp('fp_to_sint32', src[96:128])))
+        m2_expr.ExprAssign(dst[96:128], m2_expr.ExprOp('fp_to_sint32', src[96:128])))
     return e, []
 
 
 def cvtps2pd(_, instr, dst, src):
     e = []
     e.append(
-        m2_expr.ExprAff(dst[:64], m2_expr.ExprOp('fpconvert_fp64', src[:32])))
+        m2_expr.ExprAssign(dst[:64], m2_expr.ExprOp('fpconvert_fp64', src[:32])))
     e.append(
-        m2_expr.ExprAff(dst[64:128], m2_expr.ExprOp('fpconvert_fp64', src[32:64])))
+        m2_expr.ExprAssign(dst[64:128], m2_expr.ExprOp('fpconvert_fp64', src[32:64])))
     return e, []
 
 
 def cvtps2pi(_, instr, dst, src):
     e = []
     e.append(
-        m2_expr.ExprAff(dst[:32], m2_expr.ExprOp('fp_to_sint32', src[:32])))
+        m2_expr.ExprAssign(dst[:32], m2_expr.ExprOp('fp_to_sint32', src[:32])))
     e.append(
-        m2_expr.ExprAff(dst[32:64], m2_expr.ExprOp('fp_to_sint32', src[32:64])))
+        m2_expr.ExprAssign(dst[32:64], m2_expr.ExprOp('fp_to_sint32', src[32:64])))
     return e, []
 
 
 def cvtsd2si(_, instr, dst, src):
     e = []
     e.append(
-        m2_expr.ExprAff(dst[:32], m2_expr.ExprOp('fp_to_sint32', src[:64])))
+        m2_expr.ExprAssign(dst[:32], m2_expr.ExprOp('fp_to_sint32', src[:64])))
     return e, []
 
 
 def cvtsd2ss(_, instr, dst, src):
     e = []
     e.append(
-        m2_expr.ExprAff(dst[:32], m2_expr.ExprOp('fpconvert_fp32', src[:64])))
+        m2_expr.ExprAssign(dst[:32], m2_expr.ExprOp('fpconvert_fp32', src[:64])))
     return e, []
 
 
 def cvtsi2sd(_, instr, dst, src):
     e = []
     e.append(
-        m2_expr.ExprAff(
+        m2_expr.ExprAssign(
             dst[:64],
             m2_expr.ExprOp(
                 'sint_to_fp',
@@ -4208,21 +4208,21 @@ def cvtsi2sd(_, instr, dst, src):
 def cvtsi2ss(_, instr, dst, src):
     e = []
     e.append(
-        m2_expr.ExprAff(dst[:32], m2_expr.ExprOp('sint_to_fp', src[:32])))
+        m2_expr.ExprAssign(dst[:32], m2_expr.ExprOp('sint_to_fp', src[:32])))
     return e, []
 
 
 def cvtss2sd(_, instr, dst, src):
     e = []
     e.append(
-        m2_expr.ExprAff(dst[:64], m2_expr.ExprOp('fpconvert_fp64', src[:32])))
+        m2_expr.ExprAssign(dst[:64], m2_expr.ExprOp('fpconvert_fp64', src[:32])))
     return e, []
 
 
 def cvtss2si(_, instr, dst, src):
     e = []
     e.append(
-        m2_expr.ExprAff(dst[:32], m2_expr.ExprOp('fp_to_sint32', src[:32])))
+        m2_expr.ExprAssign(dst[:32], m2_expr.ExprOp('fp_to_sint32', src[:32])))
     return e, []
 
 
@@ -4236,7 +4236,7 @@ def _cvtt_tpl(dst, src, numbers, double):
         else:
             tmp_src = src[i*32:i*32 + 32]
 
-        e.append(m2_expr.ExprAff(
+        e.append(m2_expr.ExprAssign(
             dst[i*32:i*32 + 32],
             m2_expr.ExprOp('fp_to_sint32', m2_expr.ExprOp(
                 'fpround_towardszero',
@@ -4249,7 +4249,7 @@ def cvttpd2pi(_, instr, dst, src):
 
 def cvttpd2dq(_, instr, dst, src):
     e = _cvtt_tpl(dst, src, [0, 1], double=True)
-    e.append(m2_expr.ExprAff(dst[64:128], m2_expr.ExprInt(0, 64)))
+    e.append(m2_expr.ExprAssign(dst[64:128], m2_expr.ExprInt(0, 64)))
     return e, []
 
 def cvttsd2si(_, instr, dst, src):
@@ -4268,44 +4268,44 @@ def movss(_, instr, dst, src):
     e = []
     if not isinstance(dst, m2_expr.ExprMem) and not isinstance(src, m2_expr.ExprMem):
         # Source and Destination xmm
-        e.append(m2_expr.ExprAff(dst[:32], src[:32]))
+        e.append(m2_expr.ExprAssign(dst[:32], src[:32]))
     elif not isinstance(src, m2_expr.ExprMem) and isinstance(dst, m2_expr.ExprMem):
         # Source XMM Destination Mem
-        e.append(m2_expr.ExprAff(dst, src[:32]))
+        e.append(m2_expr.ExprAssign(dst, src[:32]))
     else:
         # Source Mem Destination XMM
-        e.append(m2_expr.ExprAff(
+        e.append(m2_expr.ExprAssign(
             dst, m2_expr.ExprCompose(src, m2_expr.ExprInt(0, 96))))
     return e, []
 
 
 def ucomiss(_, instr, src1, src2):
     e = []
-    e.append(m2_expr.ExprAff(zf, m2_expr.ExprOp(
+    e.append(m2_expr.ExprAssign(zf, m2_expr.ExprOp(
         'ucomiss_zf', src1[:32], src2[:32])))
-    e.append(m2_expr.ExprAff(pf, m2_expr.ExprOp(
+    e.append(m2_expr.ExprAssign(pf, m2_expr.ExprOp(
         'ucomiss_pf', src1[:32], src2[:32])))
-    e.append(m2_expr.ExprAff(cf, m2_expr.ExprOp(
+    e.append(m2_expr.ExprAssign(cf, m2_expr.ExprOp(
         'ucomiss_cf', src1[:32], src2[:32])))
 
-    e.append(m2_expr.ExprAff(of, m2_expr.ExprInt(0, 1)))
-    e.append(m2_expr.ExprAff(af, m2_expr.ExprInt(0, 1)))
-    e.append(m2_expr.ExprAff(nf, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(of, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(af, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(nf, m2_expr.ExprInt(0, 1)))
 
     return e, []
 
 def ucomisd(_, instr, src1, src2):
     e = []
-    e.append(m2_expr.ExprAff(zf, m2_expr.ExprOp(
+    e.append(m2_expr.ExprAssign(zf, m2_expr.ExprOp(
         'ucomisd_zf', src1[:64], src2[:64])))
-    e.append(m2_expr.ExprAff(pf, m2_expr.ExprOp(
+    e.append(m2_expr.ExprAssign(pf, m2_expr.ExprOp(
         'ucomisd_pf', src1[:64], src2[:64])))
-    e.append(m2_expr.ExprAff(cf, m2_expr.ExprOp(
+    e.append(m2_expr.ExprAssign(cf, m2_expr.ExprOp(
         'ucomisd_cf', src1[:64], src2[:64])))
 
-    e.append(m2_expr.ExprAff(of, m2_expr.ExprInt(0, 1)))
-    e.append(m2_expr.ExprAff(af, m2_expr.ExprInt(0, 1)))
-    e.append(m2_expr.ExprAff(nf, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(of, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(af, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(nf, m2_expr.ExprInt(0, 1)))
 
     return e, []
 
@@ -4322,7 +4322,7 @@ def pshufb(_, instr, dst, src):
         index = src[
             i:i + bit_l].zeroExtend(dst.size) << m2_expr.ExprInt(3, dst.size)
         value = (dst >> index)[:8]
-        e.append(m2_expr.ExprAff(dst[i:i + 8],
+        e.append(m2_expr.ExprAssign(dst[i:i + 8],
                                  m2_expr.ExprCond(src[i + 7:i + 8],
                                                   m2_expr.ExprInt(0, 8),
                                                   value)))
@@ -4337,7 +4337,7 @@ def pshufd(_, instr, dst, src, imm):
         # shift is 2 bits long, expr.size is 128
         # => shift + 32 <= src.size
         out.append(src[shift: shift + 32])
-    return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out))], []
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out))], []
 
 
 def pshuflw(_, instr, dst, src, imm):
@@ -4347,7 +4347,7 @@ def pshuflw(_, instr, dst, src, imm):
         shift = ((control >> (i * 2)) & 3) * 16
         out.append(src[shift: shift + 16])
     out.append(src[64:])
-    return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out))], []
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out))], []
 
 
 def pshufhw(_, instr, dst, src, imm):
@@ -4356,7 +4356,7 @@ def pshufhw(_, instr, dst, src, imm):
     for i in xrange(4):
         shift = ((control >> (i * 2)) & 3) * 16
         out.append(src[shift + 64: shift + 16 + 64])
-    return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out))], []
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out))], []
 
 
 def ps_rl_ll(ir, instr, dst, src, op, size):
@@ -4378,7 +4378,7 @@ def ps_rl_ll(ir, instr, dst, src, op, size):
     out = []
     for i in xrange(0, dst.size, size):
         out.append(m2_expr.ExprOp(op, dst[i:i + size], count))
-    return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out))], []
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out))], []
 
 
 def psrlw(ir, instr, dst, src):
@@ -4418,18 +4418,18 @@ def pslldq(_, instr, dst, src):
     e = []
     count = int(src)
     if count > 15:
-        return [m2_expr.ExprAff(dst, m2_expr.ExprInt(0, dst.size))], []
+        return [m2_expr.ExprAssign(dst, m2_expr.ExprInt(0, dst.size))], []
     else:
-        return [m2_expr.ExprAff(dst, dst << m2_expr.ExprInt(8 * count, dst.size))], []
+        return [m2_expr.ExprAssign(dst, dst << m2_expr.ExprInt(8 * count, dst.size))], []
 
 
 def psrldq(_, instr, dst, src):
     assert src.is_int()
     count = int(src)
     if count > 15:
-        return [m2_expr.ExprAff(dst, m2_expr.ExprInt(0, dst.size))], []
+        return [m2_expr.ExprAssign(dst, m2_expr.ExprInt(0, dst.size))], []
     else:
-        return [m2_expr.ExprAff(dst, dst >> m2_expr.ExprInt(8 * count, dst.size))], []
+        return [m2_expr.ExprAssign(dst, dst >> m2_expr.ExprInt(8 * count, dst.size))], []
 
 
 def iret(ir, instr):
@@ -4447,7 +4447,7 @@ def pcmpeq(_, instr, dst, src, size):
     e = []
     for i in xrange(0, dst.size, size):
         test = m2_expr.expr_is_equal(dst[i:i + size], src[i:i + size])
-        e.append(m2_expr.ExprAff(dst[i:i + size],
+        e.append(m2_expr.ExprAssign(dst[i:i + size],
                                  m2_expr.ExprCond(test,
                                                   m2_expr.ExprInt(-1, size),
                                                   m2_expr.ExprInt(0, size))))
@@ -4458,7 +4458,7 @@ def pcmpgt(_, instr, dst, src, size):
     e = []
     for i in xrange(0, dst.size, size):
         test = m2_expr.expr_is_signed_greater(dst[i:i + size], src[i:i + size])
-        e.append(m2_expr.ExprAff(dst[i:i + size],
+        e.append(m2_expr.ExprAssign(dst[i:i + size],
                                  m2_expr.ExprCond(test,
                                                   m2_expr.ExprInt(-1, size),
                                                   m2_expr.ExprInt(0, size))))
@@ -4500,7 +4500,7 @@ def punpck(_, instr, dst, src, size, off):
     for i in xrange(dst.size / (2 * size)):
         slices.append(dst[size * i + off: size * i + off + size])
         slices.append(src[size * i + off: size * i + off + size])
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprCompose(*slices)))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*slices)))
     return e, []
 
 
@@ -4545,7 +4545,7 @@ def pinsr(_, instr, dst, src, imm, size):
             64: 0x1}[size]
 
     sel = (int(imm) & mask) * size
-    e.append(m2_expr.ExprAff(dst[sel:sel + size], src[:size]))
+    e.append(m2_expr.ExprAssign(dst[sel:sel + size], src[:size]))
 
     return e, []
 
@@ -4575,7 +4575,7 @@ def pextr(_, instr, dst, src, imm, size):
             64: 0x1}[size]
 
     sel = (int(imm) & mask) * size
-    e.append(m2_expr.ExprAff(dst, src[sel:sel + size].zeroExtend(dst.size)))
+    e.append(m2_expr.ExprAssign(dst, src[sel:sel + size].zeroExtend(dst.size)))
 
     return e, []
 
@@ -4599,49 +4599,49 @@ def pextrq(ir, instr, dst, src, imm):
 def unpckhps(_, instr, dst, src):
     e = []
     src = m2_expr.ExprCompose(dst[64:96], src[64:96], dst[96:128], src[96:128])
-    e.append(m2_expr.ExprAff(dst, src))
+    e.append(m2_expr.ExprAssign(dst, src))
     return e, []
 
 
 def unpckhpd(_, instr, dst, src):
     e = []
     src = m2_expr.ExprCompose(dst[64:128], src[64:128])
-    e.append(m2_expr.ExprAff(dst, src))
+    e.append(m2_expr.ExprAssign(dst, src))
     return e, []
 
 
 def unpcklps(_, instr, dst, src):
     e = []
     src = m2_expr.ExprCompose(dst[0:32], src[0:32], dst[32:64], src[32:64])
-    e.append(m2_expr.ExprAff(dst, src))
+    e.append(m2_expr.ExprAssign(dst, src))
     return e, []
 
 
 def unpcklpd(_, instr, dst, src):
     e = []
     src = m2_expr.ExprCompose(dst[0:64], src[0:64])
-    e.append(m2_expr.ExprAff(dst, src))
+    e.append(m2_expr.ExprAssign(dst, src))
     return e, []
 
 
 def movlpd(_, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst[:64], src[:64]))
+    e.append(m2_expr.ExprAssign(dst[:64], src[:64]))
     return e, []
 
 
 def movlps(_, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst[:64], src[:64]))
+    e.append(m2_expr.ExprAssign(dst[:64], src[:64]))
     return e, []
 
 
 def movhpd(_, instr, dst, src):
     e = []
     if src.size == 64:
-        e.append(m2_expr.ExprAff(dst[64:128], src))
+        e.append(m2_expr.ExprAssign(dst[64:128], src))
     elif dst.size == 64:
-        e.append(m2_expr.ExprAff(dst, src[64:128]))
+        e.append(m2_expr.ExprAssign(dst, src[64:128]))
     else:
         raise RuntimeError("bad encoding!")
     return e, []
@@ -4649,25 +4649,25 @@ def movhpd(_, instr, dst, src):
 
 def movlhps(_, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst[64:128], src[:64]))
+    e.append(m2_expr.ExprAssign(dst[64:128], src[:64]))
     return e, []
 
 
 def movhlps(_, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst[:64], src[64:128]))
+    e.append(m2_expr.ExprAssign(dst[:64], src[64:128]))
     return e, []
 
 
 def movdq2q(_, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst, src[:64]))
+    e.append(m2_expr.ExprAssign(dst, src[:64]))
     return e, []
 
 
 def movq2dq(_, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst, src[:64].zeroExtend(dst.size)))
+    e.append(m2_expr.ExprAssign(dst, src[:64].zeroExtend(dst.size)))
     return e, []
 
 
@@ -4678,7 +4678,7 @@ def sqrt_gen(_, instr, dst, src, size):
         out.append(m2_expr.ExprOp('fsqrt',
                                   src[i * size: (i + 1) * size]))
     src = m2_expr.ExprCompose(*out)
-    e.append(m2_expr.ExprAff(dst, src))
+    e.append(m2_expr.ExprAssign(dst, src))
     return e, []
 
 
@@ -4692,7 +4692,7 @@ def sqrtps(ir, instr, dst, src):
 
 def sqrtsd(_, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst[:64],
+    e.append(m2_expr.ExprAssign(dst[:64],
                              m2_expr.ExprOp('fsqrt',
                                             src[:64])))
     return e, []
@@ -4700,7 +4700,7 @@ def sqrtsd(_, instr, dst, src):
 
 def sqrtss(_, instr, dst, src):
     e = []
-    e.append(m2_expr.ExprAff(dst[:32],
+    e.append(m2_expr.ExprAssign(dst[:32],
                              m2_expr.ExprOp('fsqrt',
                                             src[:32])))
     return e, []
@@ -4712,14 +4712,14 @@ def pmovmskb(_, instr, dst, src):
     for i in xrange(src.size / 8):
         out.append(src[8 * i + 7:8 * (i + 1)])
     src = m2_expr.ExprCompose(*out)
-    e.append(m2_expr.ExprAff(dst, src.zeroExtend(dst.size)))
+    e.append(m2_expr.ExprAssign(dst, src.zeroExtend(dst.size)))
     return e, []
 
 
 def smsw(ir, instr, dst):
     e = []
     LOG_X86_SEM.warning("DEFAULT SMSW %s!!", str(dst))
-    e.append(m2_expr.ExprAff(dst, m2_expr.ExprInt(0x80050033, 32)[:dst.size]))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprInt(0x80050033, 32)[:dst.size]))
     return e, []
 
 
@@ -4744,7 +4744,7 @@ def palignr(ir, instr, dst, src, imm):
             dst[:shift],
         )
 
-    return [m2_expr.ExprAff(dst, result)], []
+    return [m2_expr.ExprAssign(dst, result)], []
 
 
 def _signed_saturation(expr, dst_size):
@@ -4816,7 +4816,7 @@ def packsswb(ir, instr, dst, src):
     for source in [dst, src]:
         for start in xrange(0, dst.size, 16):
             out.append(_signed_saturation(source[start:start + 16], 8))
-    return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out))], []
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out))], []
 
 
 def packssdw(ir, instr, dst, src):
@@ -4824,7 +4824,7 @@ def packssdw(ir, instr, dst, src):
     for source in [dst, src]:
         for start in xrange(0, dst.size, 32):
             out.append(_signed_saturation(source[start:start + 32], 16))
-    return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out))], []
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out))], []
 
 
 def packuswb(ir, instr, dst, src):
@@ -4832,7 +4832,7 @@ def packuswb(ir, instr, dst, src):
     for source in [dst, src]:
         for start in xrange(0, dst.size, 16):
             out.append(_unsigned_saturation(source[start:start + 16], 8))
-    return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out))], []
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out))], []
 
 
 def _saturation_sub_unsigned(expr):
@@ -4912,7 +4912,7 @@ def maskmovq(ir, instr, src, mask):
         cur_label = check_labels[i]
         next_check_label = check_labels[i + 1] if (i + 1) < len(check_labels) else loc_next_expr
         write_label = write_labels[i]
-        check = m2_expr.ExprAff(ir.IRDst,
+        check = m2_expr.ExprAssign(ir.IRDst,
                                 m2_expr.ExprCond(bit,
                                                  write_label,
                                                  next_check_label))
@@ -4926,13 +4926,13 @@ def maskmovq(ir, instr, src, mask):
         write_addr = dst_addr + m2_expr.ExprInt(i, dst_addr.size)
 
         # @8[DI/EDI/RDI + i] = src[byte i]
-        write_mem = m2_expr.ExprAff(m2_expr.ExprMem(write_addr, 8),
+        write_mem = m2_expr.ExprAssign(m2_expr.ExprMem(write_addr, 8),
                                     src[start: start + 8])
-        jump = m2_expr.ExprAff(ir.IRDst, next_check_label)
+        jump = m2_expr.ExprAssign(ir.IRDst, next_check_label)
         blks.append(IRBlock(cur_label.loc_key, [AssignBlock([write_mem, jump], instr)]))
 
     # If mask is null, bypass all
-    e = [m2_expr.ExprAff(ir.IRDst, m2_expr.ExprCond(mask,
+    e = [m2_expr.ExprAssign(ir.IRDst, m2_expr.ExprCond(mask,
                                                     check_labels[0],
                                                     loc_next_expr))]
     return e, blks
@@ -4945,7 +4945,7 @@ def emms(ir, instr):
 # Common value without too many option, 0x1fa0
 STMXCSR_VALUE = 0x1fa0
 def stmxcsr(ir, instr, dst):
-    return [m2_expr.ExprAff(dst, m2_expr.ExprInt(STMXCSR_VALUE, dst.size))], []
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprInt(STMXCSR_VALUE, dst.size))], []
 
 def ldmxcsr(ir, instr, dst):
     # Implemented as a NOP
@@ -4977,7 +4977,7 @@ def shufps(ir, instr, dst, src, imm8):
         else:
             source = src
         out.append(_select4(source, (control >> (i * 2)) & 3))
-    return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out))], []
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out))], []
 
 
 def shufpd(ir, instr, dst, src, imm8):
@@ -4985,19 +4985,19 @@ def shufpd(ir, instr, dst, src, imm8):
     control = int(imm8)
     out.append(dst[64:] if control & 1 else dst[:64])
     out.append(src[64:] if control & 2 else src[:64])
-    return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out))], []
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out))], []
 
 def movmskps(ir, instr, dst, src):
     out = []
     for i in xrange(4):
         out.append(src[(32 * i) + 31:(32 * i) + 32])
-    return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out).zeroExtend(dst.size))], []
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out).zeroExtend(dst.size))], []
 
 def movmskpd(ir, instr, dst, src):
     out = []
     for i in xrange(2):
         out.append(src[(64 * i) + 63:(64 * i) + 64])
-    return [m2_expr.ExprAff(dst, m2_expr.ExprCompose(*out).zeroExtend(dst.size))], []
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out).zeroExtend(dst.size))], []
 
 
 mnemo_func = {'mov': mov,
@@ -5692,17 +5692,17 @@ class ir_x86_16(IntermediateRepresentation):
                         for irblock in extra_ir]
 
         cond_bloc = []
-        cond_bloc.append(m2_expr.ExprAff(c_reg,
+        cond_bloc.append(m2_expr.ExprAssign(c_reg,
                                          c_reg - m2_expr.ExprInt(1,
                                                                  c_reg.size)))
-        cond_bloc.append(m2_expr.ExprAff(self.IRDst, m2_expr.ExprCond(c_cond,
+        cond_bloc.append(m2_expr.ExprAssign(self.IRDst, m2_expr.ExprCond(c_cond,
                                                                       loc_skip_expr,
                                                                       loc_do_expr)))
         cond_bloc = IRBlock(loc_end, [AssignBlock(cond_bloc, instr)])
         e_do = instr_ir
 
         c = IRBlock(loc_do, [AssignBlock(e_do, instr)])
-        e_n = [m2_expr.ExprAff(self.IRDst, m2_expr.ExprCond(c_reg, loc_do_expr,
+        e_n = [m2_expr.ExprAssign(self.IRDst, m2_expr.ExprCond(c_reg, loc_do_expr,
                                                             loc_skip_expr))]
         return e_n, [cond_bloc, c] + new_extra_ir
 
@@ -5712,7 +5712,7 @@ class ir_x86_16(IntermediateRepresentation):
     def expraff_fix_regs_for_mode(self, e, mode=64):
         dst = self.expr_fix_regs_for_mode(e.dst, mode)
         src = self.expr_fix_regs_for_mode(e.src, mode)
-        return m2_expr.ExprAff(dst, src)
+        return m2_expr.ExprAssign(dst, src)
 
     def irbloc_fix_regs_for_mode(self, irblock, mode=64):
         irs = []
@@ -5771,7 +5771,7 @@ class ir_x86_64(ir_x86_16):
             if dst != self.pc:
                 dst = dst.replace_expr(pc_fixed)
             src = src.replace_expr(pc_fixed)
-            instr_ir[i] = m2_expr.ExprAff(dst, src)
+            instr_ir[i] = m2_expr.ExprAssign(dst, src)
 
         for idx, irblock in enumerate(extra_ir):
             extra_ir[idx] = irblock.modify_exprs(lambda expr: expr.replace_expr(pc_fixed) \

--- a/miasm2/core/sembuilder.py
+++ b/miasm2/core/sembuilder.py
@@ -161,7 +161,7 @@ class SemBuilder(object):
         """Recursive function transforming a @body to a block expression
         Return:
          - AST to append to body (real python statements)
-         - a list of blocks, ie list of affblock, ie list of ExprAff (AST)"""
+         - a list of blocks, ie list of affblock, ie list of ExprAssign (AST)"""
 
         # Init
         ## Real instructions
@@ -188,7 +188,7 @@ class SemBuilder(object):
 
                 dst.ctx = ast.Load()
 
-                res = ast.Call(func=ast.Name(id='ExprAff',
+                res = ast.Call(func=ast.Name(id='ExprAssign',
                                              ctx=ast.Load()),
                                args=[dst, src],
                                keywords=[],
@@ -230,7 +230,7 @@ class SemBuilder(object):
                 IRDst = ast.Attribute(value=ast.Name(id='ir',
                                                      ctx=ast.Load()),
                                       attr='IRDst', ctx=ast.Load())
-                blocks[-1][-1].append(ast.Call(func=ast.Name(id='ExprAff',
+                blocks[-1][-1].append(ast.Call(func=ast.Name(id='ExprAssign',
                                                              ctx=ast.Load()),
                                                args=[IRDst, dst],
                                                keywords=[],
@@ -248,7 +248,7 @@ class SemBuilder(object):
                         raise RuntimeError("Imbricated if unimplemented")
 
                     ## Close the last block
-                    jmp_end = ast.Call(func=ast.Name(id='ExprAff',
+                    jmp_end = ast.Call(func=ast.Name(id='ExprAssign',
                                                      ctx=ast.Load()),
                                        args=[IRDst, loc_end],
                                        keywords=[],

--- a/miasm2/expression/expression_helper.py
+++ b/miasm2/expression/expression_helper.py
@@ -515,7 +515,7 @@ class CondConstraintZero(CondConstraint):
     operator = m2_expr.TOK_EQUAL
 
     def to_constraint(self):
-        return m2_expr.ExprAff(self.expr, m2_expr.ExprInt(0, self.expr.size))
+        return m2_expr.ExprAssign(self.expr, m2_expr.ExprInt(0, self.expr.size))
 
 
 class CondConstraintNotZero(CondConstraint):
@@ -525,7 +525,7 @@ class CondConstraintNotZero(CondConstraint):
 
     def to_constraint(self):
         cst1, cst2 = m2_expr.ExprInt(0, 1), m2_expr.ExprInt(1, 1)
-        return m2_expr.ExprAff(cst1, m2_expr.ExprCond(self.expr, cst1, cst2))
+        return m2_expr.ExprAssign(cst1, m2_expr.ExprCond(self.expr, cst1, cst2))
 
 
 ConstrainedValue = collections.namedtuple("ConstrainedValue",
@@ -568,7 +568,7 @@ def possible_values(expr):
                                          m2_expr.ExprMem(consval.value,
                                                          expr.size))
                         for consval in possible_values(expr.arg))
-    elif isinstance(expr, m2_expr.ExprAff):
+    elif isinstance(expr, m2_expr.ExprAssign):
         consvals.update(possible_values(expr.src))
     # Special case: constraint insertion
     elif isinstance(expr, m2_expr.ExprCond):

--- a/miasm2/expression/parser.py
+++ b/miasm2/expression/parser.py
@@ -1,6 +1,6 @@
 import pyparsing
 from miasm2.expression.expression import ExprInt, ExprId, ExprLoc, ExprSlice, \
-    ExprMem, ExprCond, ExprCompose, ExprOp, ExprAff, LocKey
+    ExprMem, ExprCond, ExprCompose, ExprOp, ExprAssign, LocKey
 
 integer = pyparsing.Word(pyparsing.nums).setParseAction(lambda t:
                                                         int(t[0]))
@@ -22,7 +22,7 @@ STR_EXPRMEM = pyparsing.Suppress("ExprMem")
 STR_EXPRCOND = pyparsing.Suppress("ExprCond")
 STR_EXPRCOMPOSE = pyparsing.Suppress("ExprCompose")
 STR_EXPROP = pyparsing.Suppress("ExprOp")
-STR_EXPRAFF = pyparsing.Suppress("ExprAff")
+STR_EXPRASSIGN = pyparsing.Suppress("ExprAssign")
 
 LOCKEY = pyparsing.Suppress("LocKey")
 
@@ -51,7 +51,7 @@ expr_mem = STR_EXPRMEM + LPARENTHESIS + expr + STR_COMMA + str_int + RPARENTHESI
 expr_cond = STR_EXPRCOND + LPARENTHESIS + expr + STR_COMMA + expr + STR_COMMA + expr + RPARENTHESIS
 expr_compose = STR_EXPRCOMPOSE + LPARENTHESIS + pyparsing.delimitedList(expr, delim=',') + RPARENTHESIS
 expr_op = STR_EXPROP + LPARENTHESIS + string + STR_COMMA + pyparsing.delimitedList(expr, delim=',') + RPARENTHESIS
-expr_aff = STR_EXPRAFF + LPARENTHESIS + expr + STR_COMMA + expr + RPARENTHESIS
+expr_aff = STR_EXPRASSIGN + LPARENTHESIS + expr + STR_COMMA + expr + RPARENTHESIS
 
 expr << (expr_int | expr_id | expr_loc | expr_slice | expr_mem | expr_cond | \
          expr_compose | expr_op | expr_aff)
@@ -69,7 +69,7 @@ expr_mem.setParseAction(lambda t: ExprMem(*t))
 expr_cond.setParseAction(lambda t: ExprCond(*t))
 expr_compose.setParseAction(lambda t: ExprCompose(*t))
 expr_op.setParseAction(lambda t: ExprOp(*t))
-expr_aff.setParseAction(lambda t: ExprAff(*t))
+expr_aff.setParseAction(lambda t: ExprAssign(*t))
 
 
 def str_to_expr(str_in):

--- a/miasm2/ir/analysis.py
+++ b/miasm2/ir/analysis.py
@@ -4,7 +4,7 @@ import warnings
 import logging
 
 from miasm2.ir.ir import IntermediateRepresentation, AssignBlock
-from miasm2.expression.expression import ExprOp, ExprAff
+from miasm2.expression.expression import ExprOp, ExprAssign
 from miasm2.analysis.data_flow import dead_simp as new_dead_simp_imp
 
 
@@ -45,8 +45,8 @@ class ira(IntermediateRepresentation):
 
         call_assignblk = AssignBlock(
             [
-                ExprAff(self.ret_reg, ExprOp('call_func_ret', addr, self.sp)),
-                ExprAff(self.sp, ExprOp('call_func_stack', addr, self.sp))
+                ExprAssign(self.ret_reg, ExprOp('call_func_ret', addr, self.sp)),
+                ExprAssign(self.sp, ExprOp('call_func_stack', addr, self.sp))
             ],
             instr
         )

--- a/miasm2/ir/ir.py
+++ b/miasm2/ir/ir.py
@@ -58,7 +58,7 @@ class AssignBlock(object):
 
     def __init__(self, irs=None, instr=None):
         """Create a new AssignBlock
-        @irs: (optional) sequence of ExprAff, or dictionnary dst (Expr) -> src
+        @irs: (optional) sequence of ExprAssign, or dictionnary dst (Expr) -> src
               (Expr)
         @instr: (optional) associate an instruction with this AssignBlock
 
@@ -66,7 +66,7 @@ class AssignBlock(object):
         if irs is None:
             irs = []
         self._instr = instr
-        self._assigns = {} # ExprAff.dst -> ExprAff.src
+        self._assigns = {} # ExprAssign.dst -> ExprAssign.src
 
         # Concurrent assignments are handled in _set
         if hasattr(irs, "iteritems"):
@@ -250,10 +250,10 @@ class AssignBlock(object):
             out.append("%s = %s" % (dst, src))
         return "\n".join(out)
 
-    def dst2ExprAff(self, dst):
-        """Return an ExprAff corresponding to @dst equation
+    def dst2ExprAssign(self, dst):
+        """Return an ExprAssign corresponding to @dst equation
         @dst: Expr instance"""
-        return m2_expr.ExprAff(dst, self[dst])
+        return m2_expr.ExprAssign(dst, self[dst])
 
     def simplify(self, simplifier):
         """

--- a/miasm2/ir/translators/C.py
+++ b/miasm2/ir/translators/C.py
@@ -77,7 +77,7 @@ class TranslatorC(Translator):
         value, int_size = int_size_to_bn(offset, 64)
         return 'bignum_from_string("%s", %d)' % (value, int_size)
 
-    def from_ExprAff(self, expr):
+    def from_ExprAssign(self, expr):
         new_dst = self.from_expr(expr.dst)
         new_src = self.from_expr(expr.src)
         return "%s = %s" % (new_dst, new_src)

--- a/miasm2/ir/translators/miasm.py
+++ b/miasm2/ir/translators/miasm.py
@@ -30,8 +30,8 @@ class TranslatorMiasm(Translator):
         args = ["%s" % self.from_expr(arg) for arg in expr.args]
         return "ExprCompose(%s)" % ", ".join(args)
 
-    def from_ExprAff(self, expr):
-        return "ExprAff(%s, %s)" % (self.from_expr(expr.dst),
+    def from_ExprAssign(self, expr):
+        return "ExprAssign(%s, %s)" % (self.from_expr(expr.dst),
                                     self.from_expr(expr.src))
 
     def from_ExprMem(self, expr):

--- a/miasm2/ir/translators/python.py
+++ b/miasm2/ir/translators/python.py
@@ -74,7 +74,7 @@ class TranslatorPython(Translator):
 
         raise NotImplementedError("Unknown operator: %s" % expr.op)
 
-    def from_ExprAff(self, expr):
+    def from_ExprAssign(self, expr):
         return "%s = %s" % tuple(map(self.from_expr, (expr.dst, expr.src)))
 
 

--- a/miasm2/ir/translators/smt2.py
+++ b/miasm2/ir/translators/smt2.py
@@ -278,7 +278,7 @@ class TranslatorSMT2(Translator):
 
         return res
 
-    def from_ExprAff(self, expr):
+    def from_ExprAssign(self, expr):
         src = self.from_expr(expr.src)
         dst = self.from_expr(expr.dst)
         return smt2_assert(smt2_eq(src, dst))

--- a/miasm2/ir/translators/translator.py
+++ b/miasm2/ir/translators/translator.py
@@ -83,9 +83,9 @@ class Translator(object):
         """
         raise NotImplementedError("Abstract method")
 
-    def from_ExprAff(self, expr):
-        """Translate an ExprAff
-        @expr: ExprAff to translate
+    def from_ExprAssign(self, expr):
+        """Translate an ExprAssign
+        @expr: ExprAssign to translate
         """
         raise NotImplementedError("Abstract method")
 
@@ -111,7 +111,7 @@ class Translator(object):
                     m2_expr.ExprSlice: self.from_ExprSlice,
                     m2_expr.ExprOp: self.from_ExprOp,
                     m2_expr.ExprMem: self.from_ExprMem,
-                    m2_expr.ExprAff: self.from_ExprAff,
+                    m2_expr.ExprAssign: self.from_ExprAssign,
                     m2_expr.ExprCond: self.from_ExprCond
                     }
         for target, handler in handlers.iteritems():

--- a/miasm2/ir/translators/z3_ir.py
+++ b/miasm2/ir/translators/z3_ir.py
@@ -239,7 +239,7 @@ class TranslatorZ3(Translator):
 
         return res
 
-    def from_ExprAff(self, expr):
+    def from_ExprAssign(self, expr):
         src = self.from_expr(expr.src)
         dst = self.from_expr(expr.dst)
         return (src == dst)

--- a/test/analysis/data_flow.py
+++ b/test/analysis/data_flow.py
@@ -1,5 +1,5 @@
 """ Test cases for dead code elimination"""
-from miasm2.expression.expression import ExprId, ExprInt, ExprAff, ExprMem
+from miasm2.expression.expression import ExprId, ExprInt, ExprAssign, ExprMem
 from miasm2.core.locationdb import LocationDB
 from miasm2.analysis.data_flow import *
 from miasm2.ir.analysis import ira
@@ -83,9 +83,9 @@ IRA = IRATest(loc_db)
 
 G1_IRA = IRA.new_ircfg()
 
-G1_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST1)], [ExprAff(b, CST2)]])
-G1_IRB1 = gen_irblock(LBL1, [[ExprAff(a, b)]])
-G1_IRB2 = gen_irblock(LBL2, [[ExprAff(r, a)]])
+G1_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST1)], [ExprAssign(b, CST2)]])
+G1_IRB1 = gen_irblock(LBL1, [[ExprAssign(a, b)]])
+G1_IRB2 = gen_irblock(LBL2, [[ExprAssign(r, a)]])
 
 for irb in [G1_IRB0, G1_IRB1, G1_IRB2]:
     G1_IRA.add_irblock(irb)
@@ -96,9 +96,9 @@ G1_IRA.add_uniq_edge(G1_IRB1.loc_key, G1_IRB2.loc_key)
 # Expected output for graph 1
 G1_EXP_IRA = IRA.new_ircfg()
 
-G1_EXP_IRB0 = gen_irblock(LBL0, [[], [ExprAff(b, CST2)]])
-G1_EXP_IRB1 = gen_irblock(LBL1, [[ExprAff(a, b)]])
-G1_EXP_IRB2 = gen_irblock(LBL2, [[ExprAff(r, a)]])
+G1_EXP_IRB0 = gen_irblock(LBL0, [[], [ExprAssign(b, CST2)]])
+G1_EXP_IRB1 = gen_irblock(LBL1, [[ExprAssign(a, b)]])
+G1_EXP_IRB2 = gen_irblock(LBL2, [[ExprAssign(r, a)]])
 
 for irb in [G1_EXP_IRB0, G1_EXP_IRB1, G1_EXP_IRB2]:
     G1_EXP_IRA.add_irblock(irb)
@@ -107,9 +107,9 @@ for irb in [G1_EXP_IRB0, G1_EXP_IRB1, G1_EXP_IRB2]:
 
 G2_IRA = IRA.new_ircfg()
 
-G2_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST1)], [ExprAff(r, CST1)]])
-G2_IRB1 = gen_irblock(LBL1, [[ExprAff(a, a+CST1)]])
-G2_IRB2 = gen_irblock(LBL2, [[ExprAff(a, r)]])
+G2_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST1)], [ExprAssign(r, CST1)]])
+G2_IRB1 = gen_irblock(LBL1, [[ExprAssign(a, a+CST1)]])
+G2_IRB2 = gen_irblock(LBL2, [[ExprAssign(a, r)]])
 
 for irb in [G2_IRB0, G2_IRB1, G2_IRB2]:
     G2_IRA.add_irblock(irb)
@@ -121,7 +121,7 @@ G2_IRA.add_uniq_edge(G2_IRB1.loc_key, G2_IRB1.loc_key)
 # Expected output for graph 2
 G2_EXP_IRA = IRA.new_ircfg()
 
-G2_EXP_IRB0 = gen_irblock(LBL0, [[], [ExprAff(r, CST1)]])
+G2_EXP_IRB0 = gen_irblock(LBL0, [[], [ExprAssign(r, CST1)]])
 G2_EXP_IRB1 = gen_irblock(LBL1, [[]])
 G2_EXP_IRB2 = gen_irblock(LBL2, [[]])
 
@@ -132,9 +132,9 @@ for irb in [G2_EXP_IRB0, G2_EXP_IRB1, G2_EXP_IRB2]:
 
 G3_IRA = IRA.new_ircfg()
 
-G3_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST1)]])
-G3_IRB1 = gen_irblock(LBL1, [[ExprAff(a, a+CST1)]])
-G3_IRB2 = gen_irblock(LBL2, [[ExprAff(r, a)]])
+G3_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST1)]])
+G3_IRB1 = gen_irblock(LBL1, [[ExprAssign(a, a+CST1)]])
+G3_IRB2 = gen_irblock(LBL2, [[ExprAssign(r, a)]])
 
 for irb in [G3_IRB0, G3_IRB1, G3_IRB2]:
     G3_IRA.add_irblock(irb)
@@ -146,9 +146,9 @@ G3_IRA.add_uniq_edge(G3_IRB1.loc_key, G3_IRB1.loc_key)
 # Expected output for graph 3
 G3_EXP_IRA = IRA.new_ircfg()
 
-G3_EXP_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST1)]])
-G3_EXP_IRB1 = gen_irblock(LBL1, [[ExprAff(a, a+CST1)]])
-G3_EXP_IRB2 = gen_irblock(LBL2, [[ExprAff(r, a)]])
+G3_EXP_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST1)]])
+G3_EXP_IRB1 = gen_irblock(LBL1, [[ExprAssign(a, a+CST1)]])
+G3_EXP_IRB2 = gen_irblock(LBL2, [[ExprAssign(r, a)]])
 
 for irb in [G3_EXP_IRB0, G3_EXP_IRB1, G3_EXP_IRB2]:
     G3_EXP_IRA.add_irblock(irb)
@@ -157,10 +157,10 @@ for irb in [G3_EXP_IRB0, G3_EXP_IRB1, G3_EXP_IRB2]:
 
 G4_IRA = IRA.new_ircfg()
 
-G4_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST1)]])
-G4_IRB1 = gen_irblock(LBL1, [[ExprAff(a, a+CST1)]])
-G4_IRB2 = gen_irblock(LBL2, [[ExprAff(a, a+CST2)]])
-G4_IRB3 = gen_irblock(LBL3, [[ExprAff(a, CST3)], [ExprAff(r, a)]])
+G4_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST1)]])
+G4_IRB1 = gen_irblock(LBL1, [[ExprAssign(a, a+CST1)]])
+G4_IRB2 = gen_irblock(LBL2, [[ExprAssign(a, a+CST2)]])
+G4_IRB3 = gen_irblock(LBL3, [[ExprAssign(a, CST3)], [ExprAssign(r, a)]])
 
 for irb in [G4_IRB0, G4_IRB1, G4_IRB2, G4_IRB3]:
     G4_IRA.add_irblock(irb)
@@ -176,7 +176,7 @@ G4_EXP_IRA = IRA.new_ircfg()
 G4_EXP_IRB0 = gen_irblock(LBL0, [[]])
 G4_EXP_IRB1 = gen_irblock(LBL1, [[]])
 G4_EXP_IRB2 = gen_irblock(LBL2, [[]])
-G4_EXP_IRB3 = gen_irblock(LBL3, [[ExprAff(a, CST3)], [ExprAff(r, a)]])
+G4_EXP_IRB3 = gen_irblock(LBL3, [[ExprAssign(a, CST3)], [ExprAssign(r, a)]])
 
 for irb in [G4_EXP_IRB0, G4_EXP_IRB1, G4_EXP_IRB2, G4_EXP_IRB3]:
     G4_EXP_IRA.add_irblock(irb)
@@ -185,12 +185,12 @@ for irb in [G4_EXP_IRB0, G4_EXP_IRB1, G4_EXP_IRB2, G4_EXP_IRB3]:
 
 G5_IRA = IRA.new_ircfg()
 
-G5_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST1)]])
-G5_IRB1 = gen_irblock(LBL1, [[ExprAff(r, CST2)]])
-G5_IRB2 = gen_irblock(LBL2, [[ExprAff(a, a+CST2)]])
-G5_IRB3 = gen_irblock(LBL3, [[ExprAff(a, a+CST3)]])
-G5_IRB4 = gen_irblock(LBL4, [[ExprAff(a, a+CST1)]])
-G5_IRB5 = gen_irblock(LBL5, [[ExprAff(a, r)]])
+G5_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST1)]])
+G5_IRB1 = gen_irblock(LBL1, [[ExprAssign(r, CST2)]])
+G5_IRB2 = gen_irblock(LBL2, [[ExprAssign(a, a+CST2)]])
+G5_IRB3 = gen_irblock(LBL3, [[ExprAssign(a, a+CST3)]])
+G5_IRB4 = gen_irblock(LBL4, [[ExprAssign(a, a+CST1)]])
+G5_IRB5 = gen_irblock(LBL5, [[ExprAssign(a, r)]])
 
 for irb in [G5_IRB0, G5_IRB1, G5_IRB2, G5_IRB3, G5_IRB4, G5_IRB5]:
     G5_IRA.add_irblock(irb)
@@ -207,7 +207,7 @@ G5_IRA.add_uniq_edge(G5_IRB4.loc_key, G5_IRB1.loc_key)
 G5_EXP_IRA = IRA.new_ircfg()
 
 G5_EXP_IRB0 = gen_irblock(LBL0, [[]])
-G5_EXP_IRB1 = gen_irblock(LBL1, [[ExprAff(r, CST2)]])
+G5_EXP_IRB1 = gen_irblock(LBL1, [[ExprAssign(r, CST2)]])
 G5_EXP_IRB2 = gen_irblock(LBL2, [[]])
 G5_EXP_IRB3 = gen_irblock(LBL3, [[]])
 G5_EXP_IRB4 = gen_irblock(LBL4, [[]])
@@ -222,10 +222,10 @@ for irb in [G5_EXP_IRB0, G5_EXP_IRB1, G5_EXP_IRB2,
 
 G6_IRA = IRA.new_ircfg()
 
-G6_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST1)]])
-G6_IRB1 = gen_irblock(LBL1, [[ExprAff(b, a)]])
-G6_IRB2 = gen_irblock(LBL2, [[ExprAff(a, b)]])
-G6_IRB3 = gen_irblock(LBL3, [[ExprAff(r, CST2)]])
+G6_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST1)]])
+G6_IRB1 = gen_irblock(LBL1, [[ExprAssign(b, a)]])
+G6_IRB2 = gen_irblock(LBL2, [[ExprAssign(a, b)]])
+G6_IRB3 = gen_irblock(LBL3, [[ExprAssign(r, CST2)]])
 
 for irb in [G6_IRB0, G6_IRB1, G6_IRB2, G6_IRB3]:
     G6_IRA.add_irblock(irb)
@@ -241,7 +241,7 @@ G6_EXP_IRA = IRA.new_ircfg()
 G6_EXP_IRB0 = gen_irblock(LBL0, [[]])
 G6_EXP_IRB1 = gen_irblock(LBL1, [[]])
 G6_EXP_IRB2 = gen_irblock(LBL2, [[]])
-G6_EXP_IRB3 = gen_irblock(LBL3, [[ExprAff(r, CST2)]])
+G6_EXP_IRB3 = gen_irblock(LBL3, [[ExprAssign(r, CST2)]])
 
 for irb in [G6_EXP_IRB0, G6_EXP_IRB1, G6_EXP_IRB2, G6_EXP_IRB3]:
     G6_EXP_IRA.add_irblock(irb)
@@ -250,10 +250,10 @@ for irb in [G6_EXP_IRB0, G6_EXP_IRB1, G6_EXP_IRB2, G6_EXP_IRB3]:
 
 G7_IRA = IRA.new_ircfg()
 
-G7_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST1)], [ExprAff(r, CST1)]])
-G7_IRB1 = gen_irblock(LBL1, [[ExprAff(a, a+CST1)]])
-G7_IRB2 = gen_irblock(LBL2, [[ExprAff(a, a+CST2)]])
-G7_IRB3 = gen_irblock(LBL3, [[ExprAff(a, r)]])
+G7_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST1)], [ExprAssign(r, CST1)]])
+G7_IRB1 = gen_irblock(LBL1, [[ExprAssign(a, a+CST1)]])
+G7_IRB2 = gen_irblock(LBL2, [[ExprAssign(a, a+CST2)]])
+G7_IRB3 = gen_irblock(LBL3, [[ExprAssign(a, r)]])
 
 for irb in [G7_IRB0, G7_IRB1, G7_IRB2, G7_IRB3]:
     G7_IRA.add_irblock(irb)
@@ -268,7 +268,7 @@ G7_IRA.add_uniq_edge(G7_IRB0.loc_key, G7_IRB2.loc_key)
 # Expected output for graph 7
 G7_EXP_IRA = IRA.new_ircfg()
 
-G7_EXP_IRB0 = gen_irblock(LBL0, [[], [ExprAff(r, CST1)]])
+G7_EXP_IRB0 = gen_irblock(LBL0, [[], [ExprAssign(r, CST1)]])
 G7_EXP_IRB1 = gen_irblock(LBL1, [[]])
 G7_EXP_IRB2 = gen_irblock(LBL2, [[]])
 G7_EXP_IRB3 = gen_irblock(LBL3, [[]])
@@ -280,10 +280,10 @@ for irb in [G7_EXP_IRB0, G7_EXP_IRB1, G7_EXP_IRB2, G7_EXP_IRB3]:
 
 G8_IRA = IRA.new_ircfg()
 
-G8_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST1)], [ExprAff(b, CST1)]])
-G8_IRB1 = gen_irblock(LBL1, [[ExprAff(a, a+CST1)]])
-G8_IRB2 = gen_irblock(LBL2, [[ExprAff(b, b+CST2)]])
-G8_IRB3 = gen_irblock(LBL3, [[ExprAff(a, b)]])
+G8_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST1)], [ExprAssign(b, CST1)]])
+G8_IRB1 = gen_irblock(LBL1, [[ExprAssign(a, a+CST1)]])
+G8_IRB2 = gen_irblock(LBL2, [[ExprAssign(b, b+CST2)]])
+G8_IRB3 = gen_irblock(LBL3, [[ExprAssign(a, b)]])
 
 
 for irb in [G8_IRB0, G8_IRB1, G8_IRB2, G8_IRB3]:
@@ -312,11 +312,11 @@ for irb in [G8_EXP_IRB0, G8_EXP_IRB1, G8_EXP_IRB2, G8_EXP_IRB3]:
 
 G9_IRA = IRA.new_ircfg()
 
-G9_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST1)], [ExprAff(b, CST1)]])
-G9_IRB1 = gen_irblock(LBL1, [[ExprAff(a, a+CST1)], [ExprAff(b, b+CST1)]])
-G9_IRB2 = gen_irblock(LBL2, [[ExprAff(a, a+CST2)], [ExprAff(b, b+CST2)]])
-G9_IRB3 = gen_irblock(LBL3, [[ExprAff(a, b)]])
-G9_IRB4 = gen_irblock(LBL4, [[ExprAff(r, a)], [ExprAff(r, b)]])
+G9_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST1)], [ExprAssign(b, CST1)]])
+G9_IRB1 = gen_irblock(LBL1, [[ExprAssign(a, a+CST1)], [ExprAssign(b, b+CST1)]])
+G9_IRB2 = gen_irblock(LBL2, [[ExprAssign(a, a+CST2)], [ExprAssign(b, b+CST2)]])
+G9_IRB3 = gen_irblock(LBL3, [[ExprAssign(a, b)]])
+G9_IRB4 = gen_irblock(LBL4, [[ExprAssign(r, a)], [ExprAssign(r, b)]])
 
 for irb in [G9_IRB0, G9_IRB1, G9_IRB2, G9_IRB3, G9_IRB4]:
     G9_IRA.add_irblock(irb)
@@ -335,11 +335,11 @@ G9_IRA.add_uniq_edge(G9_IRB3.loc_key, G9_IRB4.loc_key)
 
 G9_EXP_IRA = IRA.new_ircfg()
 
-G9_EXP_IRB0 = gen_irblock(LBL0, [[], [ExprAff(b, CST1)]])
-G9_EXP_IRB1 = gen_irblock(LBL1, [[], [ExprAff(b, b+CST1)]])
-G9_EXP_IRB2 = gen_irblock(LBL2, [[], [ExprAff(b, b+CST2)]])
+G9_EXP_IRB0 = gen_irblock(LBL0, [[], [ExprAssign(b, CST1)]])
+G9_EXP_IRB1 = gen_irblock(LBL1, [[], [ExprAssign(b, b+CST1)]])
+G9_EXP_IRB2 = gen_irblock(LBL2, [[], [ExprAssign(b, b+CST2)]])
 G9_EXP_IRB3 = gen_irblock(LBL3, [[]])
-G9_EXP_IRB4 = gen_irblock(LBL4, [[], [ExprAff(r, b)]])
+G9_EXP_IRB4 = gen_irblock(LBL4, [[], [ExprAssign(r, b)]])
 
 for irb in [G9_EXP_IRB0, G9_EXP_IRB1, G9_EXP_IRB2, G9_EXP_IRB3, G9_EXP_IRB4]:
     G9_EXP_IRA.add_irblock(irb)
@@ -349,10 +349,10 @@ for irb in [G9_EXP_IRB0, G9_EXP_IRB1, G9_EXP_IRB2, G9_EXP_IRB3, G9_EXP_IRB4]:
 
 G10_IRA = IRA.new_ircfg()
 
-G10_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST1)]])
-G10_IRB1 = gen_irblock(LBL1, [[ExprAff(b, a)]])
-G10_IRB2 = gen_irblock(LBL2, [[ExprAff(a, b)]])
-G10_IRB3 = gen_irblock(LBL3, [[ExprAff(r, CST1)]])
+G10_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST1)]])
+G10_IRB1 = gen_irblock(LBL1, [[ExprAssign(b, a)]])
+G10_IRB2 = gen_irblock(LBL2, [[ExprAssign(a, b)]])
+G10_IRB3 = gen_irblock(LBL3, [[ExprAssign(r, CST1)]])
 
 for irb in [G10_IRB0, G10_IRB1, G10_IRB2, G10_IRB3]:
     G10_IRA.add_irblock(irb)
@@ -369,7 +369,7 @@ G10_EXP_IRA = IRA.new_ircfg()
 G10_EXP_IRB0 = gen_irblock(LBL0, [[]])
 G10_EXP_IRB1 = gen_irblock(LBL1, [[]])
 G10_EXP_IRB2 = gen_irblock(LBL2, [[]])
-G10_EXP_IRB3 = gen_irblock(LBL3, [[ExprAff(r, CST1)]])
+G10_EXP_IRB3 = gen_irblock(LBL3, [[ExprAssign(r, CST1)]])
 
 for irb in [G10_EXP_IRB0, G10_EXP_IRB1, G10_EXP_IRB2, G10_EXP_IRB3]:
     G10_EXP_IRA.add_irblock(irb)
@@ -378,11 +378,11 @@ for irb in [G10_EXP_IRB0, G10_EXP_IRB1, G10_EXP_IRB2, G10_EXP_IRB3]:
 
 G11_IRA = IRA.new_ircfg()
 
-G11_IRB0 = gen_irblock(LBL0, [[ExprAff(a, b)]])
-G11_IRB1 = gen_irblock(LBL1, [[ExprAff(b, a)]])
-G11_IRB2 = gen_irblock(LBL2, [[ExprAff(r, a)]])
-G11_IRB3 = gen_irblock(LBL3, [[ExprAff(a, a+CST1)]])
-G11_IRB4 = gen_irblock(LBL4, [[ExprAff(b, b+CST1)]])
+G11_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, b)]])
+G11_IRB1 = gen_irblock(LBL1, [[ExprAssign(b, a)]])
+G11_IRB2 = gen_irblock(LBL2, [[ExprAssign(r, a)]])
+G11_IRB3 = gen_irblock(LBL3, [[ExprAssign(a, a+CST1)]])
+G11_IRB4 = gen_irblock(LBL4, [[ExprAssign(b, b+CST1)]])
 
 
 for irb in [G11_IRB0, G11_IRB1, G11_IRB2]:
@@ -398,11 +398,11 @@ G11_IRA.add_uniq_edge(G11_IRB1.loc_key, G11_IRB2.loc_key)
 # Expected output for graph 11
 G11_EXP_IRA = IRA.new_ircfg()
 
-G11_EXP_IRB0 = gen_irblock(LBL0, [[ExprAff(a, b)]])
-G11_EXP_IRB1 = gen_irblock(LBL1, [[ExprAff(b, a)]])
-G11_EXP_IRB2 = gen_irblock(LBL2, [[ExprAff(r, a)]])
-#G11_EXP_IRB3 = gen_irblock(LBL3, [[ExprAff(a, a+CST1)]])
-#G11_EXP_IRB4 = gen_irblock(LBL4, [[ExprAff(b, b+CST1)]])
+G11_EXP_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, b)]])
+G11_EXP_IRB1 = gen_irblock(LBL1, [[ExprAssign(b, a)]])
+G11_EXP_IRB2 = gen_irblock(LBL2, [[ExprAssign(r, a)]])
+#G11_EXP_IRB3 = gen_irblock(LBL3, [[ExprAssign(a, a+CST1)]])
+#G11_EXP_IRB4 = gen_irblock(LBL4, [[ExprAssign(b, b+CST1)]])
 
 for irb in [G11_EXP_IRB0, G11_EXP_IRB1,
             G11_EXP_IRB2]:
@@ -413,12 +413,12 @@ for irb in [G11_EXP_IRB0, G11_EXP_IRB1,
 
 G12_IRA = IRA.new_ircfg()
 
-G12_IRB0 = gen_irblock(LBL0, [[ExprAff(r, CST1)], [ExprAff(a, CST2)]])
-G12_IRB1 = gen_irblock(LBL1, [[ExprAff(r, CST2)]])
-G12_IRB2 = gen_irblock(LBL2, [[ExprAff(r, a)], [ExprAff(b, CST3)]])
-G12_IRB3 = gen_irblock(LBL3, [[ExprAff(r, CST3)]])
-G12_IRB4 = gen_irblock(LBL4, [[ExprAff(r, CST2)]])
-G12_IRB5 = gen_irblock(LBL5, [[ExprAff(r, b)]])
+G12_IRB0 = gen_irblock(LBL0, [[ExprAssign(r, CST1)], [ExprAssign(a, CST2)]])
+G12_IRB1 = gen_irblock(LBL1, [[ExprAssign(r, CST2)]])
+G12_IRB2 = gen_irblock(LBL2, [[ExprAssign(r, a)], [ExprAssign(b, CST3)]])
+G12_IRB3 = gen_irblock(LBL3, [[ExprAssign(r, CST3)]])
+G12_IRB4 = gen_irblock(LBL4, [[ExprAssign(r, CST2)]])
+G12_IRB5 = gen_irblock(LBL5, [[ExprAssign(r, b)]])
 
 for irb in [G12_IRB0, G12_IRB1, G12_IRB2, G12_IRB3, G12_IRB4, G12_IRB5]:
     G12_IRA.add_irblock(irb)
@@ -433,11 +433,11 @@ G12_IRA.add_uniq_edge(G12_IRB4.loc_key, G12_IRB5.loc_key)
 G12_EXP_IRA = IRA.new_ircfg()
 
 G12_EXP_IRB0 = gen_irblock(LBL0, [[], []])
-G12_EXP_IRB1 = gen_irblock(LBL1, [[ExprAff(r, CST2)]])
-G12_EXP_IRB2 = gen_irblock(LBL2, [[], [ExprAff(b, CST3)]])
-G12_EXP_IRB3 = gen_irblock(LBL3, [[ExprAff(r, CST3)]])
+G12_EXP_IRB1 = gen_irblock(LBL1, [[ExprAssign(r, CST2)]])
+G12_EXP_IRB2 = gen_irblock(LBL2, [[], [ExprAssign(b, CST3)]])
+G12_EXP_IRB3 = gen_irblock(LBL3, [[ExprAssign(r, CST3)]])
 G12_EXP_IRB4 = gen_irblock(LBL4, [[]])
-G12_EXP_IRB5 = gen_irblock(LBL5, [[ExprAff(r, b)]])
+G12_EXP_IRB5 = gen_irblock(LBL5, [[ExprAssign(r, b)]])
 
 
 for irb in [G12_EXP_IRB0, G12_EXP_IRB1,
@@ -449,12 +449,12 @@ for irb in [G12_EXP_IRB0, G12_EXP_IRB1,
 
 G13_IRA = IRA.new_ircfg()
 
-G13_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST1)], [ExprAff(b, CST2)]])
-G13_IRB1 = gen_irblock(LBL1, [[ExprAff(r, b)]])
-G13_IRB2 = gen_irblock(LBL2, [[ExprAff(d, CST2)], [ExprAff(a, b+CST1),
-                                                   ExprAff(c, a+b)]])
+G13_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST1)], [ExprAssign(b, CST2)]])
+G13_IRB1 = gen_irblock(LBL1, [[ExprAssign(r, b)]])
+G13_IRB2 = gen_irblock(LBL2, [[ExprAssign(d, CST2)], [ExprAssign(a, b+CST1),
+                                                   ExprAssign(c, a+b)]])
 G13_IRB3 = gen_irblock(LBL3, [[]]) # lost son
-G13_IRB4 = gen_irblock(LBL4, [[ExprAff(b, CST2)]])
+G13_IRB4 = gen_irblock(LBL4, [[ExprAssign(b, CST2)]])
 
 for irb in [G13_IRB0, G13_IRB1, G13_IRB2, G13_IRB4]:
     G13_IRA.add_irblock(irb)
@@ -467,12 +467,12 @@ G13_IRA.add_uniq_edge(G13_IRB4.loc_key, G13_IRB2.loc_key)
 # Expected output for graph 13
 G13_EXP_IRA = IRA.new_ircfg()
 
-G13_EXP_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST1)], [ExprAff(b, CST2)]])
-G13_EXP_IRB1 = gen_irblock(LBL1, [[ExprAff(r, b)]])
-G13_EXP_IRB2 = gen_irblock(LBL2, [[ExprAff(d, CST2)], [ExprAff(a, b+CST1),
-                                                       ExprAff(c, a+b)]])
+G13_EXP_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST1)], [ExprAssign(b, CST2)]])
+G13_EXP_IRB1 = gen_irblock(LBL1, [[ExprAssign(r, b)]])
+G13_EXP_IRB2 = gen_irblock(LBL2, [[ExprAssign(d, CST2)], [ExprAssign(a, b+CST1),
+                                                       ExprAssign(c, a+b)]])
 G13_EXP_IRB3 = gen_irblock(LBL3, [[]])
-G13_EXP_IRB4 = gen_irblock(LBL4, [[ExprAff(b, CST2)]])
+G13_EXP_IRB4 = gen_irblock(LBL4, [[ExprAssign(b, CST2)]])
 
 for irb in [G13_EXP_IRB0, G13_EXP_IRB1, G13_EXP_IRB2, G13_EXP_IRB4]:
     G13_EXP_IRA.add_irblock(irb)
@@ -484,9 +484,9 @@ for irb in [G13_EXP_IRB0, G13_EXP_IRB1, G13_EXP_IRB2, G13_EXP_IRB4]:
 
 G14_IRA = IRA.new_ircfg()
 
-G14_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST1)], [ExprAff(c, a)],
-                              [ExprAff(a, CST2)]])
-G14_IRB1 = gen_irblock(LBL1, [[ExprAff(r, a+c)]])
+G14_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST1)], [ExprAssign(c, a)],
+                              [ExprAssign(a, CST2)]])
+G14_IRB1 = gen_irblock(LBL1, [[ExprAssign(r, a+c)]])
 
 for irb in [G14_IRB0, G14_IRB1]:
     G14_IRA.add_irblock(irb)
@@ -496,9 +496,9 @@ G14_IRA.add_uniq_edge(G14_IRB0.loc_key, G14_IRB1.loc_key)
 # Expected output for graph 1
 G14_EXP_IRA = IRA.new_ircfg()
 
-G14_EXP_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST1)], [ExprAff(c, a)],
-                                  [ExprAff(a, CST2)]])
-G14_EXP_IRB1 = gen_irblock(LBL1, [[ExprAff(r, a+c)]])
+G14_EXP_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST1)], [ExprAssign(c, a)],
+                                  [ExprAssign(a, CST2)]])
+G14_EXP_IRB1 = gen_irblock(LBL1, [[ExprAssign(r, a+c)]])
 
 for irb in [G14_EXP_IRB0, G14_EXP_IRB1]:
     G14_EXP_IRA.add_irblock(irb)
@@ -508,10 +508,10 @@ for irb in [G14_EXP_IRB0, G14_EXP_IRB1]:
 
 G15_IRA = IRA.new_ircfg()
 
-G15_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST2)], [ExprAff(a, CST1),
-                                                   ExprAff(b, a+CST2),
-                                                   ExprAff(c, CST1)]])
-G15_IRB1 = gen_irblock(LBL1, [[ExprAff(r, a)]])
+G15_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST2)], [ExprAssign(a, CST1),
+                                                   ExprAssign(b, a+CST2),
+                                                   ExprAssign(c, CST1)]])
+G15_IRB1 = gen_irblock(LBL1, [[ExprAssign(r, a)]])
 
 for irb in [G15_IRB0, G15_IRB1]:
     G15_IRA.add_irblock(irb)
@@ -521,8 +521,8 @@ G15_IRA.add_uniq_edge(G15_IRB0.loc_key, G15_IRB1.loc_key)
 # Expected output for graph 1
 G15_EXP_IRA = IRA.new_ircfg()
 
-G15_EXP_IRB0 = gen_irblock(LBL0, [[], [ExprAff(a, CST1)]])
-G15_EXP_IRB1 = gen_irblock(LBL1, [[ExprAff(r, a)]])
+G15_EXP_IRB0 = gen_irblock(LBL0, [[], [ExprAssign(a, CST1)]])
+G15_EXP_IRB1 = gen_irblock(LBL1, [[ExprAssign(r, a)]])
 
 for irb in [G15_EXP_IRB0, G15_EXP_IRB1]:
     G15_EXP_IRA.add_irblock(irb)
@@ -531,10 +531,10 @@ for irb in [G15_EXP_IRB0, G15_EXP_IRB1]:
 
 G16_IRA = IRA.new_ircfg()
 
-G16_IRB0 = gen_irblock(LBL0, [[ExprAff(a, CST1), ExprAff(b, CST2),
-                               ExprAff(c, CST3)], [ExprAff(a, c+CST1),
-                                                   ExprAff(b, c+CST2)]])
-G16_IRB1 = gen_irblock(LBL1, [[ExprAff(r, a+b)], [ExprAff(r, c+r)]])
+G16_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, CST1), ExprAssign(b, CST2),
+                               ExprAssign(c, CST3)], [ExprAssign(a, c+CST1),
+                                                   ExprAssign(b, c+CST2)]])
+G16_IRB1 = gen_irblock(LBL1, [[ExprAssign(r, a+b)], [ExprAssign(r, c+r)]])
 G16_IRB2 = gen_irblock(LBL2, [[]])
 
 for irb in [G16_IRB0, G16_IRB1]:
@@ -549,9 +549,9 @@ for irb in [G16_IRB0, G16_IRB1]:
 # Expected output for graph 1
 G16_EXP_IRA = IRA.new_ircfg()
 
-G16_EXP_IRB0 = gen_irblock(LBL0, [[ExprAff(c, CST3)], [ExprAff(a, c + CST1),
-                                                       ExprAff(b, c + CST2)]])
-G16_EXP_IRB1 = gen_irblock(LBL1, [[ExprAff(r, a+b)], [ExprAff(r, c+r)]])
+G16_EXP_IRB0 = gen_irblock(LBL0, [[ExprAssign(c, CST3)], [ExprAssign(a, c + CST1),
+                                                       ExprAssign(b, c + CST2)]])
+G16_EXP_IRB1 = gen_irblock(LBL1, [[ExprAssign(r, a+b)], [ExprAssign(r, c+r)]])
 
 for irb in [G16_EXP_IRB0, G16_EXP_IRB1]:
     G16_EXP_IRA.add_irblock(irb)
@@ -560,57 +560,57 @@ for irb in [G16_EXP_IRB0, G16_EXP_IRB1]:
 
 G17_IRA = IRA.new_ircfg()
 
-G17_IRB0 = gen_irblock(LBL0, [[ExprAff(a, a*b),
-                               ExprAff(b, c),
-                               ExprAff(c, CST1)],
+G17_IRB0 = gen_irblock(LBL0, [[ExprAssign(a, a*b),
+                               ExprAssign(b, c),
+                               ExprAssign(c, CST1)],
 
-                              [ExprAff(d, d+ CST2)],
+                              [ExprAssign(d, d+ CST2)],
 
-                              [ExprAff(a, CST1),
-                               ExprAff(b, a),
-                               ExprAff(c, b)],
+                              [ExprAssign(a, CST1),
+                               ExprAssign(b, a),
+                               ExprAssign(c, b)],
 
-                              [ExprAff(ExprMem(d+CST1, 32), a),
-                               ExprAff(a, b),
-                               ExprAff(b, c),
-                               ExprAff(c, CST1)],
+                              [ExprAssign(ExprMem(d+CST1, 32), a),
+                               ExprAssign(a, b),
+                               ExprAssign(b, c),
+                               ExprAssign(c, CST1)],
 
-                              [ExprAff(a, CST1),
-                               ExprAff(b, a),
-                               ExprAff(c, b)],
+                              [ExprAssign(a, CST1),
+                               ExprAssign(b, a),
+                               ExprAssign(c, b)],
 
-                              [ExprAff(ExprMem(d+CST2, 32), a),
-                               ExprAff(a, b),
-                               ExprAff(b, c),
-                               ExprAff(c, CST1)],
+                              [ExprAssign(ExprMem(d+CST2, 32), a),
+                               ExprAssign(a, b),
+                               ExprAssign(b, c),
+                               ExprAssign(c, CST1)],
 
 
-                              [ExprAff(a, CST2),
-                               ExprAff(b, a),
-                               ExprAff(c, b)],
+                              [ExprAssign(a, CST2),
+                               ExprAssign(b, a),
+                               ExprAssign(c, b)],
 
-                              [ExprAff(a, a+CST1)],
+                              [ExprAssign(a, a+CST1)],
 
-                              [ExprAff(d, a),
-                               ExprAff(a, d)],
+                              [ExprAssign(d, a),
+                               ExprAssign(a, d)],
 
-                              [ExprAff(d, d+CST1)],
+                              [ExprAssign(d, d+CST1)],
 
-                              [ExprAff(a, CST2),
-                               ExprAff(b, a),
-                               ExprAff(c, b)],
+                              [ExprAssign(a, CST2),
+                               ExprAssign(b, a),
+                               ExprAssign(c, b)],
 
-                              [ExprAff(a, a+CST2)],
+                              [ExprAssign(a, a+CST2)],
 
-                              [ExprAff(a, CST2),
-                               ExprAff(b, a),
-                               ExprAff(c, b)],
+                              [ExprAssign(a, CST2),
+                               ExprAssign(b, a),
+                               ExprAssign(c, b)],
 
-                              [ExprAff(a, CST1),
-                               ExprAff(b, a),
-                               ExprAff(c, b)],
+                              [ExprAssign(a, CST1),
+                               ExprAssign(b, a),
+                               ExprAssign(c, b)],
 
-                              [ExprAff(ExprMem(d, 32), a+b+c)],
+                              [ExprAssign(ExprMem(d, 32), a+b+c)],
 
                          ])
 
@@ -624,34 +624,34 @@ G17_EXP_IRA = IRA.new_ircfg()
 
 G17_EXP_IRB0 = gen_irblock(LBL0, [[],
 
-                                  [ExprAff(d, d+ CST2)],
+                                  [ExprAssign(d, d+ CST2)],
 
-                                  [ExprAff(a, CST1)],
+                                  [ExprAssign(a, CST1)],
 
-                                  [ExprAff(ExprMem(d+CST1, 32), a)],
+                                  [ExprAssign(ExprMem(d+CST1, 32), a)],
 
-                                  [ExprAff(a, CST1)],
+                                  [ExprAssign(a, CST1)],
 
-                                  [ExprAff(ExprMem(d+CST2, 32), a)],
+                                  [ExprAssign(ExprMem(d+CST2, 32), a)],
 
-                                  [ExprAff(a, CST2)],
+                                  [ExprAssign(a, CST2)],
 
-                                  [ExprAff(a, a+CST1)],
+                                  [ExprAssign(a, a+CST1)],
 
-                                  [ExprAff(d, a)],
+                                  [ExprAssign(d, a)],
 
-                                  [ExprAff(d, d+CST1)],
+                                  [ExprAssign(d, d+CST1)],
 
-                                  [ExprAff(a, CST2)],
+                                  [ExprAssign(a, CST2)],
 
-                                  [ExprAff(a, a+CST2)],
+                                  [ExprAssign(a, a+CST2)],
 
-                                  [ExprAff(a, CST2),
-                                   ExprAff(b, a)],
+                                  [ExprAssign(a, CST2),
+                                   ExprAssign(b, a)],
 
-                                  [ExprAff(a, CST1),
-                                   ExprAff(b, a),
-                                   ExprAff(c, b)],
+                                  [ExprAssign(a, CST1),
+                                   ExprAssign(b, a),
+                                   ExprAssign(c, b)],
 
                                   G17_IRB0[14]
                                   # Trick because a+b+c != ((a+b)+c)

--- a/test/analysis/depgraph.py
+++ b/test/analysis/depgraph.py
@@ -1,5 +1,5 @@
 """Regression test module for DependencyGraph"""
-from miasm2.expression.expression import ExprId, ExprInt, ExprAff, ExprCond, \
+from miasm2.expression.expression import ExprId, ExprInt, ExprAssign, ExprCond, \
     ExprLoc, LocKey
 from miasm2.core.locationdb import LocationDB
 from miasm2.ir.analysis import ira
@@ -236,9 +236,9 @@ END = ExprId("END", IRDst.size)
 
 G1_IRA = IRA.new_ircfg()
 
-G1_IRB0 = gen_irblock(LBL0, [[ExprAff(C, CST1), ExprAff(IRDst, ExprLoc(LBL1, 32))]])
-G1_IRB1 = gen_irblock(LBL1, [[ExprAff(B, C), ExprAff(IRDst, ExprLoc(LBL2, 32))]])
-G1_IRB2 = gen_irblock(LBL2, [[ExprAff(A, B), ExprAff(IRDst, END)]])
+G1_IRB0 = gen_irblock(LBL0, [[ExprAssign(C, CST1), ExprAssign(IRDst, ExprLoc(LBL1, 32))]])
+G1_IRB1 = gen_irblock(LBL1, [[ExprAssign(B, C), ExprAssign(IRDst, ExprLoc(LBL2, 32))]])
+G1_IRB2 = gen_irblock(LBL2, [[ExprAssign(A, B), ExprAssign(IRDst, END)]])
 
 for irb in [G1_IRB0, G1_IRB1, G1_IRB2]:
     G1_IRA.add_irblock(irb)
@@ -247,9 +247,9 @@ for irb in [G1_IRB0, G1_IRB1, G1_IRB2]:
 
 G2_IRA = IRA.new_ircfg()
 
-G2_IRB0 = gen_irblock(LBL0, [[ExprAff(C, CST1), ExprAff(IRDst, ExprLoc(LBL1, 32))]])
-G2_IRB1 = gen_irblock(LBL1, [[ExprAff(B, CST2), ExprAff(IRDst, ExprLoc(LBL2, 32))]])
-G2_IRB2 = gen_irblock(LBL2, [[ExprAff(A, B + C), ExprAff(IRDst, END)]])
+G2_IRB0 = gen_irblock(LBL0, [[ExprAssign(C, CST1), ExprAssign(IRDst, ExprLoc(LBL1, 32))]])
+G2_IRB1 = gen_irblock(LBL1, [[ExprAssign(B, CST2), ExprAssign(IRDst, ExprLoc(LBL2, 32))]])
+G2_IRB2 = gen_irblock(LBL2, [[ExprAssign(A, B + C), ExprAssign(IRDst, END)]])
 
 for irb in [G2_IRB0, G2_IRB1, G2_IRB2]:
     G2_IRA.add_irblock(irb)
@@ -262,7 +262,7 @@ G3_IRA = IRA.new_ircfg()
 G3_IRB0 = gen_irblock(
     LBL0,
     [
-        [ExprAff(C, CST1), ExprAff(
+        [ExprAssign(C, CST1), ExprAssign(
             IRDst, ExprCond(
                 COND,
                 ExprLoc(LBL1, 32),
@@ -273,9 +273,9 @@ G3_IRB0 = gen_irblock(
     ]
 )
 
-G3_IRB1 = gen_irblock(LBL1, [[ExprAff(B, CST2), ExprAff(IRDst, ExprLoc(LBL3, 32))]])
-G3_IRB2 = gen_irblock(LBL2, [[ExprAff(B, CST3), ExprAff(IRDst, ExprLoc(LBL3, 32))]])
-G3_IRB3 = gen_irblock(LBL3, [[ExprAff(A, B + C), ExprAff(IRDst, END)]])
+G3_IRB1 = gen_irblock(LBL1, [[ExprAssign(B, CST2), ExprAssign(IRDst, ExprLoc(LBL3, 32))]])
+G3_IRB2 = gen_irblock(LBL2, [[ExprAssign(B, CST3), ExprAssign(IRDst, ExprLoc(LBL3, 32))]])
+G3_IRB3 = gen_irblock(LBL3, [[ExprAssign(A, B + C), ExprAssign(IRDst, END)]])
 
 for irb in [G3_IRB0, G3_IRB1, G3_IRB2, G3_IRB3]:
     G3_IRA.add_irblock(irb)
@@ -284,12 +284,12 @@ for irb in [G3_IRB0, G3_IRB1, G3_IRB2, G3_IRB3]:
 
 G4_IRA = IRA.new_ircfg()
 
-G4_IRB0 = gen_irblock(LBL0, [[ExprAff(C, CST1), ExprAff(IRDst, ExprLoc(LBL1, 32))]])
+G4_IRB0 = gen_irblock(LBL0, [[ExprAssign(C, CST1), ExprAssign(IRDst, ExprLoc(LBL1, 32))]])
 G4_IRB1 = gen_irblock(
     LBL1,
     [
-        [ExprAff(C, C + CST2)],
-        [ExprAff(IRDst,
+        [ExprAssign(C, C + CST2)],
+        [ExprAssign(IRDst,
                  ExprCond(
                      C,
                      ExprLoc(LBL2, 32),
@@ -298,7 +298,7 @@ G4_IRB1 = gen_irblock(
         ]]
 )
 
-G4_IRB2 = gen_irblock(LBL2, [[ExprAff(A, B), ExprAff(IRDst, END)]])
+G4_IRB2 = gen_irblock(LBL2, [[ExprAssign(A, B), ExprAssign(IRDst, END)]])
 
 for irb in [G4_IRB0, G4_IRB1, G4_IRB2]:
     G4_IRA.add_irblock(irb)
@@ -308,12 +308,12 @@ for irb in [G4_IRB0, G4_IRB1, G4_IRB2]:
 
 G5_IRA = IRA.new_ircfg()
 
-G5_IRB0 = gen_irblock(LBL0, [[ExprAff(B, CST1), ExprAff(IRDst, ExprLoc(LBL1, 32))]])
+G5_IRB0 = gen_irblock(LBL0, [[ExprAssign(B, CST1), ExprAssign(IRDst, ExprLoc(LBL1, 32))]])
 G5_IRB1 = gen_irblock(
     LBL1,
     [
-        [ExprAff(B, B + CST2)],
-        [ExprAff(
+        [ExprAssign(B, B + CST2)],
+        [ExprAssign(
             IRDst,
             ExprCond(
                 B,
@@ -325,7 +325,7 @@ G5_IRB1 = gen_irblock(
     ]
 )
 
-G5_IRB2 = gen_irblock(LBL2, [[ExprAff(A, B), ExprAff(IRDst, END)]])
+G5_IRB2 = gen_irblock(LBL2, [[ExprAssign(A, B), ExprAssign(IRDst, END)]])
 
 for irb in [G5_IRB0, G5_IRB1, G5_IRB2]:
     G5_IRA.add_irblock(irb)
@@ -334,8 +334,8 @@ for irb in [G5_IRB0, G5_IRB1, G5_IRB2]:
 
 G6_IRA = IRA.new_ircfg()
 
-G6_IRB0 = gen_irblock(LBL0, [[ExprAff(B, CST1), ExprAff(IRDst, ExprLoc(LBL1, 32))]])
-G6_IRB1 = gen_irblock(LBL1, [[ExprAff(A, B), ExprAff(IRDst, ExprLoc(LBL1, 32))]])
+G6_IRB0 = gen_irblock(LBL0, [[ExprAssign(B, CST1), ExprAssign(IRDst, ExprLoc(LBL1, 32))]])
+G6_IRB1 = gen_irblock(LBL1, [[ExprAssign(A, B), ExprAssign(IRDst, ExprLoc(LBL1, 32))]])
 
 for irb in [G6_IRB0, G6_IRB1]:
     G6_IRA.add_irblock(irb)
@@ -344,13 +344,13 @@ for irb in [G6_IRB0, G6_IRB1]:
 
 G7_IRA = IRA.new_ircfg()
 
-G7_IRB0 = gen_irblock(LBL0, [[ExprAff(C, CST1), ExprAff(IRDst, ExprLoc(LBL1, 32))]])
+G7_IRB0 = gen_irblock(LBL0, [[ExprAssign(C, CST1), ExprAssign(IRDst, ExprLoc(LBL1, 32))]])
 G7_IRB1 = gen_irblock(
     LBL1,
     [
-        [ExprAff(B, C)],
-        [ExprAff(A, B)],
-        [ExprAff(
+        [ExprAssign(B, C)],
+        [ExprAssign(A, B)],
+        [ExprAssign(
             IRDst,
             ExprCond(
                 COND,
@@ -362,7 +362,7 @@ G7_IRB1 = gen_irblock(
     ]
 )
 
-G7_IRB2 = gen_irblock(LBL2, [[ExprAff(D, A), ExprAff(IRDst, END)]])
+G7_IRB2 = gen_irblock(LBL2, [[ExprAssign(D, A), ExprAssign(IRDst, END)]])
 
 for irb in [G7_IRB0, G7_IRB1, G7_IRB2]:
     G7_IRA.add_irblock(irb)
@@ -371,13 +371,13 @@ for irb in [G7_IRB0, G7_IRB1, G7_IRB2]:
 
 G8_IRA = IRA.new_ircfg()
 
-G8_IRB0 = gen_irblock(LBL0, [[ExprAff(C, CST1), ExprAff(IRDst, ExprLoc(LBL1, 32))]])
+G8_IRB0 = gen_irblock(LBL0, [[ExprAssign(C, CST1), ExprAssign(IRDst, ExprLoc(LBL1, 32))]])
 G8_IRB1 = gen_irblock(
     LBL1,
     [
-        [ExprAff(B, C)],
-        [ExprAff(C, D),
-         ExprAff(
+        [ExprAssign(B, C)],
+        [ExprAssign(C, D),
+         ExprAssign(
              IRDst,
              ExprCond(
                  COND,
@@ -388,7 +388,7 @@ G8_IRB1 = gen_irblock(
         ]
     ]
 )
-G8_IRB2 = gen_irblock(LBL2, [[ExprAff(A, B), ExprAff(IRDst, END)]])
+G8_IRB2 = gen_irblock(LBL2, [[ExprAssign(A, B), ExprAssign(IRDst, END)]])
 
 for irb in [G8_IRB0, G8_IRB1, G8_IRB2]:
     G8_IRA.add_irblock(irb)
@@ -402,8 +402,8 @@ G10_IRA = IRA.new_ircfg()
 G10_IRB1 = gen_irblock(
     LBL1,
     [
-        [ExprAff(B, B + CST2),
-         ExprAff(
+        [ExprAssign(B, B + CST2),
+         ExprAssign(
              IRDst,
              ExprCond(
                  COND,
@@ -415,7 +415,7 @@ G10_IRB1 = gen_irblock(
     ]
 )
 
-G10_IRB2 = gen_irblock(LBL2, [[ExprAff(A, B), ExprAff(IRDst, END)]])
+G10_IRB2 = gen_irblock(LBL2, [[ExprAssign(A, B), ExprAssign(IRDst, END)]])
 
 for irb in [G10_IRB1, G10_IRB2]:
     G10_IRA.add_irblock(irb)
@@ -427,9 +427,9 @@ G11_IRA = IRA.new_ircfg()
 G11_IRB0 = gen_irblock(
     LBL0,
     [
-        [ExprAff(A, CST1),
-         ExprAff(B, CST2),
-         ExprAff(IRDst, ExprLoc(LBL1, 32))
+        [ExprAssign(A, CST1),
+         ExprAssign(B, CST2),
+         ExprAssign(IRDst, ExprLoc(LBL1, 32))
         ]
     ]
 )
@@ -437,14 +437,14 @@ G11_IRB0 = gen_irblock(
 G11_IRB1 = gen_irblock(
     LBL1,
     [
-        [ExprAff(A, B),
-         ExprAff(B, A),
-         ExprAff(IRDst, ExprLoc(LBL2, 32))
+        [ExprAssign(A, B),
+         ExprAssign(B, A),
+         ExprAssign(IRDst, ExprLoc(LBL2, 32))
         ]
     ]
 )
 
-G11_IRB2 = gen_irblock(LBL2, [[ExprAff(A, A - B), ExprAff(IRDst, END)]])
+G11_IRB2 = gen_irblock(LBL2, [[ExprAssign(A, A - B), ExprAssign(IRDst, END)]])
 
 for irb in [G11_IRB0, G11_IRB1, G11_IRB2]:
     G11_IRA.add_irblock(irb)
@@ -453,13 +453,13 @@ for irb in [G11_IRB0, G11_IRB1, G11_IRB2]:
 
 G12_IRA = IRA.new_ircfg()
 
-G12_IRB0 = gen_irblock(LBL0, [[ExprAff(B, CST1), ExprAff(IRDst, ExprLoc(LBL1, 32))]])
+G12_IRB0 = gen_irblock(LBL0, [[ExprAssign(B, CST1), ExprAssign(IRDst, ExprLoc(LBL1, 32))]])
 G12_IRB1 = gen_irblock(
     LBL1,
     [
-        [ExprAff(A, B)],
-        [ExprAff(B, B + CST2),
-         ExprAff(
+        [ExprAssign(A, B)],
+        [ExprAssign(B, B + CST2),
+         ExprAssign(
              IRDst,
              ExprCond(
                  COND,
@@ -471,7 +471,7 @@ G12_IRB1 = gen_irblock(
     ]
 )
 
-G12_IRB2 = gen_irblock(LBL2, [[ExprAff(B, A), ExprAff(IRDst, END)]])
+G12_IRB2 = gen_irblock(LBL2, [[ExprAssign(B, A), ExprAssign(IRDst, END)]])
 
 for irb in [G12_IRB0, G12_IRB1, G12_IRB2]:
     G12_IRA.add_irblock(irb)
@@ -481,13 +481,13 @@ for irb in [G12_IRB0, G12_IRB1, G12_IRB2]:
 
 G13_IRA = IRA.new_ircfg()
 
-G13_IRB0 = gen_irblock(LBL0, [[ExprAff(A, CST1)],
-                              #[ExprAff(B, A)],
-                              [ExprAff(IRDst,
+G13_IRB0 = gen_irblock(LBL0, [[ExprAssign(A, CST1)],
+                              #[ExprAssign(B, A)],
+                              [ExprAssign(IRDst,
                                        ExprLoc(LBL1, 32))]])
-G13_IRB1 = gen_irblock(LBL1, [[ExprAff(C, A)],
-                              #[ExprAff(A, A + CST1)],
-                              [ExprAff(IRDst,
+G13_IRB1 = gen_irblock(LBL1, [[ExprAssign(C, A)],
+                              #[ExprAssign(A, A + CST1)],
+                              [ExprAssign(IRDst,
                                        ExprCond(
                                            R,
                                            ExprLoc(LBL2, 32),
@@ -495,11 +495,11 @@ G13_IRB1 = gen_irblock(LBL1, [[ExprAff(C, A)],
                                        )
                               )]])
 
-G13_IRB2 = gen_irblock(LBL2, [[ExprAff(B, A + CST3)], [ExprAff(A, B + CST3)],
-                              [ExprAff(IRDst,
+G13_IRB2 = gen_irblock(LBL2, [[ExprAssign(B, A + CST3)], [ExprAssign(A, B + CST3)],
+                              [ExprAssign(IRDst,
                                        ExprLoc(LBL1, 32))]])
 
-G13_IRB3 = gen_irblock(LBL3, [[ExprAff(R, C), ExprAff(IRDst, END)]])
+G13_IRB3 = gen_irblock(LBL3, [[ExprAssign(R, C), ExprAssign(IRDst, END)]])
 
 for irb in [G13_IRB0, G13_IRB1, G13_IRB2, G13_IRB3]:
     G13_IRA.add_irblock(irb)
@@ -508,12 +508,12 @@ for irb in [G13_IRB0, G13_IRB1, G13_IRB2, G13_IRB3]:
 
 G14_IRA = IRA.new_ircfg()
 
-G14_IRB0 = gen_irblock(LBL0, [[ExprAff(A, CST1)],
-                              [ExprAff(IRDst,
+G14_IRB0 = gen_irblock(LBL0, [[ExprAssign(A, CST1)],
+                              [ExprAssign(IRDst,
                                        ExprLoc(LBL1, 32))]
                              ])
-G14_IRB1 = gen_irblock(LBL1, [[ExprAff(B, A)],
-                              [ExprAff(IRDst,
+G14_IRB1 = gen_irblock(LBL1, [[ExprAssign(B, A)],
+                              [ExprAssign(IRDst,
                                        ExprCond(
                                            C,
                                            ExprLoc(LBL2, 32),
@@ -523,13 +523,13 @@ G14_IRB1 = gen_irblock(LBL1, [[ExprAff(B, A)],
                               ]
                              ])
 
-G14_IRB2 = gen_irblock(LBL2, [[ExprAff(D, A)],
-                              [ExprAff(A, D + CST1)],
-                              [ExprAff(IRDst,
+G14_IRB2 = gen_irblock(LBL2, [[ExprAssign(D, A)],
+                              [ExprAssign(A, D + CST1)],
+                              [ExprAssign(IRDst,
                                        ExprLoc(LBL1, 32))]
                              ])
 
-G14_IRB3 = gen_irblock(LBL3, [[ExprAff(R, D + B), ExprAff(IRDst, END)]])
+G14_IRB3 = gen_irblock(LBL3, [[ExprAssign(R, D + B), ExprAssign(IRDst, END)]])
 
 for irb in [G14_IRB0, G14_IRB1, G14_IRB2, G14_IRB3]:
     G14_IRA.add_irblock(irb)
@@ -538,18 +538,18 @@ for irb in [G14_IRB0, G14_IRB1, G14_IRB2, G14_IRB3]:
 
 G15_IRA = IRA.new_ircfg()
 
-G15_IRB0 = gen_irblock(LBL0, [[ExprAff(A, CST1), ExprAff(IRDst, ExprLoc(LBL1, 32))]])
-G15_IRB1 = gen_irblock(LBL1, [[ExprAff(D, A + B)],
-                              [ExprAff(C, D)],
-                              [ExprAff(B, C),
-                               ExprAff(IRDst,
+G15_IRB0 = gen_irblock(LBL0, [[ExprAssign(A, CST1), ExprAssign(IRDst, ExprLoc(LBL1, 32))]])
+G15_IRB1 = gen_irblock(LBL1, [[ExprAssign(D, A + B)],
+                              [ExprAssign(C, D)],
+                              [ExprAssign(B, C),
+                               ExprAssign(IRDst,
                                        ExprCond(
                                            C,
                                            ExprLoc(LBL1, 32),
                                            ExprLoc(LBL2, 32)
                                        )
                                )]])
-G15_IRB2 = gen_irblock(LBL2, [[ExprAff(R, B), ExprAff(IRDst, END)]])
+G15_IRB2 = gen_irblock(LBL2, [[ExprAssign(R, B), ExprAssign(IRDst, END)]])
 
 for irb in [G15_IRB0, G15_IRB1, G15_IRB2]:
     G15_IRA.add_irblock(irb)
@@ -560,15 +560,15 @@ G16_IRA = IRA.new_ircfg()
 
 G16_IRB0 = gen_irblock(
     LBL0, [
-        [ExprAff(A, CST1), ExprAff(IRDst, ExprLoc(LBL1, 32))]
+        [ExprAssign(A, CST1), ExprAssign(IRDst, ExprLoc(LBL1, 32))]
     ]
 )
 
 G16_IRB1 = gen_irblock(
     LBL1,
     [
-        [ExprAff(R, D),
-         ExprAff(
+        [ExprAssign(R, D),
+         ExprAssign(
              IRDst,
              ExprCond(
                  C,
@@ -590,10 +590,10 @@ G16_IRB1 = gen_irblock(
 
 
 
-G16_IRB2 = gen_irblock(LBL2, [[ExprAff(D, A), ExprAff(IRDst, ExprLoc(LBL1, 32))]])
-G16_IRB3 = gen_irblock(LBL3, [[ExprAff(R, D), ExprAff(IRDst, ExprLoc(LBL1, 32))]])
-G16_IRB4 = gen_irblock(LBL4, [[ExprAff(R, A), ExprAff(IRDst, ExprLoc(LBL1, 32))]])
-G16_IRB5 = gen_irblock(LBL5, [[ExprAff(R, A), ExprAff(IRDst, ExprLoc(LBL1, 32))]])
+G16_IRB2 = gen_irblock(LBL2, [[ExprAssign(D, A), ExprAssign(IRDst, ExprLoc(LBL1, 32))]])
+G16_IRB3 = gen_irblock(LBL3, [[ExprAssign(R, D), ExprAssign(IRDst, ExprLoc(LBL1, 32))]])
+G16_IRB4 = gen_irblock(LBL4, [[ExprAssign(R, A), ExprAssign(IRDst, ExprLoc(LBL1, 32))]])
+G16_IRB5 = gen_irblock(LBL5, [[ExprAssign(R, A), ExprAssign(IRDst, ExprLoc(LBL1, 32))]])
 
 for irb in [G16_IRB0, G16_IRB1, G16_IRB2, G16_IRB3, G16_IRB4, G16_IRB5]:
     G16_IRA.add_irblock(irb)
@@ -602,14 +602,14 @@ for irb in [G16_IRB0, G16_IRB1, G16_IRB2, G16_IRB3, G16_IRB4, G16_IRB5]:
 
 G17_IRA = IRA.new_ircfg()
 
-G17_IRB0 = gen_irblock(LBL0, [[ExprAff(A, CST1),
-                               ExprAff(D, CST2),
-                               ExprAff(IRDst, ExprLoc(LBL1, 32))]])
-G17_IRB1 = gen_irblock(LBL1, [[ExprAff(A, D),
-                               ExprAff(B, D),
-                               ExprAff(IRDst, ExprLoc(LBL2, 32))]])
-G17_IRB2 = gen_irblock(LBL2, [[ExprAff(A, A - B),
-                               ExprAff(IRDst, END)]])
+G17_IRB0 = gen_irblock(LBL0, [[ExprAssign(A, CST1),
+                               ExprAssign(D, CST2),
+                               ExprAssign(IRDst, ExprLoc(LBL1, 32))]])
+G17_IRB1 = gen_irblock(LBL1, [[ExprAssign(A, D),
+                               ExprAssign(B, D),
+                               ExprAssign(IRDst, ExprLoc(LBL2, 32))]])
+G17_IRB2 = gen_irblock(LBL2, [[ExprAssign(A, A - B),
+                               ExprAssign(IRDst, END)]])
 
 G17_IRA.add_uniq_edge(G17_IRB0.loc_key, G17_IRB1.loc_key)
 G17_IRA.add_uniq_edge(G17_IRB1.loc_key, G17_IRB2.loc_key)

--- a/test/arch/mep/ir/ut_helpers_ir.py
+++ b/test/arch/mep/ir/ut_helpers_ir.py
@@ -10,7 +10,7 @@ from miasm2.core.locationdb import LocationDB
 from miasm2.core.utils import Disasm_Exception
 from miasm2.ir.ir import AssignBlock
 from miasm2.arch.mep.ira import ir_a_mepb
-from miasm2.expression.expression import ExprId, ExprInt, ExprOp, ExprMem, ExprAff, ExprLoc
+from miasm2.expression.expression import ExprId, ExprInt, ExprOp, ExprMem, ExprAssign, ExprLoc
 
 
 def exec_instruction(mn_str, init_values, results, index=0, offset=0):
@@ -36,7 +36,7 @@ def exec_instruction(mn_str, init_values, results, index=0, offset=0):
     iir, eiir = im.get_ir(instr)
 
     # Filter out IRDst
-    iir = [ir for ir in iir if not (isinstance(ir, ExprAff) and
+    iir = [ir for ir in iir if not (isinstance(ir, ExprAssign) and
                                     isinstance(ir.dst, ExprId) and
                                     ir.dst.name == "IRDst")]
 

--- a/test/expression/expr_pickle.py
+++ b/test/expression/expr_pickle.py
@@ -1,5 +1,5 @@
 import pickle
-from miasm2.expression.expression import ExprInt, ExprAff, ExprId, \
+from miasm2.expression.expression import ExprInt, ExprAssign, ExprId, \
     Expr, ExprCompose, ExprMem
 
 
@@ -9,7 +9,7 @@ c = a + b
 d = ExprCompose(a, b)
 e = ExprMem(a, 32)
 f = a[:8]
-aff = ExprAff(a, b)
+aff = ExprAssign(a, b)
 
 
 print 'Pickling'

--- a/test/expression/expression.py
+++ b/test/expression/expression.py
@@ -61,12 +61,12 @@ for expr in [
         A + cst1,
         ExprCompose(A, cst1),
         A.msb(),
-        ExprAff(A, cst1),
+        ExprAssign(A, cst1),
 ]:
     print repr(expr)
     assert expr == eval(repr(expr))
 
 
-aff = ExprAff(A[0:32], cst1)
+aff = ExprAssign(A[0:32], cst1)
 
 assert aff.dst == A and aff.src == cst1

--- a/test/expression/parser.py
+++ b/test/expression/parser.py
@@ -1,6 +1,6 @@
 from miasm2.expression.parser import str_to_expr
 from miasm2.expression.expression import ExprInt, ExprId, ExprSlice, ExprMem, \
-    ExprCond, ExprCompose, ExprOp, ExprAff, ExprLoc, LocKey
+    ExprCond, ExprCompose, ExprOp, ExprAssign, ExprLoc, LocKey
 
 for expr_test in [ExprInt(0x12, 32),
                   ExprId('test', 32),
@@ -10,7 +10,7 @@ for expr_test in [ExprInt(0x12, 32),
                   ExprCond(ExprInt(0x10, 32), ExprInt(0x11, 32), ExprInt(0x12, 32)),
                   ExprCompose(ExprInt(0x10, 16), ExprInt(0x11, 8), ExprInt(0x12, 8)),
                   ExprInt(0x11, 8) + ExprInt(0x12, 8),
-                  ExprAff(ExprId('EAX', 32),  ExprInt(0x12, 32)),
+                  ExprAssign(ExprId('EAX', 32),  ExprInt(0x12, 32)),
                   ]:
 
     print 'Test: %s' % expr_test

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -575,9 +575,9 @@ for test, res in match_tests:
 
 
 get_tests = [
-    (ExprAff(ExprMem(a, 32), ExprMem(b, 32)).get_r(True), set([a, b, ExprMem(b, 32)])),
-    (ExprAff(ExprMem(a, 32), ExprMem(b, 32)).get_w(), set([ExprMem(a, 32)])),
-    (ExprAff(ExprMem(ExprMem(a, 32), 32), ExprMem(b, 32))
+    (ExprAssign(ExprMem(a, 32), ExprMem(b, 32)).get_r(True), set([a, b, ExprMem(b, 32)])),
+    (ExprAssign(ExprMem(a, 32), ExprMem(b, 32)).get_w(), set([ExprMem(a, 32)])),
+    (ExprAssign(ExprMem(ExprMem(a, 32), 32), ExprMem(b, 32))
      .get_r(True), set([a, b, ExprMem(b, 32), ExprMem(a, 32)])),
 ]
 

--- a/test/ir/ir.py
+++ b/test/ir/ir.py
@@ -8,11 +8,11 @@ int0 = ExprInt(0, id_a.size)
 
 # Test AssignBlock
 ## Constructors
-assignblk1 = AssignBlock([ExprAff(id_a, id_b)])
+assignblk1 = AssignBlock([ExprAssign(id_a, id_b)])
 assignblk2 = AssignBlock({id_a: id_b})
 
 ## Equality
-assignblk1_bis = AssignBlock([ExprAff(id_a, id_b)])
+assignblk1_bis = AssignBlock([ExprAssign(id_a, id_b)])
 assert assignblk1 == assignblk1_bis
 assert assignblk1 == assignblk2
 

--- a/test/ir/reduce_graph.py
+++ b/test/ir/reduce_graph.py
@@ -1,7 +1,7 @@
 """Regression test module for DependencyGraph"""
 from pdb import pm
 
-from miasm2.expression.expression import ExprId, ExprInt, ExprAff, ExprCond, \
+from miasm2.expression.expression import ExprId, ExprInt, ExprAssign, ExprCond, \
     ExprLoc, LocKey
 
 from miasm2.core.locationdb import LocationDB
@@ -109,8 +109,8 @@ G1_IRB0 = gen_irblock(
     LBL0,
     [
         [
-            ExprAff(B, C),
-            ExprAff(IRDst, ExprLoc(LBL1, 32)),
+            ExprAssign(B, C),
+            ExprAssign(IRDst, ExprLoc(LBL1, 32)),
         ]
     ]
 )
@@ -119,7 +119,7 @@ G1_IRB1 = gen_irblock(
     LBL1,
     [
         [
-            ExprAff(IRDst, ExprLoc(LBL2, 32)),
+            ExprAssign(IRDst, ExprLoc(LBL2, 32)),
         ]
     ]
 )
@@ -128,8 +128,8 @@ G1_IRB2 = gen_irblock(
     LBL2,
     [
         [
-            ExprAff(A, B),
-            ExprAff(IRDst, C),
+            ExprAssign(A, B),
+            ExprAssign(IRDst, C),
         ]
     ]
 )
@@ -144,11 +144,11 @@ G1_RES_IRB0 = gen_irblock(
     LBL0,
     [
         [
-            ExprAff(B, C),
+            ExprAssign(B, C),
         ],
         [
-            ExprAff(A, B),
-            ExprAff(IRDst, C),
+            ExprAssign(A, B),
+            ExprAssign(IRDst, C),
         ]
 
     ]
@@ -176,7 +176,7 @@ G2_IRB0 = gen_irblock(
     LBL0,
     [
         [
-            ExprAff(IRDst, ExprLoc(LBL1, 32)),
+            ExprAssign(IRDst, ExprLoc(LBL1, 32)),
         ]
     ]
 )
@@ -185,8 +185,8 @@ G2_IRB1 = gen_irblock(
     LBL1,
     [
         [
-            ExprAff(A, C),
-            ExprAff(IRDst, C),
+            ExprAssign(A, C),
+            ExprAssign(IRDst, C),
         ]
     ]
 )
@@ -202,8 +202,8 @@ G2_RES_IRB0 = gen_irblock(
     LBL0,
     [
         [
-            ExprAff(A, C),
-            ExprAff(IRDst, C),
+            ExprAssign(A, C),
+            ExprAssign(IRDst, C),
         ]
     ]
 )
@@ -222,7 +222,7 @@ G3_IRB0 = gen_irblock(
     LBL0,
     [
         [
-            ExprAff(IRDst, ExprLoc(LBL1, 32)),
+            ExprAssign(IRDst, ExprLoc(LBL1, 32)),
         ]
     ]
 )
@@ -231,8 +231,8 @@ G3_IRB1 = gen_irblock(
     LBL1,
     [
         [
-            ExprAff(A, C),
-            ExprAff(IRDst, ExprLoc(LBL2, 32)),
+            ExprAssign(A, C),
+            ExprAssign(IRDst, ExprLoc(LBL2, 32)),
         ]
     ]
 )
@@ -241,8 +241,8 @@ G3_IRB2 = gen_irblock(
     LBL2,
     [
         [
-            ExprAff(D, A),
-            ExprAff(IRDst, C),
+            ExprAssign(D, A),
+            ExprAssign(IRDst, C),
         ]
     ]
 )
@@ -259,11 +259,11 @@ G3_RES_IRB0 = gen_irblock(
     LBL0,
     [
         [
-            ExprAff(A, C),
+            ExprAssign(A, C),
         ],
         [
-            ExprAff(D, A),
-            ExprAff(IRDst, C),
+            ExprAssign(D, A),
+            ExprAssign(IRDst, C),
         ]
     ]
 )
@@ -284,7 +284,7 @@ G4_IRB0 = gen_irblock(
     LBL0,
     [
         [
-            ExprAff(IRDst, ExprLoc(LBL1, 32)),
+            ExprAssign(IRDst, ExprLoc(LBL1, 32)),
         ]
     ]
 )
@@ -293,8 +293,8 @@ G4_IRB1 = gen_irblock(
     LBL1,
     [
         [
-            ExprAff(A, C),
-            ExprAff(IRDst, ExprLoc(LBL2, 32)),
+            ExprAssign(A, C),
+            ExprAssign(IRDst, ExprLoc(LBL2, 32)),
         ]
     ]
 )
@@ -303,8 +303,8 @@ G4_IRB2 = gen_irblock(
     LBL2,
     [
         [
-            ExprAff(D, A),
-            ExprAff(IRDst, ExprLoc(LBL1, 32)),
+            ExprAssign(D, A),
+            ExprAssign(IRDst, ExprLoc(LBL1, 32)),
         ]
     ]
 )
@@ -321,11 +321,11 @@ G4_RES_IRB0 = gen_irblock(
     LBL0,
     [
         [
-            ExprAff(A, C),
+            ExprAssign(A, C),
         ],
         [
-            ExprAff(D, A),
-            ExprAff(IRDst, ExprLoc(LBL0, 32)),
+            ExprAssign(D, A),
+            ExprAssign(IRDst, ExprLoc(LBL0, 32)),
         ]
     ]
 )
@@ -345,7 +345,7 @@ G5_IRB0 = gen_irblock(
     LBL0,
     [
         [
-            ExprAff(IRDst, ExprLoc(LBL1, 32)),
+            ExprAssign(IRDst, ExprLoc(LBL1, 32)),
         ]
     ]
 )
@@ -354,8 +354,8 @@ G5_IRB1 = gen_irblock(
     LBL1,
     [
         [
-            ExprAff(A, C),
-            ExprAff(IRDst, ExprLoc(LBL2, 32)),
+            ExprAssign(A, C),
+            ExprAssign(IRDst, ExprLoc(LBL2, 32)),
         ]
     ]
 )
@@ -364,8 +364,8 @@ G5_IRB2 = gen_irblock(
     LBL2,
     [
         [
-            ExprAff(D, A),
-            ExprAff(IRDst, ExprCond(C, ExprLoc(LBL1, 32), ExprLoc(LBL3, 32))),
+            ExprAssign(D, A),
+            ExprAssign(IRDst, ExprCond(C, ExprLoc(LBL1, 32), ExprLoc(LBL3, 32))),
         ]
     ]
 )
@@ -375,8 +375,8 @@ G5_IRB3 = gen_irblock(
     LBL3,
     [
         [
-            ExprAff(D, A),
-            ExprAff(IRDst, C),
+            ExprAssign(D, A),
+            ExprAssign(IRDst, C),
         ]
     ]
 )
@@ -393,11 +393,11 @@ G5_RES_IRB0 = gen_irblock(
     LBL0,
     [
         [
-            ExprAff(A, C),
+            ExprAssign(A, C),
         ],
         [
-            ExprAff(D, A),
-            ExprAff(IRDst, ExprCond(C, ExprLoc(LBL0, 32), ExprLoc(LBL3, 32))),
+            ExprAssign(D, A),
+            ExprAssign(IRDst, ExprCond(C, ExprLoc(LBL0, 32), ExprLoc(LBL3, 32))),
         ]
     ]
 )
@@ -407,8 +407,8 @@ G5_RES_IRB3 = gen_irblock(
     LBL3,
     [
         [
-            ExprAff(D, A),
-            ExprAff(IRDst, C),
+            ExprAssign(D, A),
+            ExprAssign(IRDst, C),
         ]
     ]
 )
@@ -427,7 +427,7 @@ G6_IRB0 = gen_irblock(
     LBL0,
     [
         [
-            ExprAff(IRDst, ExprCond(C, ExprLoc(LBL1, 32), ExprLoc(LBL2, 32))),
+            ExprAssign(IRDst, ExprCond(C, ExprLoc(LBL1, 32), ExprLoc(LBL2, 32))),
         ]
     ]
 )
@@ -436,7 +436,7 @@ G6_IRB1 = gen_irblock(
     LBL1,
     [
         [
-            ExprAff(IRDst, ExprLoc(LBL3, 32)),
+            ExprAssign(IRDst, ExprLoc(LBL3, 32)),
         ]
     ]
 )
@@ -445,8 +445,8 @@ G6_IRB2 = gen_irblock(
     LBL2,
     [
         [
-            ExprAff(D, A),
-            ExprAff(IRDst, D),
+            ExprAssign(D, A),
+            ExprAssign(IRDst, D),
         ]
     ]
 )
@@ -456,8 +456,8 @@ G6_IRB3 = gen_irblock(
     LBL3,
     [
         [
-            ExprAff(A, D),
-            ExprAff(IRDst, ExprLoc(LBL3, 32)),
+            ExprAssign(A, D),
+            ExprAssign(IRDst, ExprLoc(LBL3, 32)),
         ]
     ]
 )
@@ -474,7 +474,7 @@ G6_RES_IRB0 = gen_irblock(
     LBL0,
     [
         [
-            ExprAff(IRDst, ExprCond(C, ExprLoc(LBL3, 32), ExprLoc(LBL2, 32))),
+            ExprAssign(IRDst, ExprCond(C, ExprLoc(LBL3, 32), ExprLoc(LBL2, 32))),
         ]
     ]
 )
@@ -484,8 +484,8 @@ G6_RES_IRB2 = gen_irblock(
     LBL2,
     [
         [
-            ExprAff(D, A),
-            ExprAff(IRDst, D),
+            ExprAssign(D, A),
+            ExprAssign(IRDst, D),
         ]
     ]
 )
@@ -495,8 +495,8 @@ G6_RES_IRB3 = gen_irblock(
     LBL3,
     [
         [
-            ExprAff(A, D),
-            ExprAff(IRDst, ExprLoc(LBL3, 32)),
+            ExprAssign(A, D),
+            ExprAssign(IRDst, ExprLoc(LBL3, 32)),
         ]
     ]
 )
@@ -517,8 +517,8 @@ G7_IRB0 = gen_irblock(
     LBL0,
     [
         [
-            ExprAff(A, C),
-            ExprAff(IRDst, ExprLoc(LBL1, 32)),
+            ExprAssign(A, C),
+            ExprAssign(IRDst, ExprLoc(LBL1, 32)),
         ]
     ]
 )
@@ -527,7 +527,7 @@ G7_IRB1 = gen_irblock(
     LBL1,
     [
         [
-            ExprAff(IRDst, ExprLoc(LBL1, 32)),
+            ExprAssign(IRDst, ExprLoc(LBL1, 32)),
         ]
     ]
 )
@@ -546,8 +546,8 @@ G7_RES_IRB0 = gen_irblock(
     LBL0,
     [
         [
-            ExprAff(A, C),
-            ExprAff(IRDst, ExprLoc(LBL1, 32)),
+            ExprAssign(A, C),
+            ExprAssign(IRDst, ExprLoc(LBL1, 32)),
         ]
     ]
 )
@@ -556,7 +556,7 @@ G7_RES_IRB1 = gen_irblock(
     LBL1,
     [
         [
-            ExprAff(IRDst, ExprLoc(LBL1, 32)),
+            ExprAssign(IRDst, ExprLoc(LBL1, 32)),
         ]
     ]
 )
@@ -576,7 +576,7 @@ G8_IRB0 = gen_irblock(
     LBL0,
     [
         [
-            ExprAff(IRDst, ExprLoc(LBL1, 32)),
+            ExprAssign(IRDst, ExprLoc(LBL1, 32)),
         ]
     ]
 )
@@ -585,8 +585,8 @@ G8_IRB1 = gen_irblock(
     LBL1,
     [
         [
-            ExprAff(A, C),
-            ExprAff(IRDst, ExprLoc(LBL1, 32)),
+            ExprAssign(A, C),
+            ExprAssign(IRDst, ExprLoc(LBL1, 32)),
         ]
     ]
 )
@@ -605,8 +605,8 @@ G8_RES_IRB0 = gen_irblock(
     LBL0,
     [
         [
-            ExprAff(A, C),
-            ExprAff(IRDst, ExprLoc(LBL0, 32)),
+            ExprAssign(A, C),
+            ExprAssign(IRDst, ExprLoc(LBL0, 32)),
         ]
     ]
 )

--- a/test/ir/symbexec.py
+++ b/test/ir/symbexec.py
@@ -8,7 +8,7 @@ class TestSymbExec(unittest.TestCase):
 
     def test_ClassDef(self):
         from miasm2.expression.expression import ExprInt, ExprId, ExprMem, \
-            ExprCompose, ExprAff
+            ExprCompose, ExprAssign
         from miasm2.arch.x86.sem import ir_x86_32
         from miasm2.core.locationdb import LocationDB
         from miasm2.ir.symbexec import SymbolicExecutionEngine
@@ -128,7 +128,7 @@ class TestSymbExec(unittest.TestCase):
         self.assertEqual(sb.eval_expr(id_x), id_a)
 
         ## x = a (with a = 0x0)
-        self.assertEqual(sb.eval_updt_expr(assignblk.dst2ExprAff(id_x)), ExprInt(0, 32))
+        self.assertEqual(sb.eval_updt_expr(assignblk.dst2ExprAssign(id_x)), ExprInt(0, 32))
         self.assertEqual(sb.eval_expr(id_x), ExprInt(0, 32))
         self.assertEqual(sb.eval_updt_expr(id_x), ExprInt(0, 32))
 
@@ -137,7 +137,7 @@ class TestSymbExec(unittest.TestCase):
         ## state
         reads = set()
         for dst, src in sb.modified():
-            reads.update(ExprAff(dst, src).get_r())
+            reads.update(ExprAssign(dst, src).get_r())
 
         self.assertEqual(reads, set([
             id_x, id_a,

--- a/test/ir/translators/smt2.py
+++ b/test/ir/translators/smt2.py
@@ -19,7 +19,7 @@ right = ExprCond(cond,
                  a + ExprInt(0x64L, 64),
                  ExprInt(0x16L, 64))
 
-e = ExprAff(left, right)
+e = ExprAssign(left, right)
 
 # initialise translators
 t_z3 = TranslatorZ3()

--- a/test/jitter/jitload.py
+++ b/test/jitter/jitload.py
@@ -3,7 +3,7 @@ from pdb import pm
 
 from miasm2.jitter.csts import PAGE_READ, PAGE_WRITE
 from miasm2.analysis.machine import Machine
-from miasm2.expression.expression import ExprId, ExprAff, ExprInt, ExprMem
+from miasm2.expression.expression import ExprId, ExprAssign, ExprInt, ExprMem
 
 # Initial data: from 'example/samples/x86_32_sc.bin'
 data = "8d49048d5b0180f90174058d5bffeb038d5b0189d8c3".decode("hex")
@@ -40,8 +40,8 @@ eax = ExprId("RAX", 64)[:32]
 imm0, imm4, imm4_64 = ExprInt(0, 32), ExprInt(4, 32), ExprInt(4, 64)
 memdata = ExprMem(ExprInt(run_addr, 32), len(data) * 8)
 assert myjit.eval_expr(eax) == imm0
-## Due to ExprAff construction, imm4 is "promoted" to imm4_64
-assert myjit.eval_expr(ExprAff(eax, imm4)) == imm4_64
+## Due to ExprAssign construction, imm4 is "promoted" to imm4_64
+assert myjit.eval_expr(ExprAssign(eax, imm4)) == imm4_64
 assert myjit.eval_expr(eax) == imm4
 ## Changes must be passed on myjit.cpu instance
 assert myjit.cpu.EAX == 4


### PR DESCRIPTION
Expresion: use ExprAssign instead of ExprAff

ExprAff stands for (in french) "Expression affectation"
We will now use ExprAssign (for Expression Assignment)
(instead of ExprAss)
