### PR TITLE
Fix MacOS 10.14 build

### DIFF
--- a/miasm2/jitter/vm_mngr.h
+++ b/miasm2/jitter/vm_mngr.h
@@ -35,6 +35,8 @@
 
 #ifdef __APPLE__
 #define __BYTE_ORDER __BYTE_ORDER__
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
 #elif defined(__NetBSD__) || defined(__OpenBSD__)
 #define __BYTE_ORDER _BYTE_ORDER
 #define __BIG_ENDIAN _BIG_ENDIAN


### PR DESCRIPTION
Hello Team,

Here is a patch that fixes the build on MacOS 10.14. When checkouting the code and building, I came accross this error:

```sh
/usr/bin/clang -fno-strict-aliasing -fno-common -dynamic -pipe -Os -isysroot/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/opt/local/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c miasm2/jitter/vm_mngr_py.c -o build/temp.macosx-10.14-x86_64-2.7/miasm2/jitter/vm_mngr_py.o
miasm2/jitter/vm_mngr_py.c:553:24: error: use of undeclared identifier '__BIG_ENDIAN'
        self->vm_mngr.sex   = __BIG_ENDIAN;
                              ^
miasm2/jitter/vm_mngr_py.c:561:24: error: use of undeclared identifier '__LITTLE_ENDIAN'
        self->vm_mngr.sex   = __LITTLE_ENDIAN;
                              ^
miasm2/jitter/vm_mngr_py.c:570:27: error: use of undeclared identifier '__BIG_ENDIAN'
        if (self->vm_mngr.sex == __BIG_ENDIAN) {
```

This patch fixes this. Feel free to come back to me if you want me to change anything.
Many thanks for this great project and your work :).