### PR TITLE
Make python version explicit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 from distutils.core import setup, Extension
 from distutils.util import get_platform


### PR DESCRIPTION
On many platforms, the `python` binary links to python 3. This change makes the setup script use python2 explicitly 