### PR TITLE
'tuple' object has no attribute 'op'

### DIFF
--- a/miasm/expression/simplifications_common.py
+++ b/miasm/expression/simplifications_common.py
@@ -949,7 +949,7 @@ def simp_cmp_int(expr_simp, expr):
     if len(left) == 1:
         left = left[0]
     else:
-        left = ExprOp(left.op, *left)
+        left = ExprOp(left_orig.op, *left)
 
     if left_orig.op == "+":
         new_int = expr_simp(right - last_int)


### PR DESCRIPTION
if len(left) is more than 1, it will occur 'tuple' object has no attribute 'op'