### PR TITLE
X86 SEM SH[LR]D : use masked count for all expression in _shift_tpl

### DIFF
--- a/miasm2/arch/x86/sem.py
+++ b/miasm2/arch/x86/sem.py
@@ -735,9 +735,9 @@ def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None, left=False,
 
         # An overflow can occured, emulate the 'undefined behavior'
         # Overflow behavior if (shift / size % 2)
-        base_cond_overflow = c if left else (
-            c - m2_expr.ExprInt(1, size=c.size))
-        cond_overflow = base_cond_overflow & m2_expr.ExprInt(a.size, c.size)
+        base_cond_overflow = shifter if left else (
+            shifter - m2_expr.ExprInt(1, size=shifter.size))
+        cond_overflow = base_cond_overflow & m2_expr.ExprInt(a.size, shifter.size)
         if left:
             # Overflow occurs one round before right
             mask = m2_expr.ExprCond(cond_overflow, mask, ~mask)
@@ -750,7 +750,7 @@ def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None, left=False,
 
         # Overflow case: cf come from src (bit number shifter % size)
         cf_from_src = m2_expr.ExprOp(op, b,
-                                     (c.zeroExtend(b.size) &
+                                     (shifter.zeroExtend(b.size) &
                                       m2_expr.ExprInt(a.size - 1, b.size)) - i1)
         cf_from_src = cf_from_src.msb() if left else cf_from_src[:1]
         new_cf = m2_expr.ExprCond(cond_overflow, cf_from_src, cf_from_dst)


### PR DESCRIPTION
Hello,

In the function `_shift_tpl`, the count (`c`) parameter is used without beeing masked for overflow condition & carry flag filling.

I encountered the following case where the result was not the expected one, with `A=0x1234FDB512345678`, `B=0x21AD96F921AD3D34`, `C=0x21` as entry in `SHLD A[0:32], B[0:32], C`  and the output is equal to `0x00000000435a7a68` instead of `0x000000002468acf0`.

Test case:

```python
from elfesteem.strpatchwork import StrPatchwork

from miasm2.arch.x86.arch import mn_x86
from miasm2.core import asmblock, parse_asm
from miasm2.arch.x86.ira import ir_a_x86_64
from miasm2.ir.symbexec import SymbolicExecutionEngine
from miasm2.expression.expression import ExprInt

def get_bytes(patches):
    output = StrPatchwork()
    for offset, raw in patches.items():
        output[offset] = raw
    return str(output)

def jit_it(data, reg_res, cpu_cfg={}):
    from miasm2.analysis.machine import Machine
    from miasm2.jitter.csts import PAGE_READ
    def code_sentinelle(jitter):
        jitter.run = False
        jitter.pc = 0
        return True
    machine = Machine("x86_64")
    jitter = machine.jitter()
    #jitter = machine.jitter("python")
    for k, v in cpu_cfg.items():
        setattr(jitter.cpu, k, v)
    jitter.init_stack()
    run_addr = 0x40000000
    jitter.vm.add_memory_page(run_addr, PAGE_READ, data)
    jitter.push_uint64_t(0x1337BEEF)
    jitter.add_breakpoint(0x1337BEEF, code_sentinelle)
    jitter.init_run(run_addr)
    jitter.continue_run()
    assert jitter.run is False
    return getattr(jitter.cpu, reg_res)

asmcfg, loc_db = parse_asm.parse_txt(mn_x86, 64, '''
main:
    MOV         RAX, 0x1234FDB512345678
    MOV         RDX, RAX
    MOV         RAX, 0x21AD96F921AD3D34
    MOV         RSI, RAX
    MOV         RAX, 0x0000000000000021
    MOV         RCX, RAX
    SHLD        EDX, ESI, CL
    RET
''')

patches = asmblock.asm_resolve_final(mn_x86, asmcfg, loc_db)
data = get_bytes(patches)
rdx = jit_it(data, "EDX")
print("RDX : {0:016X}".format(rdx))
assert rdx == 0x000000002468ACF0
```

Let me know if I missed something.