### PR TITLE
Enable easy pickling of dse snapshots

### DIFF
--- a/miasm2/analysis/dse.py
+++ b/miasm2/analysis/dse.py
@@ -390,7 +390,7 @@ class DSEEngine(object):
         snapshot = {
             "mem": self.jitter.vm.get_all_memory(),
             "regs": self._get_gpregs(),
-            "symb": self.symb.symbols.copy(),
+            "symb": {e: v for e,v in self.symb.symbols.items()}
         }
         return snapshot
 


### PR DESCRIPTION
Pickling currently requires some additional piping but since `DSEEngine.restore_snapshot()` only requires the symbols dictionary (rather than the entire object), this small change allows to simply save DSE state on disk with:
```
snapshot = dse.take_snapshot()
pickle.dump(snapshot, file, pickle.HIGHEST_PROTOCOL)
```
and restore with:
```
snapshot = pickle.load(file)
dse.restore_snapshot(snapshot)
```