### PR TITLE
In ARM & Aarch64 MSR and MRS instructions' exception wrong names used

### DIFF
--- a/miasm2/arch/aarch64/sem.py
+++ b/miasm2/arch/aarch64/sem.py
@@ -723,7 +723,7 @@ def mrs(ir, insr, arg1, arg2, arg3, arg4, arg5):
         out.append(nf)
         e.append(ExprAff(arg1, ExprCompose(*out).zeroExtend(arg1.size)))
     else:
-        raise NotImplementedError("MSR not implemented")
+        raise NotImplementedError("MRS not implemented")
     return e, []
 
 def msr(ir, instr, arg1, arg2, arg3, arg4, arg5):
@@ -735,7 +735,7 @@ def msr(ir, instr, arg1, arg2, arg3, arg4, arg5):
         e.append(ExprAff(cf, arg5[29:30]))
         e.append(ExprAff(of, arg5[28:29]))
     else:
-        raise NotImplementedError("MRS not implemented")
+        raise NotImplementedError("MSR not implemented")
     return e, []
 
 

--- a/miasm2/arch/arm/sem.py
+++ b/miasm2/arch/arm/sem.py
@@ -525,7 +525,7 @@ def mrs(ir, instr, a, b):
         out.append(nf)
         e.append(ExprAff(a, ExprCompose(*out)))
     else:
-        raise NotImplementedError("MSR not implemented")
+        raise NotImplementedError("MRS not implemented")
     return e, []
 
 def msr(ir, instr, a, b):
@@ -536,7 +536,7 @@ def msr(ir, instr, a, b):
         e.append(ExprAff(cf, b[29:30]))
         e.append(ExprAff(of, b[28:29]))
     else:
-        raise NotImplementedError("MRS not implemented")
+        raise NotImplementedError("MSR not implemented")
     return e, []
 
 


### PR DESCRIPTION
A minor bug fix, in ARM and Aarch64, in the respective exceptions of MRS and MSR, instruction names have been interchanged. Fixed it in the PR. 