### PR TITLE
Feature/export llvm

### DIFF
--- a/example/expression/export_llvm.py
+++ b/example/expression/export_llvm.py
@@ -1,0 +1,83 @@
+from argparse import ArgumentParser
+from miasm2.analysis.binary import Container
+from miasm2.analysis.machine import Machine
+from miasm2.jitter.llvmconvert import LLVMType, LLVMContext_IRCompilation, LLVMFunction_IRCompilation
+from llvmlite import ir as llvm_ir
+from miasm2.expression.simplifications import expr_simp_high_to_explicit
+
+parser = ArgumentParser("LLVM export example")
+parser.add_argument("target", help="Target binary")
+parser.add_argument("addr", help="Target address")
+parser.add_argument("--architecture", "-a", help="Force architecture")
+args = parser.parse_args()
+
+# This part focus on obtaining an IRCFG to transform #
+cont = Container.from_stream(open(args.target))
+machine = Machine(args.architecture if args.architecture else cont.arch)
+ir = machine.ir(cont.loc_db)
+dis = machine.dis_engine(cont.bin_stream, loc_db=cont.loc_db)
+asmcfg = dis.dis_multiblock(int(args.addr, 0))
+ircfg = ir.new_ircfg_from_asmcfg(asmcfg)
+ircfg.simplify(expr_simp_high_to_explicit)
+######################################################
+
+# Instanciate a context and the function to fill
+context = LLVMContext_IRCompilation()
+context.ir_arch = ir
+
+func = LLVMFunction_IRCompilation(context, name="test")
+func.ret_type = llvm_ir.VoidType()
+func.init_fc()
+
+# Here, as an example, we arbitrarily represent registers with global
+# variables. Locals allocas are used for the computation during the function,
+# and is finally saved in the aforementionned global variable.
+
+# In other words, for each registers:
+# entry:
+#     ...
+#     %reg_val_in = load i32 @REG
+#     %REG = alloca i32
+#     store i32 %reg_val_in, i32* %REG
+#     ...
+# exit:
+#     ...
+#     %reg_val_out = load i32 %REG
+#     store i32 %reg_val_out, i32* @REG
+#     ...
+
+all_regs = set()
+for block in ircfg.blocks.itervalues():
+    for irs in block.assignblks:
+        for dst, src in irs.get_rw(mem_read=True).iteritems():
+            elem = src.union(set([dst]))
+            all_regs.update(x for x in elem
+                            if x.is_id())
+
+reg2glob = {}
+for var in all_regs:
+    # alloca reg = global reg
+    data = context.mod.globals.get(str(var), None)
+    if data is None:
+        data = llvm_ir.GlobalVariable(context.mod,  LLVMType.IntType(var.size), name=str(var))
+    data.initializer = LLVMType.IntType(var.size)(0)
+    value = func.builder.load(data)
+    func.local_vars_pointers[var.name] = func.builder.alloca(llvm_ir.IntType(var.size), name=var.name)
+    func.builder.store(value, func.local_vars_pointers[var.name])
+    reg2glob[var] = data
+
+# IRCFG is imported, without the final "ret void"
+func.from_ircfg(ircfg, append_ret=False)
+
+# Finish the saving of registers (temporary version to global)
+for reg, glob in reg2glob.iteritems():
+    value = func.builder.load(func.local_vars_pointers[reg.name])
+    func.builder.store(value, glob)
+
+# Finish the function
+func.builder.ret_void()
+
+# Get it back
+open("out.ll", "w").write(str(func))
+# The optimized CFG can be seen with:
+# $ opt -O2 -dot-cfg -S out.ll && xdot cfg.test.dot

--- a/miasm2/jitter/llvmconvert.py
+++ b/miasm2/jitter/llvmconvert.py
@@ -482,7 +482,7 @@ class LLVMContext_IRCompilation(LLVMContext):
         return builder.store(value, ptr_casted)
 
 
-class LLVMFunction():
+class LLVMFunction(object):
     """Represent a LLVM function
 
     Implementation note:
@@ -890,6 +890,22 @@ class LLVMFunction():
                     callback = builder.udiv
 
                 ret = callback(arg_a, arg_b)
+                self.update_cache(expr, ret)
+                return ret
+
+            unsigned_cmps = {
+                "==": "==",
+                "<u": "<",
+                "<=u": "<="
+            }
+            if op in unsigned_cmps:
+                op = unsigned_cmps[op]
+                args = [self.add_ir(arg) for arg in expr.args]
+                ret = builder.select(builder.icmp_unsigned(op,
+                                                           args[0],
+                                                           args[1]),
+                                     llvm_ir.IntType(expr.size)(1),
+                                     llvm_ir.IntType(expr.size)(0))
                 self.update_cache(expr, ret)
                 return ret
 

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -664,6 +664,9 @@ testset += ExampleExpression(["expr_c.py"],
 testset += ExampleExpression(["constant_propagation.py",
                               Example.get_sample("simple_test.bin"), "-s", "0"],
                              products=["%s.propag.dot" % Example.get_sample("simple_test.bin")])
+testset += ExampleExpression(["export_llvm.py", "-a", "x86_32", Example.get_sample("simple_test.bin"), "0"],
+                             products=["out.ll"])
+
 
 for script in [["basic_op.py"],
                ["basic_simplification.py"],


### PR DESCRIPTION
Add basics to export an IRCFG as LLVM IR.
Because several tools are working on LLVM IR, but each with specific format, the user have to make its own choices.

For instance:
* for use with [RetDec](https://github.com/avast-tl/retdec), it is better to have all registers always represented as globals, in lower case, `IRDst` replaced by `@_asm_program_counter`, etc.
* for better LLVM transformation, it is nice to represent stack as an array, and represent operation on ESP with `getelementptr` operation
* [McSema](https://github.com/trailofbits/mcsema) made the choice to represent registers as a structure in function argument, with setup and exit functions. It might be better suited for recompilation (for instance, running an ARM code on a x86 machine)
* for better removal and lighter final version, one can add ABI information, such as clobber registers (avoid keeping copy of flags, etc.), link from LLVM function arguments to corresponding registers representation, returning the value in `EAX` instead of void, etc.

It may also be better to perform some of them with LLVM passes.

It would be great to add in a future the LLVM -> Expr, to enjoy going back and forth with LLVM. As Miasm is now supporting SSA, it doesn't seems to hard to achieve.