### PR TITLE
X86 SEM CMOV : add zeroextent if destination size is 32

### DIFF
--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -398,7 +398,7 @@ def gen_cmov(ir, instr, cond, dst, src, mov_if):
         dstA, dstB = loc_do_expr, loc_skip_expr
     else:
         dstA, dstB = loc_skip_expr, loc_do_expr
-    e = []
+    e = [m2_expr.ExprAssign(dst, dst)]
     e_do, extra_irs = mov(ir, instr, dst, src)
     e_do.append(m2_expr.ExprAssign(ir.IRDst, loc_skip_expr))
     e.append(m2_expr.ExprAssign(ir.IRDst, m2_expr.ExprCond(cond, dstA, dstB)))


### PR DESCRIPTION
Hello,

When an operation of type CMOV is translated a temporary basic block is generated, thus when working in 64-bit mode with a 32-bit operand, the result will never be zero-extended to 64-bit.

This is a clone of some previus pull request but for CMOV instruction.

Test case:

```python
from elfesteem.strpatchwork import StrPatchwork

from miasm2.arch.x86.arch import mn_x86
from miasm2.core import asmblock, parse_asm
from miasm2.arch.x86.ira import ir_a_x86_64
from miasm2.ir.symbexec import SymbolicExecutionEngine
from miasm2.expression.expression import ExprInt

def get_bytes(patches):
    output = StrPatchwork()
    for offset, raw in patches.items():
        output[offset] = raw
    return str(output)

def print_ir(loc_db, asmcfg):
    ir_arch = ir_a_x86_64(loc_db)
    ircfg = ir_arch.new_ircfg_from_asmcfg(asmcfg)
    for lbl, irblock in ircfg.blocks.items():
        print irblock

def jit_it(data, reg_res, cpu_cfg={}):
    from miasm2.analysis.machine import Machine
    from miasm2.jitter.csts import PAGE_READ
    def code_sentinelle(jitter):
        jitter.run = False
        jitter.pc = 0
        return True
    machine = Machine("x86_64")
    jitter = machine.jitter()
    #jitter = machine.jitter("python")
    for k, v in cpu_cfg.items():
        setattr(jitter.cpu, k, v)
    jitter.init_stack()
    run_addr = 0x40000000
    jitter.vm.add_memory_page(run_addr, PAGE_READ, data)
    jitter.push_uint64_t(0x1337BEEF)
    jitter.add_breakpoint(0x1337BEEF, code_sentinelle)
    jitter.init_run(run_addr)
    jitter.continue_run()
    assert jitter.run is False
    return getattr(jitter.cpu, reg_res)

asmcfg, loc_db = parse_asm.parse_txt(mn_x86, 64, '''
main:
    MOV RAX, 0x4142434445464748
    MOV RBX, RAX
    MOV ECX, 1
    MOV EDX, 1
    CMP EDX, ECX
    CMOVNZ EAX, EBX
    RET
''')

patches = asmblock.asm_resolve_final(mn_x86, asmcfg, loc_db)
data = get_bytes(patches)
print_ir(loc_db, asmcfg)
rax = jit_it(data, "RAX")
assert rax == 0x0000000045464748
```

Let me know If I missed something.