### PR TITLE
change return type of cntleadzeros to uint64_t

### DIFF
--- a/miasm2/jitter/op_semantics.c
+++ b/miasm2/jitter/op_semantics.c
@@ -253,15 +253,15 @@ uint64_t rot_right(uint64_t size, uint64_t a, uint64_t b)
  * - cntleadzeros(size=32, src=2): 30
  * - cntleadzeros(size=32, src=0): 32
  */
-unsigned int cntleadzeros(uint64_t size, uint64_t src)
+uint64_t cntleadzeros(uint64_t size, uint64_t src)
 {
 	int64_t i;
 
 	for (i=(int64_t)size-1; i>=0; i--){
 		if (src & (1ull << i))
-			return (unsigned int)(size - (i + 1));
+			return (uint64_t)(size - (i + 1));
 	}
-	return (unsigned int)size;
+	return (uint64_t)size;
 }
 
 /*

--- a/miasm2/jitter/op_semantics.h
+++ b/miasm2/jitter/op_semantics.h
@@ -37,7 +37,7 @@ _MIASM_EXPORT unsigned int umul16_hi(unsigned short a, unsigned short b);
 _MIASM_EXPORT uint64_t rot_left(uint64_t size, uint64_t a, uint64_t b);
 _MIASM_EXPORT uint64_t rot_right(uint64_t size, uint64_t a, uint64_t b);
 
-_MIASM_EXPORT unsigned int cntleadzeros(uint64_t size, uint64_t src);
+_MIASM_EXPORT uint64_t cntleadzeros(uint64_t size, uint64_t src);
 _MIASM_EXPORT unsigned int cnttrailzeros(uint64_t size, uint64_t src);
 
 #define UDIV(sizeA)						\


### PR DESCRIPTION
Hello,

### Problem description

I encountered a problem when jitting the following code with GCC:

```
MOV     RCX, 0x3401281234
MOV     RDX, 0x12345678
BSR     RDX, RCX
```
`RDX` is equal to `0x0000000100000025` instead of `0x0000000000000025`.

When looking at the generated `C` file here is line where the problem occurs (as the function `cntleadzeros` return type is `unsigned int`, cf https://github.com/cea-sec/miasm/blob/master/miasm2/jitter/op_semantics.h#L40):

```C
var_64_00 = (((((-(cntleadzeros(0x40, mycpu->RCX)))&0xffffffffffffffff) + 0x3fULL)&0xffffffffffffffff))&0xffffffffffffffffULL;
                // ^ bad cast here :(
```

### How to reproduce the problem?

```python
from elfesteem.strpatchwork import StrPatchwork

from miasm2.arch.x86.arch import mn_x86
from miasm2.core import asmblock, parse_asm
from miasm2.arch.x86.ira import ir_a_x86_64
from miasm2.ir.symbexec import SymbolicExecutionEngine
from miasm2.expression.expression import ExprInt

def get_bytes(patches):
    output = StrPatchwork()
    for offset, raw in patches.items():
        output[offset] = raw
    return str(output)

def print_ir(loc_db, asmcfg):
    ir_arch = ir_a_x86_64(loc_db)
    ircfg = ir_arch.new_ircfg_from_asmcfg(asmcfg)
    for lbl, irblock in ircfg.blocks.items():
        print irblock

def jit_it(data, reg_res, cpu_cfg={}):
    from miasm2.analysis.machine import Machine
    from miasm2.jitter.csts import PAGE_READ
    def code_sentinelle(jitter):
        jitter.run = False
        jitter.pc = 0
        return True
    machine = Machine("x86_64")
    jitter = machine.jitter()
    #jitter = machine.jitter("python")
    for k, v in cpu_cfg.items():
        setattr(jitter.cpu, k, v)
    jitter.init_stack()
    run_addr = 0x40000000
    jitter.vm.add_memory_page(run_addr, PAGE_READ, data)
    jitter.push_uint64_t(0x1337BEEF)
    jitter.add_breakpoint(0x1337BEEF, code_sentinelle)
    jitter.init_run(run_addr)
    jitter.continue_run()
    assert jitter.run is False
    return getattr(jitter.cpu, reg_res)

asmcfg, loc_db = parse_asm.parse_txt(mn_x86, 64, '''
main:
    MOV     RCX, 0x3401281234
    MOV     RDX, 0x12345678
    BSR     RDX, RCX
    RET
''')

patches = asmblock.asm_resolve_final(mn_x86, asmcfg, loc_db)
data = get_bytes(patches)
#print_ir(loc_db, asmcfg)
rdx = jit_it(data, "RDX")
assert rdx == 0x25
```
Let me know If I missed something.