### PR TITLE
Translator/z3: fix tipo in z3 cmp operators

### DIFF
--- a/miasm2/ir/translators/z3_ir.py
+++ b/miasm2/ir/translators/z3_ir.py
@@ -219,7 +219,7 @@ class TranslatorZ3(Translator):
                     )
                 elif expr.op == "<s":
                     res = z3.If(
-                        z3.SLT(args[0], args[1]),
+                        args[0] < args[1],
                         z3.BitVecVal(1, 1),
                         z3.BitVecVal(0, 1)
                     )
@@ -231,7 +231,7 @@ class TranslatorZ3(Translator):
                     )
                 elif expr.op == "<=s":
                     res = z3.If(
-                        z3.SLE(args[0], args[1]),
+                        args[0] <= args[1],
                         z3.BitVecVal(1, 1),
                         z3.BitVecVal(0, 1)
                     )


### PR DESCRIPTION
As stated in
https://github.com/Z3Prover/z3/blob/master/src/api/python/z3/z3.py
"Use the operator <= for signed less than or equal to."