### PR TITLE
Correct MeP BGEI semantic

### DIFF
--- a/miasm2/arch/mep/sem.py
+++ b/miasm2/arch/mep/sem.py
@@ -7,7 +7,7 @@ from miasm2.arch.mep.arch import mn_mep
 from miasm2.arch.mep.regs import PC, SP, LP, SAR, TP, RPB, RPE, RPC, EPC, NPC, \
     take_jmp, in_erepeat
 from miasm2.arch.mep.regs import EXC, HI, LO, PSW, DEPC, DBG
-from miasm2.expression.expression import ExprId, ExprInt, ExprOp
+from miasm2.expression.expression import ExprId, ExprInt, ExprOp, TOK_EQUAL
 from miasm2.expression.expression import ExprAssign, ExprCond, ExprMem
 from miasm2.core.cpu import sign_ext
 from miasm2.jitter.csts import EXCEPT_DIV_BY_ZERO
@@ -549,8 +549,9 @@ def bgei(reg_test, imm4, disp16):
     """BGEI - Branch if the register is greater or equal to imm4."""
 
     # if(Rn>=ZeroExt(imm4)) PC <- PC +SignExt((disp17)16..1||0) - (Signed comparison)
-    dst = disp16 if ">="(reg_test, imm4) else ExprLoc(ir.get_next_break_loc_key(instr), 32)
-    take_jmp = ExprInt(1, 32) if ">="(reg_test, imm4) else ExprInt(0, 32)
+    cond = i32(1) if ExprOp(TOK_EQUAL, reg_test, imm4) else compute_s_inf(imm4, reg_test).zeroExtend(32)
+    dst = disp16 if cond else ExprLoc(ir.get_next_break_loc_key(instr), 32)
+    take_jmp = ExprInt(1, 32) if cond else ExprInt(0, 32)
     PC = dst
     ir.IRDst = dst
 

--- a/test/arch/mep/ir/test_branchjump.py
+++ b/test/arch/mep/ir/test_branchjump.py
@@ -3,7 +3,7 @@
 
 from ut_helpers_ir import exec_instruction
 
-from miasm2.expression.expression import ExprId, ExprCond, ExprOp, ExprInt
+from miasm2.expression.expression import ExprId, ExprInt
 
 
 class TestBranchJump:
@@ -105,7 +105,17 @@ class TestBranchJump:
         # BGEI Rn,imm4,disp17.align2
         exec_instruction("BGEI R1, 0x5, 0x10000",
                          [(ExprId("R1", 32), ExprInt(0x10, 32))],
-                         [(ExprId("PC", 32), ExprCond(ExprOp(">=", ExprInt(0x10, 32), ExprInt(0x5, 32)), ExprInt(0xFFFF0010, 32), ExprInt(0x14, 32)))],
+                         [(ExprId("PC", 32), ExprInt(0xFFFF0010, 32))],
+                         offset=0x10)
+
+        exec_instruction("BGEI R1, 0x5, 0x10000",
+                         [(ExprId("R1", 32), ExprInt(0x01, 32))],
+                         [(ExprId("PC", 32), ExprInt(0x14, 32))],
+                         offset=0x10)
+
+        exec_instruction("BGEI R1, 0x5, 0x10000",
+                         [(ExprId("R1", 32), ExprInt(0x05, 32))],
+                         [(ExprId("PC", 32), ExprInt(0xFFFF0010, 32))],
                          offset=0x10)
 
     def test_beq(self):


### PR DESCRIPTION
While jitting a MeP binary with gcc, it discovered that the BGEI instruction semantic is not correct. Here is the fix.