### PR TITLE
Expression: replace arg by ptr in ExprMem

### DIFF
--- a/example/expression/graph_dataflow.py
+++ b/example/expression/graph_dataflow.py
@@ -50,7 +50,7 @@ def intra_block_flow_symb(ir_arch, _, flow_graph, irblock, in_nodes, out_nodes):
             node_n_w = get_node_name(irblock.loc_key, 0, n)
             if not n == src:
                 continue
-            o_r = n.arg.get_r(mem_read=False, cst_read=True)
+            o_r = n.ptr.get_r(mem_read=False, cst_read=True)
             for i, n_r in enumerate(o_r):
                 if n_r in current_nodes:
                     node_n_r = current_nodes[n_r]

--- a/miasm2/analysis/cst_propag.py
+++ b/miasm2/analysis/cst_propag.py
@@ -98,7 +98,7 @@ class SymbExecStateFix(SymbolicExecutionEngine):
             for dst, src in assignblk.iteritems():
                 src = self.propag_expr_cst(src)
                 if dst.is_mem():
-                    ptr = dst.arg
+                    ptr = dst.ptr
                     ptr = self.propag_expr_cst(ptr)
                     dst = ExprMem(ptr, dst.size)
                 new_assignblk[dst] = src

--- a/miasm2/analysis/data_analysis.py
+++ b/miasm2/analysis/data_analysis.py
@@ -29,7 +29,7 @@ def intra_block_flow_raw(ir_arch, ircfg, flow_graph, irb, in_nodes, out_nodes):
                 node_n_w = get_node_name(irb.loc_key, i, n)
                 if not n in nodes_r:
                     continue
-                o_r = n.arg.get_r(mem_read=False, cst_read=True)
+                o_r = n.ptr.get_r(mem_read=False, cst_read=True)
                 for n_r in o_r:
                     if n_r in current_nodes:
                         node_n_r = current_nodes[n_r]

--- a/miasm2/analysis/data_flow.py
+++ b/miasm2/analysis/data_flow.py
@@ -159,7 +159,7 @@ class DiGraphDefUse(DiGraph):
 
                 read_vars = expr.get_r(mem_read=deref_mem)
                 if deref_mem and lval.is_mem():
-                    read_vars.update(lval.arg.get_r(mem_read=deref_mem))
+                    read_vars.update(lval.ptr.get_r(mem_read=deref_mem))
                 for read_var in read_vars:
                     for reach in assignblk_reaching_defs.get(read_var, set()):
                         self.add_data_edge(AssignblkNode(reach[0], reach[1], read_var),
@@ -538,7 +538,7 @@ class SSADefUse(DiGraph):
         lbl, index, dst = node
         sources = set()
         if dst.is_mem():
-            sources.update(dst.arg.get_r(mem_read=True))
+            sources.update(dst.ptr.get_r(mem_read=True))
         sources.update(src.get_r(mem_read=True))
         for source in sources:
             if not source.is_mem():
@@ -741,7 +741,7 @@ class PropagateExpr(object):
                         continue
 
                     if src.is_mem():
-                        ptr = src.arg
+                        ptr = src.ptr
                         ptr = ptr.replace_expr(replace)
                         new_src = ExprMem(ptr, src.size)
                     else:
@@ -750,7 +750,7 @@ class PropagateExpr(object):
                     if dst.is_id():
                         new_dst = dst
                     elif dst.is_mem():
-                        ptr = dst.arg
+                        ptr = dst.ptr
                         ptr = ptr.replace_expr(replace)
                         new_dst = ExprMem(ptr, dst.size)
                     else:
@@ -933,8 +933,8 @@ def replace_stack_vars(ir_arch_a, ssa):
 
 
 def memlookup_test(expr, bs, is_addr_ro_variable, result):
-    if expr.is_mem() and expr.arg.is_int():
-        ptr = int(expr.arg)
+    if expr.is_mem() and expr.ptr.is_int():
+        ptr = int(expr.ptr)
         if is_addr_ro_variable(bs, ptr, expr.size):
             result.add(expr)
         return False
@@ -953,7 +953,7 @@ def get_memlookup(expr, bs, is_addr_ro_variable):
 
 
 def read_mem(bs, expr):
-    ptr = int(expr.arg)
+    ptr = int(expr.ptr)
     var_bytes = bs.getbytes(ptr, expr.size / 8)[::-1]
     try:
         value = int(var_bytes.encode('hex'), 16)
@@ -989,7 +989,7 @@ def load_from_int(ir_arch, bs, is_addr_ro_variable):
                         modified = True
                 # Test dst pointer if dst is mem
                 if dst.is_mem():
-                    ptr = dst.arg
+                    ptr = dst.ptr
                     mems = get_memlookup(ptr, bs, is_addr_ro_variable)
                     if mems:
                         replace = {}

--- a/miasm2/analysis/dse.py
+++ b/miasm2/analysis/dse.py
@@ -105,9 +105,9 @@ class ESETrackModif(EmulatedSymbExec):
                                        # symbolize
 
     def _func_read(self, expr_mem):
-        if not expr_mem.arg.is_int():
+        if not expr_mem.ptr.is_int():
             return expr_mem
-        dst_addr = int(expr_mem.arg)
+        dst_addr = int(expr_mem.ptr)
 
         if not self.dse_memory_range:
             # Trivial case (optimization)
@@ -121,7 +121,7 @@ class ESETrackModif(EmulatedSymbExec):
                 out.append(self.dse_memory_to_expr(addr))
             else:
                 # Get concrete value
-                atomic_access = ExprMem(ExprInt(addr, expr_mem.arg.size), 8)
+                atomic_access = ExprMem(ExprInt(addr, expr_mem.ptr.size), 8)
                 out.append(super(ESETrackModif, self)._func_read(atomic_access))
 
         if len(out) == 1:
@@ -284,8 +284,8 @@ class DSEEngine(object):
                     value = getattr(self.jitter.cpu, symbol.name)
                     if value != symb_value:
                         errors.append(DriftInfo(symbol, symb_value, value))
-            elif symbol.is_mem() and symbol.arg.is_int():
-                value_chr = self.jitter.vm.get_mem(int(symbol.arg),
+            elif symbol.is_mem() and symbol.ptr.is_int():
+                value_chr = self.jitter.vm.get_mem(int(symbol.ptr),
                                                    symbol.size / 8)
                 exp_value = int(value_chr[::-1].encode("hex"), 16)
                 if exp_value != symb_value:
@@ -638,7 +638,7 @@ class DSEPathConstraint(DSEEngine):
                     mem.update(eaff.src.get_r(mem_read=True))
                     for expr in mem:
                         if expr.is_mem():
-                            addr_range = expr_range(expr.arg)
+                            addr_range = expr_range(expr.ptr)
                             # At upper bounds, add the size of the memory access
                             # if addr (- [a, b], then @size[addr] reachables
                             # values are in @8[a, b + size[

--- a/miasm2/arch/arm/arch.py
+++ b/miasm2/arch/arm/arch.py
@@ -385,7 +385,7 @@ class instruction_arm(instruction):
         if not isinstance(expr, ExprMem):
             return str(expr)
 
-        expr = expr.arg
+        expr = expr.ptr
         if isinstance(expr, ExprOp) and expr.op == 'wback':
             wb = True
             expr = expr.args[0]
@@ -946,7 +946,7 @@ class arm_imm8_12(arm_arg):
         e = self.expr
         if not isinstance(e, ExprMem):
             return False
-        e = e.arg
+        e = e.ptr
         if isinstance(e, ExprOp) and e.op == 'wback':
             self.parent.wback.value = 1
             e = e.args[0]
@@ -1171,7 +1171,7 @@ class arm_op2imm(arm_imm8_12):
 
         e = self.expr
         assert(isinstance(e, ExprMem))
-        e = e.arg
+        e = e.ptr
         if e.op == 'wback':
             self.parent.wback.value = 1
             e = e.args[0]
@@ -1481,7 +1481,7 @@ class arm_immed(arm_arg):
         e = self.expr
         if not isinstance(e, ExprMem):
             return False
-        e = e.arg
+        e = e.ptr
         if isinstance(e, ExprOp) and e.op == 'wback':
             self.parent.wback.value = 1
             e = e.args[0]
@@ -1570,7 +1570,7 @@ class arm_mem_rn_imm(arm_arg):
         expr = self.expr
         if not isinstance(expr, ExprMem):
             return False
-        ptr = expr.arg
+        ptr = expr.ptr
         if ptr in gpregs.expr:
             self.value = gpregs.expr.index(ptr)
         elif (isinstance(ptr, ExprOp) and
@@ -1865,7 +1865,7 @@ class arm_offpc(arm_offreg):
         else:
             self.expr = ExprMem(self.off_reg, 32)
 
-        e = self.expr.arg
+        e = self.expr.ptr
         if isinstance(e, ExprOp) and e.op == 'wback':
             self.parent.wback.value = 1
             e = e.args[0]
@@ -1875,7 +1875,7 @@ class arm_offpc(arm_offreg):
         e = self.expr
         if not isinstance(e, ExprMem):
             return False
-        e = e.arg
+        e = e.ptr
         if not (isinstance(e, ExprOp) and e.op == "preinc"):
             log.debug('cannot encode %r', e)
             return False
@@ -1949,7 +1949,7 @@ class arm_deref_reg_imm(arm_arg):
         e = self.expr
         if not isinstance(e, ExprMem):
             return False
-        e = e.arg
+        e = e.ptr
         if not (isinstance(e, ExprOp) and e.op == 'preinc'):
             log.debug('cannot encode %r', e)
             return False
@@ -2733,7 +2733,7 @@ class armt2_imm6_11l(arm_imm):
         v = self.expr.arg.arg - 4
         s = 0
         if v != sign_ext(v & ((1 << 22) - 1), 21, 32):
-            return False 
+            return False
         if v & 0x80000000:
             s = 1
         v &= (1<<22) - 1
@@ -2961,7 +2961,7 @@ class armt_op2imm(arm_imm8_12):
 
         e = self.expr
         assert(isinstance(e, ExprMem))
-        e = e.arg
+        e = e.ptr
         if e.op == 'wback':
             self.parent.wback.value = 1
             e = e.args[0]
@@ -3034,7 +3034,7 @@ class armt_deref_reg(arm_imm8_12):
     def encode(self):
         if not isinstance(self.expr, ExprMem):
             return False
-        ptr = self.expr.arg
+        ptr = self.expr.ptr
         if not ptr.is_op('preinc'):
             return False
         if len(ptr.args) != 2:
@@ -3074,7 +3074,7 @@ class armt_deref_reg_reg(arm_arg):
         expr = self.expr
         if not expr.is_mem():
             return False
-        ptr = expr.arg
+        ptr = expr.ptr
         if not ptr.is_op('+') or len(ptr.args) != 2:
             return False
         reg1, reg2 = ptr.args
@@ -3097,7 +3097,7 @@ class armt_deref_reg_reg_lsl_1(arm_reg):
         expr = self.expr
         if not expr.is_mem():
             return False
-        ptr = expr.arg
+        ptr = expr.ptr
         if not ptr.is_op('+') or len(ptr.args) != 2:
             return False
         reg1, reg_shift = ptr.args

--- a/miasm2/arch/arm/sem.py
+++ b/miasm2/arch/arm/sem.py
@@ -761,7 +761,7 @@ def st_ld_r(ir, instr, a, a2, b, store=False, size=32, s_ext=False, z_ext=False)
     wb = False
     b = b.copy()
     postinc = False
-    b = b.arg
+    b = b.ptr
     if isinstance(b, ExprOp):
         if b.op == "wback":
             wb = True

--- a/miasm2/arch/mep/arch.py
+++ b/miasm2/arch/mep/arch.py
@@ -85,11 +85,11 @@ class instruction_mep(instruction):
             else:
                 return str(expr)
 
-        elif isinstance(expr, ExprMem) and (isinstance(expr.arg, ExprId) or isinstance(expr.arg, ExprInt)):
-            return "(%s)" % expr.arg
+        elif isinstance(expr, ExprMem) and (isinstance(expr.ptr, ExprId) or isinstance(expr.ptr, ExprInt)):
+            return "(%s)" % expr.ptr
 
-        elif isinstance(expr, ExprMem) and isinstance(expr.arg, ExprOp):
-            return "0x%X(%s)" % (expr.arg.args[1].arg, expr.arg.args[0])
+        elif isinstance(expr, ExprMem) and isinstance(expr.ptr, ExprOp):
+            return "0x%X(%s)" % (expr.ptr.args[1].arg, expr.ptr.args[0])
 
         # Raise an exception if the expression type was not processed
         message = "instruction_mep.arg2str(): don't know what \
@@ -133,18 +133,18 @@ class instruction_mep(instruction):
             o += ", %s" % ExprInt2SignedString(self.args[2].arg)
 
         elif len(self.args) == 2 and self.name in ["SB", "SH", "LBU", "LB", "LH", "LW"] and \
-                isinstance(self.args[1], ExprMem) and isinstance(self.args[1].arg, ExprOp):  # Major Opcodes #12
+                isinstance(self.args[1], ExprMem) and isinstance(self.args[1].ptr, ExprOp):  # Major Opcodes #12
             # The second operand is an offset to a register
             o += " " + self.arg2str(self.args[0])
-            o += ", %s" % ExprInt2SignedString(self.args[1].arg.args[1], "0x%X")
-            o += "(%s)" % self.arg2str(self.args[1].arg.args[0])
+            o += ", %s" % ExprInt2SignedString(self.args[1].ptr.args[1], "0x%X")
+            o += "(%s)" % self.arg2str(self.args[1].ptr.args[0])
 
         elif len(self.args) == 2 and self.name in ["SWCP", "LWCP", "SMCP", "LMCP"] \
-                and isinstance(self.args[1], ExprMem) and isinstance(self.args[1].arg, ExprOp):  # Major Opcodes #12
+                and isinstance(self.args[1], ExprMem) and isinstance(self.args[1].ptr, ExprOp):  # Major Opcodes #12
             # The second operand is an offset to a register
             o += " " + self.arg2str(self.args[0])
-            o += ", %s" % ExprInt2SignedString(self.args[1].arg.args[1])
-            o += "(%s)" % self.arg2str(self.args[1].arg.args[0])
+            o += ", %s" % ExprInt2SignedString(self.args[1].ptr.args[1])
+            o += "(%s)" % self.arg2str(self.args[1].ptr.args[0])
 
         elif self.name == "SLL" and isinstance(self.args[1], ExprInt):  # Major Opcodes #6
             # The second operand is displayed in hex, not in decimal
@@ -605,11 +605,11 @@ class mep_deref_reg(mep_arg):
 
         if not isinstance(self.expr, ExprMem):
             return False
-        if not isinstance(self.expr.arg, ExprId):
+        if not isinstance(self.expr.ptr, ExprId):
             return False
 
         # Get the ExprId index, i.e. its value
-        self.value = gpr_exprs.index(self.expr.arg)
+        self.value = gpr_exprs.index(self.expr.ptr)
         return True
 
 
@@ -666,14 +666,14 @@ class mep_deref_reg_offset(mep_arg):
         # Verify the expression
         if not isinstance(self.expr, ExprMem):
             return False
-        if not isinstance(self.expr.arg, ExprOp):
+        if not isinstance(self.expr.ptr, ExprOp):
             return False
 
         # Get the integer and check the upper bound
-        v = int(self.expr.arg.args[1].arg & 0xFFFF)
+        v = int(self.expr.ptr.args[1].arg & 0xFFFF)
 
         # Encode the values
-        self.parent.reg04_deref.value = gpr_exprs.index(self.expr.arg.args[0])
+        self.parent.reg04_deref.value = gpr_exprs.index(self.expr.ptr.args[0])
         self.value = v & 0xFFFF
         return True
 
@@ -726,15 +726,15 @@ class mep_deref_sp_offset(mep_deref_reg):
         # Verify the expression
         if not isinstance(self.expr, ExprMem):
             return False
-        if not isinstance(self.expr.arg, ExprOp):
+        if not isinstance(self.expr.ptr, ExprOp):
             return False
-        if self.expr.arg.args[0] != self.implicit_reg:
+        if self.expr.ptr.args[0] != self.implicit_reg:
             return False
 
         if getattr(self.parent, "imm7_align4", False):
 
             # Get the integer and check the upper bound
-            v = int(self.expr.arg.args[1].arg)
+            v = int(self.expr.ptr.args[1].arg)
             if v > 0x80:
                 return False
 
@@ -746,7 +746,7 @@ class mep_deref_sp_offset(mep_deref_reg):
         elif getattr(self.parent, "imm7", False):
 
             # Get the integer and check the upper bound
-            v = int(self.expr.arg.args[1].arg)
+            v = int(self.expr.ptr.args[1].arg)
             if v > 0x80:
                 return False
 
@@ -758,7 +758,7 @@ class mep_deref_sp_offset(mep_deref_reg):
         elif getattr(self.parent, "disp7_align2", False):
 
             # Get the integer and check the upper bound
-            v = int(self.expr.arg.args[1].arg)
+            v = int(self.expr.ptr.args[1].arg)
             if v > 0x80:
                 return False
 
@@ -1231,11 +1231,11 @@ class mep_abs24(mep_imm):
         the other one in imm6.
         """
 
-        if not (isinstance(self.expr, ExprMem) and isinstance(self.expr.arg, ExprInt)):
+        if not (isinstance(self.expr, ExprMem) and isinstance(self.expr.ptr, ExprInt)):
             return False
 
         # Get the integer and check the upper bound
-        v = int(self.expr.arg.arg)
+        v = int(self.expr.ptr.arg)
         if v > 0xffffff:
             return False
 

--- a/miasm2/arch/mep/sem.py
+++ b/miasm2/arch/mep/sem.py
@@ -60,7 +60,7 @@ def sb(reg_src, deref_dst):
     # MemByte(Rm31..0) <- Rn7..0
     # MemByte((ZeroExt(disp7)+TP)31..0)) <- Rn7..0
     # MemByte((SignExt(disp16)+Rm)31..0) <- Rn7..0
-    mem8[deref_dst.arg] = reg_src[:8]
+    mem8[deref_dst.ptr] = reg_src[:8]
 
 
 @sbuild.parse
@@ -70,7 +70,7 @@ def sh(reg_src, deref_dst):
     # MemHword(Rm31..1||0) <- Rn15..0
     # MemHword((ZeroExt((disp7)6..1||0)+TP)31..1||0)) <- Rn15..0
     # MemHword((SignExt(disp16)+Rm)31..1||0) <- Rn15..0
-    mem16[deref_dst.arg & i32(0xFFFFFFFE)] = reg_src[:16]
+    mem16[deref_dst.ptr & i32(0xFFFFFFFE)] = reg_src[:16]
 
 
 @sbuild.parse
@@ -83,7 +83,7 @@ def sw(reg_src, deref_dst):
     # MemWord((SignExt(disp16)+Rm)31..2||00) <- Rn31..0
     # MemWord(ZeroExt((abs24)23..2||00)) - Rn31..0
 
-    mem32[deref_dst.arg & i32(0xFFFFFFFC)] = reg_src
+    mem32[deref_dst.ptr & i32(0xFFFFFFFC)] = reg_src
 
 # Without the sembuilder
 #def sw(ir, instr, reg_src, deref_reg_or_imm, deref_reg=None):
@@ -115,7 +115,7 @@ def lb(reg_dst, deref_dst):
     # Rn <- SignExt(MemByte(Rm31..0))
     # Rn <- SignExt(MemByte((ZeroExt(disp7)+TP)31..0))
     # Rn <- SignExt(MemByte((SignExt(disp16)+Rm)31..0)
-    reg_dst = mem8[deref_dst.arg].signExtend(32)
+    reg_dst = mem8[deref_dst.ptr].signExtend(32)
 
 
 @sbuild.parse
@@ -125,7 +125,7 @@ def lh(reg_dst, deref_dst):
     # Rn <- SignExt(MemHword(Rm31..1||0))
     # Rn <- SignExt(MemHword((ZeroExt((disp7)6..1||0)+TP)31..1||0)
     # Rn <- SignExt(MemHword((SignExt(disp16)+Rm)31..1||0))
-    reg_dst = mem16[deref_dst.arg & i32(0xFFFFFFFE)].signExtend(32)
+    reg_dst = mem16[deref_dst.ptr & i32(0xFFFFFFFE)].signExtend(32)
 
 
 @sbuild.parse
@@ -136,7 +136,7 @@ def lw(reg_dst, deref_dst):
     # Rn <- MemWord((ZeroExt((disp7)6..2||00)+TP)31..2||00)
     # Rn <- MemWord((SignExt(disp16)+Rm)31..2||00)
     # Rn <- MemWord(ZeroExt((abs24)23..2||00))
-    reg_dst = mem32[deref_dst.arg & i32(0xFFFFFFFC)]
+    reg_dst = mem32[deref_dst.ptr & i32(0xFFFFFFFC)]
 
 
 @sbuild.parse
@@ -146,7 +146,7 @@ def lbu(reg_dst, deref_dst):
     # Rn <- ZeroExt(MemByte(Rm31..0))
     # Rn <- ZeroExt(MemByte((ZeroExt(disp7)+TP)31..0))
     # Rn <- ZeroExt(MemByte((SignExt(disp16)+Rm)31..0))
-    reg_dst = mem8[deref_dst.arg].zeroExtend(32)
+    reg_dst = mem8[deref_dst.ptr].zeroExtend(32)
 
 
 @sbuild.parse
@@ -156,7 +156,7 @@ def lhu(reg_dst, deref_dst):
     # Rn <- ZeroExt(MemHword(Rm31..1||0))
     # Rn <- ZeroExt(MemHword((SignExt(disp16)+Rm)31..1||0))
     # Rn <- ZeroExt(MemHword((ZeroExt((disp7)6..1||0)+TP)31..1||0))
-    reg_dst = mem16[deref_dst.arg & i32(0xFFFFFFFE)].zeroExtend(32)
+    reg_dst = mem16[deref_dst.ptr & i32(0xFFFFFFFE)].zeroExtend(32)
 
 
 ### Byte/Halfword extension instructions
@@ -767,7 +767,7 @@ def bsetm(rm_deref, imm3):
     """BSETM - Bit Set Memory"""
 
     # MemByte(Rm) <- MemByte(Rm) or (1<<imm3)
-    mem8[rm_deref.arg] = ExprOp("|", mem8[rm_deref.arg], (i8(1) << imm3[:8]))
+    mem8[rm_deref.ptr] = ExprOp("|", mem8[rm_deref.ptr], (i8(1) << imm3[:8]))
 
 
 @sbuild.parse
@@ -776,7 +776,7 @@ def bclrm(rm_deref, imm3):
 
     # MemByte(Rm) <- MemByte(Rm) and ~(1<<imm3)
     shift = ExprOp("<<", i8(1), imm3[:8])
-    mem8[rm_deref.arg] = ExprOp("&", mem8[rm_deref.arg], shift.__invert__())
+    mem8[rm_deref.ptr] = ExprOp("&", mem8[rm_deref.ptr], shift.__invert__())
 
 
 @sbuild.parse
@@ -784,7 +784,7 @@ def bnotm(rm_deref, imm3):
     """BNOTM - Bit Not Memory"""
 
     # MemByte(Rm) <- MemByte(Rm) xor (1<<imm3)
-    mem8[rm_deref.arg] = ExprOp("^", mem8[rm_deref.arg], (i8(1) << imm3[:8]))
+    mem8[rm_deref.ptr] = ExprOp("^", mem8[rm_deref.ptr], (i8(1) << imm3[:8]))
 
 
 @sbuild.parse
@@ -792,7 +792,7 @@ def btstm(r0, rm_deref, imm3):
     """BTSTM - Bit Test Memory"""
 
     # R0 <- ZeroExt( MemByte(Rm) and (1<<imm3) )
-    r0 = ExprOp("&", mem8[rm_deref.arg], i8(1) << imm3[:8]).zeroExtend(32)
+    r0 = ExprOp("&", mem8[rm_deref.ptr], i8(1) << imm3[:8]).zeroExtend(32)
 
 
 @sbuild.parse
@@ -801,8 +801,8 @@ def tas(rn, rm_deref):
 
     # temp <- Rm; Rn <- ZeroExt(MemByte(temp)); MemByte(temp) <- 1
     temp = rm_deref
-    rn = mem8[temp.arg].zeroExtend(32)
-    mem8[temp.arg] = i8(1)
+    rn = mem8[temp.ptr].zeroExtend(32)
+    mem8[temp.ptr] = i8(1)
 
 
 ### Data cache option
@@ -1076,7 +1076,7 @@ def smcp(reg_src, deref_dst):
     """SMCP - Store Word to memory from a coprocessor register"""
 
     # MemDword(Rm31..3||000) <- CRn
-    mem32[deref_dst.arg & i32(0xFFFFFFF8)] = reg_src
+    mem32[deref_dst.ptr & i32(0xFFFFFFF8)] = reg_src
 
 
 @sbuild.parse
@@ -1084,7 +1084,7 @@ def lmcp(reg_dst, deref_src):
     """LMCP - Load Word from memory to a coprocessor register"""
 
     # CRn <- MemDword(Rm31..3||000)
-    reg_dst = mem32[deref_src.arg & i32(0xFFFFFFF8)]
+    reg_dst = mem32[deref_src.ptr & i32(0xFFFFFFF8)]
 
 
 @sbuild.parse
@@ -1092,8 +1092,8 @@ def swcpi(reg_src, deref_dst):
     """SWCPI - Store Word to memory, and increment the address"""
 
     # MemWord(Rm31..2||00) <- CRn 31..0; Rm<-Rm+4
-    mem32[deref_dst.arg & i32(0xFFFFFFFC)] = reg_src
-    deref_dst.arg = deref_dst.arg + i32(4)
+    mem32[deref_dst.ptr & i32(0xFFFFFFFC)] = reg_src
+    deref_dst.ptr = deref_dst.ptr + i32(4)
 
 
 @sbuild.parse
@@ -1101,8 +1101,8 @@ def lwcpi(reg_dst, deref_src):
     """LWCPI - Load Word from memory, and increment the address"""
 
     # CRn <- MemWord(Rm31..2||00); Rm<-Rm+4
-    reg_dst = mem32[deref_src.arg & i32(0xFFFFFFFC)]
-    deref_src.arg = deref_src.arg + i32(4)
+    reg_dst = mem32[deref_src.ptr & i32(0xFFFFFFFC)]
+    deref_src.ptr = deref_src.ptr + i32(4)
 
 
 @sbuild.parse
@@ -1110,8 +1110,8 @@ def smcpi(reg_src, deref_dst):
     """SMCPI - Store Word to memory, and increment the address"""
 
     # MemDword(Rm31..3||000) <- CRn; Rm<-Rm+8
-    mem32[deref_dst.arg & i32(0xFFFFFFF8)] = reg_src
-    deref_dst.arg = deref_dst.arg + i32(8)
+    mem32[deref_dst.ptr & i32(0xFFFFFFF8)] = reg_src
+    deref_dst.ptr = deref_dst.ptr + i32(8)
 
 
 @sbuild.parse
@@ -1119,8 +1119,8 @@ def lmcpi(reg_dst, deref_src):
     """LMCPI - Load Word from memory, and increment the address"""
 
     # CRn <- MemDword(Rm31..3||000); Rm<-Rm+8
-    reg_dst = mem32[deref_src.arg & i32(0xFFFFFFFC)]
-    deref_src.arg = deref_src.arg + i32(8)
+    reg_dst = mem32[deref_src.ptr & i32(0xFFFFFFFC)]
+    deref_src.ptr = deref_src.ptr + i32(8)
 
 
 ### IR MeP definitions

--- a/miasm2/arch/mips32/arch.py
+++ b/miasm2/arch/mips32/arch.py
@@ -69,7 +69,7 @@ class instruction_mips32(cpu.instruction):
             else:
                 return str(expr)
         assert(isinstance(expr, ExprMem))
-        arg = expr.arg
+        arg = expr.ptr
         if isinstance(arg, ExprId):
             return "(%s)"%arg
         assert(len(arg.args) == 2 and arg.op == '+')
@@ -394,13 +394,13 @@ class mips32_dreg_imm(mips32_arg):
         e = self.expr
         if not isinstance(e, ExprMem):
             return False
-        arg = e.arg
-        if isinstance(arg, ExprId):
+        ptr = e.ptr
+        if isinstance(ptr, ExprId):
             self.parent.imm.expr = ExprInt(0, 32)
-            r = arg
-        elif len(arg.args) == 2 and arg.op == "+":
-            self.parent.imm.expr = arg.args[1]
-            r = arg.args[0]
+            r = ptr
+        elif len(ptr.args) == 2 and ptr.op == "+":
+            self.parent.imm.expr = ptr.args[1]
+            r = ptr.args[0]
         else:
             return False
         self.value = gpregs.expr.index(r)
@@ -409,11 +409,11 @@ class mips32_dreg_imm(mips32_arg):
     @staticmethod
     def arg2str(expr, index=None):
         assert(isinstance(expr, ExprMem))
-        arg = expr.arg
-        if isinstance(arg, ExprId):
-            return "(%s)"%arg
-        assert(len(arg.args) == 2 and arg.op == '+')
-        return "%s(%s)"%(arg.args[1], arg.args[0])
+        ptr = expr.ptr
+        if isinstance(ptr, ExprId):
+            return "(%s)"%ptr
+        assert(len(ptr.args) == 2 and ptr.op == '+')
+        return "%s(%s)"%(ptr.args[1], ptr.args[0])
 
 class mips32_esize(mips32_imm, mips32_arg):
     def decode(self, v):

--- a/miasm2/arch/mips32/sem.py
+++ b/miasm2/arch/mips32/sem.py
@@ -64,18 +64,18 @@ def l_b(arg1):
 def lbu(arg1, arg2):
     """A byte is loaded (unsigned extended) into a register @arg1 from the
     specified address @arg2."""
-    arg1 = mem8[arg2.arg].zeroExtend(32)
+    arg1 = mem8[arg2.ptr].zeroExtend(32)
 
 @sbuild.parse
 def lhu(arg1, arg2):
     """A word is loaded (unsigned extended) into a register @arg1 from the
     specified address @arg2."""
-    arg1 = mem16[arg2.arg].zeroExtend(32)
+    arg1 = mem16[arg2.ptr].zeroExtend(32)
 
 @sbuild.parse
 def lb(arg1, arg2):
     "A byte is loaded into a register @arg1 from the specified address @arg2."
-    arg1 = mem8[arg2.arg].signExtend(32)
+    arg1 = mem8[arg2.ptr].signExtend(32)
 
 @sbuild.parse
 def beq(arg1, arg2, arg3):
@@ -174,11 +174,11 @@ def l_sub(arg1, arg2, arg3):
 def sb(arg1, arg2):
     """The least significant byte of @arg1 is stored at the specified address
     @arg2."""
-    mem8[arg2.arg] = arg1[:8]
+    mem8[arg2.ptr] = arg1[:8]
 
 @sbuild.parse
 def sh(arg1, arg2):
-    mem16[arg2.arg] = arg1[:16]
+    mem16[arg2.ptr] = arg1[:16]
 
 @sbuild.parse
 def movn(arg1, arg2, arg3):

--- a/miasm2/arch/msp430/arch.py
+++ b/miasm2/arch/msp430/arch.py
@@ -115,15 +115,15 @@ class instruction_msp430(instruction):
         elif isinstance(expr, ExprOp) and expr.op == "autoinc":
             o = "@%s+" % str(expr.args[0])
         elif isinstance(expr, ExprMem):
-            if isinstance(expr.arg, ExprId):
+            if isinstance(expr.ptr, ExprId):
                 if index == 0:
-                    o = "@%s" % expr.arg
+                    o = "@%s" % expr.ptr
                 else:
-                    o = "0x0(%s)" % expr.arg
-            elif isinstance(expr.arg, ExprInt):
-                o = "@%s" % expr.arg
-            elif isinstance(expr.arg, ExprOp):
-                o = "%s(%s)" % (expr.arg.args[1], expr.arg.args[0])
+                    o = "0x0(%s)" % expr.ptr
+            elif isinstance(expr.ptr, ExprInt):
+                o = "@%s" % expr.ptr
+            elif isinstance(expr.ptr, ExprOp):
+                o = "%s(%s)" % (expr.ptr.args[1], expr.ptr.args[0])
         else:
             raise NotImplementedError('unknown instance expr = %s' % type(expr))
         return o
@@ -388,20 +388,20 @@ class msp430_sreg_arg(reg_noarg, msp430_arg):
                 self.value = 0
                 self.parent.off_s.value = v
         elif isinstance(e, ExprMem):
-            if isinstance(e.arg, ExprId):
+            if isinstance(e.ptr, ExprId):
                 self.parent.a_s.value = 0b10
-                self.value = self.reg_info.expr.index(e.arg)
-            elif isinstance(e.arg, ExprInt):
+                self.value = self.reg_info.expr.index(e.ptr)
+            elif isinstance(e.ptr, ExprInt):
                 self.parent.a_s.value = 0b01
                 self.value = self.reg_info.expr.index(SR)
-                self.parent.off_s.value = int(e.arg)
-            elif isinstance(e.arg, ExprOp):
+                self.parent.off_s.value = int(e.ptr)
+            elif isinstance(e.ptr, ExprOp):
                 self.parent.a_s.value = 0b01
-                self.value = self.reg_info.expr.index(e.arg.args[0])
-                self.parent.off_s.value = int(e.arg.args[1])
+                self.value = self.reg_info.expr.index(e.ptr.args[0])
+                self.parent.off_s.value = int(e.ptr.args[1])
             else:
                 raise NotImplementedError(
-                    'unknown instance e.arg = %s' % type(e.arg))
+                    'unknown instance e.ptr = %s' % type(e.ptr))
         elif isinstance(e, ExprOp) and e.op == "autoinc":
             self.parent.a_s.value = 0b11
             self.value = self.reg_info.expr.index(e.args[0])
@@ -443,15 +443,15 @@ class msp430_dreg_arg(msp430_sreg_arg):
             self.parent.a_d.value = 0
             self.value = self.reg_info.expr.index(e)
         elif isinstance(e, ExprMem):
-            if isinstance(e.arg, ExprId):
-                r, i = e.arg, ExprInt(0, 16)
-            elif isinstance(e.arg, ExprOp):
-                r, i = e.arg.args[0], e.arg.args[1]
-            elif isinstance(e.arg, ExprInt):
-                r, i = SR, e.arg
+            if isinstance(e.ptr, ExprId):
+                r, i = e.ptr, ExprInt(0, 16)
+            elif isinstance(e.ptr, ExprOp):
+                r, i = e.ptr.args[0], e.ptr.args[1]
+            elif isinstance(e.ptr, ExprInt):
+                r, i = SR, e.ptr
             else:
                 raise NotImplementedError(
-                    'unknown instance e.arg = %s' % type(e.arg))
+                    'unknown instance e.arg = %s' % type(e.ptr))
             self.parent.a_d.value = 1
             self.value = self.reg_info.expr.index(r)
             self.parent.off_d.value = int(i)

--- a/miasm2/arch/ppc/arch.py
+++ b/miasm2/arch/ppc/arch.py
@@ -77,7 +77,7 @@ class instruction_ppc(instruction):
         if isinstance(e, ExprId) or isinstance(e, ExprInt):
             return str(e)
         elif isinstance(e, ExprMem):
-            addr = e.arg
+            addr = e.ptr
             if isinstance(addr, ExprInt) or isinstance(addr, ExprId):
                 out = '(%s)'%addr
             elif isinstance(addr, ExprOp):
@@ -509,7 +509,7 @@ class ppc_deref32(ppc_arg):
         e = self.expr
         if not isinstance(e, ExprMem):
             return False
-        addr = e.arg
+        addr = e.ptr
         if isinstance(addr, ExprId) or isinstance(addr, ExprInt):
             addr = addr + ExprInt(0, 32)
         elif not isinstance(addr, ExprOp):

--- a/miasm2/arch/ppc/sem.py
+++ b/miasm2/arch/ppc/sem.py
@@ -250,7 +250,7 @@ def mn_do_load(ir, instr, arg1, arg2, arg3=None):
     if arg3 is None:
         assert isinstance(arg2, ExprMem)
 
-        address = arg2.arg
+        address = arg2.ptr
     else:
         address = arg2 + arg3
 
@@ -267,7 +267,7 @@ def mn_do_load(ir, instr, arg1, arg2, arg3=None):
     ret.append(ExprAssign(arg1, src))
     if has_u:
         if arg3 is None:
-            ret.append(ExprAssign(arg2.arg.args[0], address))
+            ret.append(ExprAssign(arg2.ptr.args[0], address))
         else:
             ret.append(ExprAssign(arg2, address))
 
@@ -586,7 +586,7 @@ def mn_do_store(ir, instr, arg1, arg2, arg3=None):
     if arg3 is None:
         assert isinstance(arg2, ExprMem)
 
-        address = arg2.arg
+        address = arg2.ptr
     else:
         address = arg2 + arg3
 
@@ -599,7 +599,7 @@ def mn_do_store(ir, instr, arg1, arg2, arg3=None):
     ret.append(ExprAssign(dest, src))
     if has_u:
         if arg3 is None:
-            ret.append(ExprAssign(arg2.arg.args[0], address))
+            ret.append(ExprAssign(arg2.ptr.args[0], address))
         else:
             ret.append(ExprAssign(arg2, address))
 

--- a/miasm2/arch/sh4/arch.py
+++ b/miasm2/arch/sh4/arch.py
@@ -169,7 +169,7 @@ class sh4_dgpreg(sh4_arg):
         start, stop = super(sh4_dgpreg, self).fromstring(text, loc_db, parser_result)
         if start is None or self.expr == [None]:
             return start, stop
-        self.expr = ExprMem(self.expr.arg, self.sz)
+        self.expr = ExprMem(self.expr.ptr, self.sz)
         return start, stop
 
     def decode(self, v):
@@ -181,9 +181,9 @@ class sh4_dgpreg(sh4_arg):
         e = self.expr
         if not isinstance(e, ExprMem):
             return False
-        if not isinstance(e.arg, ExprId):
+        if not isinstance(e.ptr, ExprId):
             return False
-        v = gpregs.expr.index(e.arg)
+        v = gpregs.expr.index(e.ptr)
         self.value = v
         return True
 
@@ -195,9 +195,9 @@ class sh4_dgpregpinc(sh4_arg):
         start, stop = super(sh4_dgpregpinc, self).fromstring(text, loc_db, parser_result)
         if self.expr == [None]:
             return None, None
-        if not isinstance(self.expr.arg, ExprOp):
+        if not isinstance(self.expr.ptr, ExprOp):
             return None, None
-        if self.expr.arg.op != self.op:
+        if self.expr.ptr.op != self.op:
             return None, None
         return start, stop
 
@@ -211,7 +211,7 @@ class sh4_dgpregpinc(sh4_arg):
         e = self.expr
         if not isinstance(e, ExprMem):
             return False
-        e = e.arg
+        e = e.ptr
         res = match_expr(e, ExprOp(self.op, jra), [jra])
         if not res:
             return False
@@ -246,10 +246,10 @@ class sh4_dgpreg_imm(sh4_dgpreg):
         s = self.sz
         if not isinstance(e, ExprMem):
             return False
-        if isinstance(e.arg, ExprId):
-            v = gpregs.expr.index(e.arg)
+        if isinstance(e.ptr, ExprId):
+            v = gpregs.expr.index(e.ptr)
             p.disp.value = 0
-        elif isinstance(e.arg, ExprOp):
+        elif isinstance(e.ptr, ExprOp):
             res = match_expr(e, ExprMem(jra + jrb, self.sz), [jra, jrb])
             if not res:
                 return False
@@ -415,20 +415,20 @@ class instruction_sh4(instruction):
             else:
                 return str(expr)
         assert(isinstance(expr, ExprMem))
-        expr = expr.arg
+        ptr = expr.ptr
 
-        if isinstance(expr, ExprOp):
-            if expr.op == "predec":
-                s = '-%s' % expr.args[0]
-            elif expr.op == "postinc":
-                s = '%s+' % expr.args[0]
+        if isinstance(ptr, ExprOp):
+            if ptr.op == "predec":
+                s = '-%s' % ptr.args[0]
+            elif ptr.op == "postinc":
+                s = '%s+' % ptr.args[0]
             else:
                 s = ','.join([str(x).replace('(', '').replace(')', '')
-                              for x in expr.args])
+                              for x in ptr.args])
                 s = "(%s)"%s
             s = "@%s" % s
-        elif isinstance(expr, ExprId):
-            s = "@%s" % expr
+        elif isinstance(ptr, ExprId):
+            s = "@%s" % ptr
         else:
             raise NotImplementedError('zarb arg2str')
         return s

--- a/miasm2/core/objc.py
+++ b/miasm2/core/objc.py
@@ -1012,12 +1012,12 @@ class ExprToAccessC(ExprReducer):
 
         if not isinstance(node.expr, ExprMem):
             return None
-        if node.arg.info is None:
+        if node.ptr.info is None:
             return None
-        assert isinstance(node.arg.info, set)
+        assert isinstance(node.ptr.info, set)
         void_type = self.types_mngr.void_ptr
         found = set()
-        for subcgenobj in node.arg.info:
+        for subcgenobj in node.ptr.info:
             if isinstance(subcgenobj.ctype, ObjCArray):
                 nobj = CGenArray(subcgenobj, 0,
                                  void_type.align,
@@ -1285,7 +1285,7 @@ class ExprCToExpr(ExprReducer):
             out = (src.arg, ObjCPtr(src_type.objtype,
                                     void_type.align, void_type.size))
         elif isinstance(src, ExprMem):
-            out = (src.arg, ObjCPtr(src_type,
+            out = (src.ptr, ObjCPtr(src_type,
                                     void_type.align, void_type.size))
         elif isinstance(src_type, ObjCStruct):
             out = (src, ObjCPtr(src_type,

--- a/miasm2/expression/expression.py
+++ b/miasm2/expression/expression.py
@@ -733,7 +733,7 @@ class ExprAssign(Expr):
     def get_r(self, mem_read=False, cst_read=False):
         elements = self._src.get_r(mem_read, cst_read)
         if isinstance(self._dst, ExprMem) and mem_read:
-            elements.update(self._dst.arg.get_r(mem_read, cst_read))
+            elements.update(self._dst.ptr.get_r(mem_read, cst_read))
         return elements
 
     def get_w(self):
@@ -891,47 +891,56 @@ class ExprMem(Expr):
      - Memory write
     """
 
-    __slots__ = Expr.__slots__ + ["_arg"]
+    __slots__ = Expr.__slots__ + ["_ptr"]
 
-    def __init__(self, arg, size=None):
+    def __init__(self, ptr, size=None):
         """Create an ExprMem
-        @arg: Expr, memory access address
+        @ptr: Expr, memory access address
         @size: int, memory access size
         """
         if size is None:
-            warnings.warn('DEPRECATION WARNING: size is a mandatory argument: use ExprMem(arg, SIZE)')
+            warnings.warn('DEPRECATION WARNING: size is a mandatory argument: use ExprMem(ptr, SIZE)')
             size = 32
 
-        # arg must be Expr
-        assert isinstance(arg, Expr)
+        # ptr must be Expr
+        assert isinstance(ptr, Expr)
         assert isinstance(size, (int, long))
 
-        if not isinstance(arg, Expr):
+        if not isinstance(ptr, Expr):
             raise ValueError(
-                'ExprMem: arg must be an Expr (not %s)' % type(arg))
+                'ExprMem: ptr must be an Expr (not %s)' % type(ptr))
 
         super(ExprMem, self).__init__(size)
-        self._arg = arg
+        self._ptr = ptr
 
-    arg = property(lambda self: self._arg)
+    def get_arg(self):
+        warnings.warn('DEPRECATION WARNING: use exprmem.ptr instead of exprmem.arg')
+        return self.ptr
+
+    def set_arg(self, value):
+        warnings.warn('DEPRECATION WARNING: use exprmem.ptr instead of exprmem.arg')
+        self.ptr = value
+
+    ptr = property(lambda self: self._ptr)
+    arg = property(get_arg, set_arg)
 
     def __reduce__(self):
-        state = self._arg, self._size
+        state = self._ptr, self._size
         return self.__class__, state
 
-    def __new__(cls, arg, size=None):
+    def __new__(cls, ptr, size=None):
         if size is None:
-            warnings.warn('DEPRECATION WARNING: size is a mandatory argument: use ExprMem(arg, SIZE)')
+            warnings.warn('DEPRECATION WARNING: size is a mandatory argument: use ExprMem(ptr, SIZE)')
             size = 32
 
-        return Expr.get_object(cls, (arg, size))
+        return Expr.get_object(cls, (ptr, size))
 
     def __str__(self):
-        return "@%d[%s]" % (self.size, str(self.arg))
+        return "@%d[%s]" % (self.size, str(self.ptr))
 
     def get_r(self, mem_read=False, cst_read=False):
         if mem_read:
-            return set(self._arg.get_r(mem_read, cst_read).union(set([self])))
+            return set(self._ptr.get_r(mem_read, cst_read).union(set([self])))
         else:
             return set([self])
 
@@ -939,37 +948,37 @@ class ExprMem(Expr):
         return set([self])  # [memreg]
 
     def _exprhash(self):
-        return hash((EXPRMEM, hash(self._arg), self._size))
+        return hash((EXPRMEM, hash(self._ptr), self._size))
 
     def _exprrepr(self):
         return "%s(%r, %r)" % (self.__class__.__name__,
-                               self._arg, self._size)
+                               self._ptr, self._size)
 
     def __contains__(self, expr):
-        return self == expr or self._arg.__contains__(expr)
+        return self == expr or self._ptr.__contains__(expr)
 
     @visit_chk
     def visit(self, callback, test_visit=None):
-        arg = self._arg.visit(callback, test_visit)
-        if arg == self._arg:
+        ptr = self._ptr.visit(callback, test_visit)
+        if ptr == self._ptr:
             return self
-        return ExprMem(arg, self.size)
+        return ExprMem(ptr, self.size)
 
     def copy(self):
-        arg = self.arg.copy()
-        return ExprMem(arg, size=self.size)
+        ptr = self.ptr.copy()
+        return ExprMem(ptr, size=self.size)
 
     def is_mem_segm(self):
         """Returns True if is ExprMem and ptr is_op_segm"""
-        return self._arg.is_op_segm()
+        return self._ptr.is_op_segm()
 
     def depth(self):
-        return self._arg.depth() + 1
+        return self._ptr.depth() + 1
 
     def graph_recursive(self, graph):
         graph.add_node(self)
-        self._arg.graph_recursive(graph)
-        graph.add_uniq_edge(self, self._arg)
+        self._ptr.graph_recursive(graph)
+        graph.add_uniq_edge(self, self._ptr)
 
     def is_mem(self):
         return True
@@ -1426,7 +1435,7 @@ def compare_exprs(expr1, expr2):
         ret = compare_exprs(expr1.src2, expr2.src2)
         return ret
     elif cls1 == ExprMem:
-        ret = compare_exprs(expr1.arg, expr2.arg)
+        ret = compare_exprs(expr1.ptr, expr2.ptr)
         if ret:
             return ret
         return cmp(expr1.size, expr2.size)
@@ -1616,7 +1625,7 @@ def match_expr(expr, pattern, tks, result=None):
             return False
         if expr.size != pattern.size:
             return False
-        return match_expr(expr.arg, pattern.arg, tks, result)
+        return match_expr(expr.ptr, pattern.ptr, tks, result)
 
     elif expr.is_slice():
         if not pattern.is_slice():

--- a/miasm2/expression/expression_helper.py
+++ b/miasm2/expression/expression_helper.py
@@ -272,7 +272,7 @@ class Variables_Identifier(object):
             pass
 
         elif isinstance(expr, m2_expr.ExprMem):
-            self.find_variables_rec(expr.arg)
+            self.find_variables_rec(expr.ptr)
 
         elif isinstance(expr, m2_expr.ExprCompose):
             for arg in expr.args:
@@ -567,7 +567,7 @@ def possible_values(expr):
         consvals.update(ConstrainedValue(consval.constraints,
                                          m2_expr.ExprMem(consval.value,
                                                          expr.size))
-                        for consval in possible_values(expr.arg))
+                        for consval in possible_values(expr.ptr))
     elif isinstance(expr, m2_expr.ExprAssign):
         consvals.update(possible_values(expr.src))
     # Special case: constraint insertion

--- a/miasm2/expression/expression_reduce.py
+++ b/miasm2/expression/expression_reduce.py
@@ -68,13 +68,13 @@ class ExprNodeMem(ExprNode):
     def __init__(self, expr):
         assert expr.is_mem()
         super(ExprNodeMem, self).__init__(expr)
-        self.arg = None
+        self.ptr = None
 
     def __repr__(self):
         if self.info is not None:
             out = repr(self.info)
         else:
-            out = "@%d[%r]" % (self.expr.size, self.arg)
+            out = "@%d[%r]" % (self.expr.size, self.ptr)
         return out
 
 
@@ -173,9 +173,9 @@ class ExprReducer(object):
         elif isinstance(expr, ExprInt):
             node = ExprNodeInt(expr)
         elif isinstance(expr, ExprMem):
-            son = self.expr2node(expr.arg)
+            son = self.expr2node(expr.ptr)
             node = ExprNodeMem(expr)
-            node.arg = son
+            node.ptr = son
         elif isinstance(expr, ExprSlice):
             son = self.expr2node(expr.arg)
             node = ExprNodeSlice(expr)
@@ -223,9 +223,9 @@ class ExprReducer(object):
         elif isinstance(expr, ExprLoc):
             node = ExprNodeLoc(expr)
         elif isinstance(expr, ExprMem):
-            arg = self.categorize(node.arg, lvl=lvl + 1, **kwargs)
-            node = ExprNodeMem(ExprMem(arg.expr, expr.size))
-            node.arg = arg
+            ptr = self.categorize(node.ptr, lvl=lvl + 1, **kwargs)
+            node = ExprNodeMem(ExprMem(ptr.expr, expr.size))
+            node.ptr = ptr
         elif isinstance(expr, ExprSlice):
             arg = self.categorize(node.arg, lvl=lvl + 1, **kwargs)
             node = ExprNodeSlice(ExprSlice(arg.expr, expr.start, expr.stop))

--- a/miasm2/expression/simplifications_common.py
+++ b/miasm2/expression/simplifications_common.py
@@ -509,7 +509,7 @@ def simp_slice(e_s, expr):
     if (expr.arg.is_mem() and
           expr.start == 0 and
           expr.arg.size > expr.stop and expr.stop % 8 == 0):
-        return ExprMem(expr.arg.arg, size=expr.stop)
+        return ExprMem(expr.arg.ptr, size=expr.stop)
     # distributivity of slice and &
     # (a & int)[x:y] => 0 if int[x:y] == 0
     if expr.arg.is_op("&") and expr.arg.args[-1].is_int():
@@ -576,9 +576,9 @@ def simp_compose(e_s, expr):
     for i, arg in enumerate(args[:-1]):
         nxt = args[i + 1]
         if arg.is_mem() and nxt.is_mem():
-            gap = e_s(nxt.arg - arg.arg)
+            gap = e_s(nxt.ptr - arg.ptr)
             if gap.is_int() and arg.size % 8 == 0 and int(gap) == arg.size / 8:
-                args = args[:i] + [ExprMem(arg.arg,
+                args = args[:i] + [ExprMem(arg.ptr,
                                           arg.size + nxt.size)] + args[i + 2:]
                 return ExprCompose(*args)
 
@@ -664,8 +664,8 @@ def simp_mem(e_s, expr):
     "Common simplifications on ExprMem"
 
     # @32[x?a:b] => x?@32[a]:@32[b]
-    if expr.arg.is_cond():
-        cond = expr.arg
+    if expr.ptr.is_cond():
+        cond = expr.ptr
         ret = ExprCond(cond.cond,
                        ExprMem(cond.src1, expr.size),
                        ExprMem(cond.src2, expr.size))

--- a/miasm2/ir/ir.py
+++ b/miasm2/ir/ir.py
@@ -230,7 +230,7 @@ class AssignBlock(object):
             src_read = src.get_r(mem_read=mem_read, cst_read=cst_read)
             if isinstance(dst, m2_expr.ExprMem) and mem_read:
                 # Read on destination happens only with ExprMem
-                src_read.update(dst.arg.get_r(mem_read=mem_read,
+                src_read.update(dst.ptr.get_r(mem_read=mem_read,
                                               cst_read=cst_read))
             out[dst] = src_read
         return out

--- a/miasm2/ir/translators/C.py
+++ b/miasm2/ir/translators/C.py
@@ -92,7 +92,7 @@ class TranslatorC(Translator):
         return out
 
     def from_ExprMem(self, expr):
-        ptr = expr.arg
+        ptr = expr.ptr
         if ptr.size <= self.NATIVE_INT_MAX_SIZE:
             new_ptr = self.from_expr(ptr)
             if expr.size <= self.NATIVE_INT_MAX_SIZE:

--- a/miasm2/ir/translators/miasm.py
+++ b/miasm2/ir/translators/miasm.py
@@ -35,7 +35,7 @@ class TranslatorMiasm(Translator):
                                     self.from_expr(expr.src))
 
     def from_ExprMem(self, expr):
-        return "ExprMem(%s, size=%d)" % (self.from_expr(expr.arg), expr.size)
+        return "ExprMem(%s, size=%d)" % (self.from_expr(expr.ptr), expr.size)
 
 
 # Register the class

--- a/miasm2/ir/translators/python.py
+++ b/miasm2/ir/translators/python.py
@@ -24,7 +24,7 @@ class TranslatorPython(Translator):
         return str(expr)
 
     def from_ExprMem(self, expr):
-        return "memory(%s, 0x%x)" % (self.from_expr(expr.arg),
+        return "memory(%s, 0x%x)" % (self.from_expr(expr.ptr),
                                      expr.size / 8)
 
     def from_ExprSlice(self, expr):

--- a/miasm2/ir/translators/smt2.py
+++ b/miasm2/ir/translators/smt2.py
@@ -149,11 +149,11 @@ class TranslatorSMT2(Translator):
         return bit_vec_val(str(offset), expr.size)
 
     def from_ExprMem(self, expr):
-        addr = self.from_expr(expr.arg)
+        addr = self.from_expr(expr.ptr)
         # size to read from memory
         size = expr.size
         # size of memory address
-        addr_size = expr.arg.size
+        addr_size = expr.ptr.size
         return self._mem.get(addr, size, addr_size)
 
     def from_ExprSlice(self, expr):

--- a/miasm2/ir/translators/z3_ir.py
+++ b/miasm2/ir/translators/z3_ir.py
@@ -144,7 +144,7 @@ class TranslatorZ3(Translator):
         return z3.BitVec(str(loc_key), expr.size)
 
     def from_ExprMem(self, expr):
-        addr = self.from_expr(expr.arg)
+        addr = self.from_expr(expr.ptr)
         return self._mem.get(addr, expr.size)
 
     def from_ExprSlice(self, expr):

--- a/miasm2/jitter/codegen.py
+++ b/miasm2/jitter/codegen.py
@@ -272,7 +272,7 @@ class CGen(object):
                         )
                     )
             elif isinstance(dst, ExprMem):
-                ptr = dst.arg.replace_expr(prefetchers)
+                ptr = dst.ptr.replace_expr(prefetchers)
                 if ptr.size <= self.translator.NATIVE_INT_MAX_SIZE:
                     new_dst = ExprMem(ptr, dst.size)
                     str_dst = self.id_to_c(new_dst).replace('MEM_LOOKUP', 'MEM_WRITE')

--- a/miasm2/jitter/emulatedsymbexec.py
+++ b/miasm2/jitter/emulatedsymbexec.py
@@ -41,7 +41,7 @@ class EmulatedSymbExec(SymbolicExecutionEngine):
         """Memory read wrapper for symbolic execution
         @expr_mem: ExprMem"""
 
-        addr = expr_mem.arg
+        addr = expr_mem.ptr
         if not addr.is_int():
             return expr_mem
         addr = int(addr)
@@ -67,7 +67,7 @@ class EmulatedSymbExec(SymbolicExecutionEngine):
         to_write = data.arg.arg
 
         # Format information
-        addr = dest.arg.arg.arg
+        addr = dest.ptr.arg.arg
         size = data.size / 8
         content = hex(to_write).replace("0x", "").replace("L", "")
         content = "0" * (size * 2 - len(content)) + content

--- a/miasm2/jitter/llvmconvert.py
+++ b/miasm2/jitter/llvmconvert.py
@@ -679,7 +679,7 @@ class LLVMFunction():
             builder.store(src, ptr_casted)
 
         elif isinstance(dst, ExprMem):
-            addr = self.add_ir(dst.arg)
+            addr = self.add_ir(dst.ptr)
             self.llvm_context.memory_write(self, addr, dst.size, src)
         else:
             raise Exception("UnknownAffectationType")
@@ -1091,7 +1091,7 @@ class LLVMFunction():
 
         if isinstance(expr, ExprMem):
 
-            addr = self.add_ir(expr.arg)
+            addr = self.add_ir(expr.ptr)
             return self.llvm_context.memory_lookup(self, addr, expr.size)
 
         if isinstance(expr, ExprCond):


### PR DESCRIPTION
To access a `ExprMem` pointer:
```
mem = ExprMem(XXX, 32)
ptr = mem.ptr
```

The old api `.arg` is still supported, but with a warning.
