### PR TITLE
Stop disassembling at INT

### DIFF
--- a/miasm2/arch/x86/arch.py
+++ b/miasm2/arch/x86/arch.py
@@ -500,7 +500,7 @@ class instruction_x86(instruction):
         if self.name.startswith('LOOP'):
             return True
         if self.name.startswith('INT'):
-            return True
+            return False
         if self.name.startswith('SYS'):
             return True
         return self.name in ['CALL']


### PR DESCRIPTION
When there are INT 3 instructions perhaps behind ExitProcess call and it's in the last basic block of a function(in memory), dis_multiblock(https://github.com/cea-sec/miasm/blob/master/miasm2/core/asmblock.py#L1554) disassembles also the following function if there's no other padding