### PR TITLE
X86 sem : mov assignexpr rot / shift

### DIFF
--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -636,17 +636,18 @@ def _rotate_tpl(ir, instr, dst, src, op, left=False):
             m2_expr.ExprAssign(of, new_of),
             m2_expr.ExprAssign(dst, res)
             ]
+    e = []
+    if dst.size == 32 and dst in replace_regs[64]:
+        e.append(m2_expr.ExprAssign(dst[:dst.size], dst))
     # Don't generate conditional shifter on constant
     if isinstance(shifter, m2_expr.ExprInt):
         if int(shifter) != 0:
             return (e_do, [])
         else:
-            return ([], [])
-    e = []
+            return (e, [])
     loc_do, loc_do_expr = ir.gen_loc_key_and_expr(ir.IRDst.size)
     loc_skip = ir.get_next_loc_key(instr)
     loc_skip_expr = m2_expr.ExprLoc(loc_skip, ir.IRDst.size)
-
     e_do.append(m2_expr.ExprAssign(ir.IRDst, loc_skip_expr))
     e.append(m2_expr.ExprAssign(
         ir.IRDst, m2_expr.ExprCond(shifter, loc_do_expr, loc_skip_expr)))
@@ -685,17 +686,18 @@ def rotate_with_carry_tpl(ir, instr, op, dst, src):
             m2_expr.ExprAssign(of, new_of),
             m2_expr.ExprAssign(dst, new_dst)
             ]
+    e = []
+    if dst.size == 32 and dst in replace_regs[64]:
+        e.append(m2_expr.ExprAssign(dst[:dst.size], dst))
     # Don't generate conditional shifter on constant
     if isinstance(shifter, m2_expr.ExprInt):
         if int(shifter) != 0:
             return (e_do, [])
         else:
-            return ([], [])
-    e = []
+            return (e, [])
     loc_do, loc_do_expr = ir.gen_loc_key_and_expr(ir.IRDst.size)
     loc_skip = ir.get_next_loc_key(instr)
     loc_skip_expr = m2_expr.ExprLoc(loc_skip, ir.IRDst.size)
-
     e_do.append(m2_expr.ExprAssign(ir.IRDst, loc_skip_expr))
     e.append(m2_expr.ExprAssign(
         ir.IRDst, m2_expr.ExprCond(shifter, loc_do_expr, loc_skip_expr)))
@@ -772,15 +774,15 @@ def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None, left=False,
         m2_expr.ExprAssign(a, res),
     ]
     e_do += update_flag_znp(res)
-
+    e = []
+    if a.size == 32 and a in replace_regs[64]:
+        e.append(m2_expr.ExprAssign(a[:a.size], a))
     # Don't generate conditional shifter on constant
     if isinstance(shifter, m2_expr.ExprInt):
         if int(shifter) != 0:
-            return e_do, []
+            return (e_do, [])
         else:
-            return [], []
-
-    e = []
+            return (e, [])
     loc_do, loc_do_expr = ir.gen_loc_key_and_expr(ir.IRDst.size)
     loc_skip = ir.get_next_loc_key(instr)
     loc_skip_expr = m2_expr.ExprLoc(loc_skip, ir.IRDst.size)

--- a/miasm2/ir/translators/C.py
+++ b/miasm2/ir/translators/C.py
@@ -317,7 +317,7 @@ class TranslatorC(Translator):
                         ">>>": "ror",
                         "<<<": "rol"
                     }
-                    out = "bignum_%d(%s, %d, bignum_to_uint64(%s))" % (
+                    out = "bignum_%s(%s, %d, bignum_to_uint64(%s))" % (
                         op[expr.op], arg0, expr.size, arg1
                     )
                     out = "bignum_mask(%s, %d)"% (out, expr.size)


### PR DESCRIPTION
When an operation of type shift / rotate is translated a temporary basic block is generated to handle 0-rotate / 0-shift.
Thus when working in 64-bit mode with a 32-bit operand, the result will never be zero-extended to 64-bit.
E.g:

```py
from miasm2.arch.x86.arch import mn_x86
from miasm2.core import asmblock, parse_asm
from miasm2.arch.x86.ira import ir_a_x86_64
from miasm2.ir.symbexec import SymbolicExecutionEngine
from miasm2.expression.expression import ExprInt

asmcfg, loc_db = parse_asm.parse_txt(mn_x86, 64, '''
main:
MOV        RAX, 0x00
MOV        RCX, RAX
MOV        RAX, 0x4142434445464748
MOV        RDX, RAX
ROR        EDX, CL
RET
''')
asmblock.asm_resolve_final(mn_x86, asmcfg, loc_db)
ir_arch = ir_a_x86_64(loc_db)
ircfg = ir_arch.new_ircfg_from_asmcfg(asmcfg)
symb = SymbolicExecutionEngine(ir_arch)
cur_addr = symb.run_at(ircfg, 0x00)
assert  symb.symbols[mn_x86.regs.RDX] == ExprInt(0x45464748, 64)
```

I don't know if it is the best option but I decided to update flags only in the temporary block and destination is updated in the original block.

Also attached another commit that fix a typeerror in the C translator (`TypeError: %d format: a number is required, not str`)

Waiting for your input.