### PR TITLE
Not shown instruction prefix

### DIFF
--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -540,7 +540,10 @@ class instruction_x86(instruction):
         self.additional_info.prefixed = getattr(c, "prefixed", "")
 
     def __str__(self):
-        o = super(instruction_x86, self).__str__()
+        return self.to_string()
+      
+    def to_string(self, loc_db=None):
+        o = super(instruction_x86, self).to_string(loc_db)
         if self.additional_info.g1.value & 1:
             o = "LOCK %s" % o
         if self.additional_info.g1.value & 2:


### PR DESCRIPTION
Instruction prefix wasn't shown when to_string method was used since instruction_x86(https://github.com/cea-sec/miasm/blob/master/miasm2/arch/x86/arch.py#L452) used just the inherited one from instruction(https://github.com/cea-sec/miasm/blob/master/miasm2/core/cpu.py#L997) which doesn't support these prefixes. It is used perhaps by AsmBlock(https://github.com/cea-sec/miasm/blob/master/miasm2/core/asmblock.py#L147) and it makes the prefixes invisible for it and many others.