### PR TITLE
Revert 879 mov assignexpr rot shift ; Simplify assignexpr rot shift & patch simplification

### DIFF
--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -638,7 +638,7 @@ def _rotate_tpl(ir, instr, dst, src, op, left=False):
             ]
     e = []
     if dst.size == 32 and dst in replace_regs[64]:
-        e.append(m2_expr.ExprAssign(dst[:dst.size], dst))
+        e.append(m2_expr.ExprAssign(dst, dst))
     # Don't generate conditional shifter on constant
     if isinstance(shifter, m2_expr.ExprInt):
         if int(shifter) != 0:
@@ -688,7 +688,7 @@ def rotate_with_carry_tpl(ir, instr, op, dst, src):
             ]
     e = []
     if dst.size == 32 and dst in replace_regs[64]:
-        e.append(m2_expr.ExprAssign(dst[:dst.size], dst))
+        e.append(m2_expr.ExprAssign(dst, dst))
     # Don't generate conditional shifter on constant
     if isinstance(shifter, m2_expr.ExprInt):
         if int(shifter) != 0:
@@ -776,7 +776,7 @@ def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None, left=False,
     e_do += update_flag_znp(res)
     e = []
     if a.size == 32 and a in replace_regs[64]:
-        e.append(m2_expr.ExprAssign(a[:a.size], a))
+        e.append(m2_expr.ExprAssign(a, a))
     # Don't generate conditional shifter on constant
     if isinstance(shifter, m2_expr.ExprInt):
         if int(shifter) != 0:
@@ -5652,7 +5652,6 @@ class ir_x86_16(IntermediateRepresentation):
 
         instr_ir, extra_ir = mnemo_func[
             instr.name.lower()](self, instr, *args)
-
         self.mod_pc(instr, instr_ir, extra_ir)
         instr.additional_info.except_on_instr = False
         if instr.additional_info.g1.value & 6 == 0 or \

--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -636,9 +636,7 @@ def _rotate_tpl(ir, instr, dst, src, op, left=False):
             m2_expr.ExprAssign(of, new_of),
             m2_expr.ExprAssign(dst, res)
             ]
-    e = []
-    if dst.size == 32 and dst in replace_regs[64]:
-        e.append(m2_expr.ExprAssign(dst, dst))
+    e = [m2_expr.ExprAssign(dst, dst)]
     # Don't generate conditional shifter on constant
     if isinstance(shifter, m2_expr.ExprInt):
         if int(shifter) != 0:
@@ -686,9 +684,7 @@ def rotate_with_carry_tpl(ir, instr, op, dst, src):
             m2_expr.ExprAssign(of, new_of),
             m2_expr.ExprAssign(dst, new_dst)
             ]
-    e = []
-    if dst.size == 32 and dst in replace_regs[64]:
-        e.append(m2_expr.ExprAssign(dst, dst))
+    e = [m2_expr.ExprAssign(dst, dst)]
     # Don't generate conditional shifter on constant
     if isinstance(shifter, m2_expr.ExprInt):
         if int(shifter) != 0:
@@ -774,9 +770,7 @@ def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None, left=False,
         m2_expr.ExprAssign(a, res),
     ]
     e_do += update_flag_znp(res)
-    e = []
-    if a.size == 32 and a in replace_regs[64]:
-        e.append(m2_expr.ExprAssign(a, a))
+    e = [m2_expr.ExprAssign(a, a)]
     # Don't generate conditional shifter on constant
     if isinstance(shifter, m2_expr.ExprInt):
         if int(shifter) != 0:

--- a/miasm2/ir/translators/C.py
+++ b/miasm2/ir/translators/C.py
@@ -317,7 +317,7 @@ class TranslatorC(Translator):
                         ">>>": "ror",
                         "<<<": "rol"
                     }
-                    out = "bignum_%d(%s, %d, bignum_to_uint64(%s))" % (
+                    out = "bignum_%s(%s, %d, bignum_to_uint64(%s))" % (
                         op[expr.op], arg0, expr.size, arg1
                     )
                     out = "bignum_mask(%s, %d)"% (out, expr.size)

--- a/miasm2/ir/translators/C.py
+++ b/miasm2/ir/translators/C.py
@@ -317,7 +317,7 @@ class TranslatorC(Translator):
                         ">>>": "ror",
                         "<<<": "rol"
                     }
-                    out = "bignum_%s(%s, %d, bignum_to_uint64(%s))" % (
+                    out = "bignum_%d(%s, %d, bignum_to_uint64(%s))" % (
                         op[expr.op], arg0, expr.size, arg1
                     )
                     out = "bignum_mask(%s, %d)"% (out, expr.size)

--- a/miasm2/jitter/codegen.py
+++ b/miasm2/jitter/codegen.py
@@ -170,7 +170,8 @@ class CGen(object):
             # Simplify high level operators
             out = []
             for irblock in irblocks:
-                new_irblock = irblock.simplify(expr_simp_high_to_explicit)[1]
+                new_irblock = self.ir_arch.irbloc_fix_regs_for_mode(irblock, self.ir_arch.attrib)
+                new_irblock = new_irblock.simplify(expr_simp_high_to_explicit)[1]
                 out.append(new_irblock)
             irblocks = out
 
@@ -631,13 +632,12 @@ class CGen(object):
         for instr, irblocks in zip(block.lines, irblocks_list):
             instr_attrib, irblocks_attributes = self.get_attributes(instr, irblocks, log_mn, log_regs)
             for index, irblock in enumerate(irblocks):
-                new_irblock = self.ir_arch.irbloc_fix_regs_for_mode(irblock, self.ir_arch.attrib)
-                label = str(new_irblock.loc_key)
+                label = str(irblock.loc_key)
                 out.append("%-40s // %.16X %s" %
                            (label + ":", instr.offset, instr))
                 if index == 0:
                     out += self.gen_pre_code(instr_attrib)
-                out += self.gen_irblock(instr_attrib, irblocks_attributes[index], instr_offsets, new_irblock)
+                out += self.gen_irblock(instr_attrib, irblocks_attributes[index], instr_offsets, irblock)
 
         out += self.gen_finalize(block)
 


### PR DESCRIPTION
Hello,

You are gonna hate me but there is still some problems...

My test case was not good enough because the same bug is still present when using the GCC JIT.

I didn't catch the issue because when the IR was displayed, the assignation was as follow:

`RDX = zeroExt_64(RDX[0:32])`

But in fact the operation returned was:

`ExprAssign(ExprId('EDX', 32), ExprId('EDX', 32))`

So under the python jitter, the zeroextend was done, but not under GCC JIT, the operation disappeared in the generated C file.

Now the fix create the following asssignation expression:

`ExprAssign(ExprId('RDX', 64), ExprOp('zeroExt_32', ExprId('EDX', 32)))`

Now the test seems ok with python or GCC JIT.

Sorry for the inconvenience.