### PR TITLE
Add compose_and_mask simplification pass

### DIFF
--- a/miasm/expression/simplifications.py
+++ b/miasm/expression/simplifications.py
@@ -58,7 +58,7 @@ class ExpressionSimplifier(object):
             simplifications_common.simp_test_signext_inf,
             simplifications_common.simp_test_zeroext_inf,
             simplifications_common.simp_cond_inf_eq_unsigned_zero,
-
+            simplifications_common.simp_compose_and_mask,
         ],
 
         m2_expr.ExprSlice: [

--- a/miasm/expression/simplifications_common.py
+++ b/miasm/expression/simplifications_common.py
@@ -1570,8 +1570,8 @@ def simp_compose_and_mask(_, expr):
         return expr
     if not arg2.is_int():
         return expr
-    int2 = arg2.arg.arg
+    int2 = arg2.arg
     if (int2 + 1) & int2 != 0:
         return expr
-    mask_size = int2.bit_length() + 7 // 8
+    mask_size = int2.arg.bit_length() + 7 // 8
     return ExprSlice(arg1, 0, mask_size).zeroExtend(expr.size)

--- a/miasm/expression/simplifications_common.py
+++ b/miasm/expression/simplifications_common.py
@@ -1570,7 +1570,8 @@ def simp_compose_and_mask(_, expr):
         return expr
     if not arg2.is_int():
         return expr
-    for i in range(8, arg1.size, 8):
-        if arg2.arg == ExprInt(0, i).mask.arg:
-            return ExprSlice(arg1, 0, i)
-    return expr
+    int2 = arg2.arg.arg
+    if (int2 + 1) & int2 != 0:
+        return expr
+    mask_size = int2.bit_length() + 7 // 8
+    return ExprSlice(arg1, 0, mask_size).zeroExtend(expr.size)

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -194,8 +194,8 @@ to_test = [(ExprInt(1, 32) - ExprInt(1, 32), ExprInt(0, 32)),
             ExprOp('&', a, ExprInt(0xFFFFFFF0, 32))),
 
            (ExprCompose(ExprId("a", 8), ExprId("b", 24)) & ExprInt(0xFF, 32), ExprCompose(ExprId("a", 8), ExprInt(0x0, 24))),
-           (ExprCompose(ExprInt(0x12, 8), ExprInt(0x34, 8)) & ExprInt(0xFFFF, 16), ExprInt(0x3412, 16)),
-           (ExprCompose(ExprInt(0x12, 8), ExprInt(0x345678, 24)) & ExprInt(0xFFFFFF, 32), ExprInt(0x567812, 32)),
+           (ExprCompose(ExprId("a", 8), ExprInt(0x12, 8), ExprId("b", 16)) & ExprInt(0xFFFF, 32), ExprCompose(ExprId("a", 8), ExprInt(0x12, 24))),
+           (ExprCompose(ExprId("a", 8), ExprInt(0x1234, 16), ExprId("b", 8)) & ExprInt(0xFFFF, 32), ExprCompose(ExprId("a", 8), ExprInt(0x34, 24))),
 
            (a[:32], a),
            (a[:8][:8], a[:8]),

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -194,7 +194,7 @@ to_test = [(ExprInt(1, 32) - ExprInt(1, 32), ExprInt(0, 32)),
             ExprOp('&', a, ExprInt(0xFFFFFFF0, 32))),
 
            (ExprCompose(ExprInt(0x1234, 16), ExprId("a", 16)) & ExprInt(0xFF, 32), ExprInt(0x34, 32)),
-           (ExprCompose(ExprInt(0x12, 8), ExprInt(0x34, 8)) & ExprInt(0xFFFF, 16), ExprInt(0x3412, 32)),
+           (ExprCompose(ExprInt(0x12, 8), ExprInt(0x34, 8)) & ExprInt(0xFFFF, 16), ExprInt(0x3412, 16)),
            (ExprCompose(ExprInt(0x12, 8), ExprInt(0x3456, 16), ExprInt(0x78, 8)) & ExprInt(0xFFFFFF, 32), ExprInt(0x345612, 32)),
            (ExprCompose(ExprInt(0x1234, 16), ExprId("a", 8), ExprInt(0x67, 8)) & ExprInt(0xFFFFFFFF, 32), ExprCompose(ExprInt(0x1234, 16), ExprId("a", 8), ExprInt(0x67, 8))),
 

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -193,10 +193,9 @@ to_test = [(ExprInt(1, 32) - ExprInt(1, 32), ExprInt(0, 32)),
            (ExprOp('<<', ExprOp('>>', a, ExprInt(0x4, 32)), ExprInt(0x4, 32)),
             ExprOp('&', a, ExprInt(0xFFFFFFF0, 32))),
 
-           (ExprCompose(ExprInt(0x1234, 16), ExprId("a", 16)) & ExprInt(0xFF, 32), ExprInt(0x34, 32)),
+           (ExprCompose(ExprId("a", 8), ExprId("b", 24)) & ExprInt(0xFF, 32), ExprCompose(ExprId("a", 8), ExprInt(0x0, 24))),
            (ExprCompose(ExprInt(0x12, 8), ExprInt(0x34, 8)) & ExprInt(0xFFFF, 16), ExprInt(0x3412, 16)),
-           (ExprCompose(ExprInt(0x12, 8), ExprInt(0x3456, 16), ExprInt(0x78, 8)) & ExprInt(0xFFFFFF, 32), ExprInt(0x345612, 32)),
-           (ExprCompose(ExprInt(0x1234, 16), ExprId("a", 8), ExprInt(0x67, 8)) & ExprInt(0xFFFFFFFF, 32), ExprCompose(ExprInt(0x1234, 16), ExprId("a", 8), ExprInt(0x67, 8))),
+           (ExprCompose(ExprInt(0x12, 8), ExprInt(0x345678, 24)) & ExprInt(0xFFFFFF, 32), ExprInt(0x567812, 32)),
 
            (a[:32], a),
            (a[:8][:8], a[:8]),

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -192,6 +192,12 @@ to_test = [(ExprInt(1, 32) - ExprInt(1, 32), ExprInt(0, 32)),
             ExprOp('&', a, ExprInt(0x0FFFFFFF, 32))),
            (ExprOp('<<', ExprOp('>>', a, ExprInt(0x4, 32)), ExprInt(0x4, 32)),
             ExprOp('&', a, ExprInt(0xFFFFFFF0, 32))),
+
+           (ExprCompose(ExprInt(0x1234, 16), ExprId("a", 16)) & ExprInt(0xFF, 32), ExprInt(0x34, 8)),
+           (ExprCompose(ExprInt(0x12, 8), ExprInt(0x34, 8)) & ExprInt(0xFFFF, 16), ExprInt(0x3412, 16)),
+           (ExprCompose(ExprInt(0x12, 8), ExprInt(0x3456, 16), ExprInt(0x78, 8)) & ExprInt(0xFFFFFF, 32), ExprInt(0x345612, 32)),
+           (ExprCompose(ExprInt(0x1234, 16), ExprId("a", 8), ExprInt(0x67, 8)) & ExprInt(0xFFFFFFFF, 32), ExprCompose(ExprInt(0x1234, 16), ExprId("a", 8), ExprInt(0x67, 8))),
+
            (a[:32], a),
            (a[:8][:8], a[:8]),
            (a[:16][:8], a[:8]),

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -193,8 +193,8 @@ to_test = [(ExprInt(1, 32) - ExprInt(1, 32), ExprInt(0, 32)),
            (ExprOp('<<', ExprOp('>>', a, ExprInt(0x4, 32)), ExprInt(0x4, 32)),
             ExprOp('&', a, ExprInt(0xFFFFFFF0, 32))),
 
-           (ExprCompose(ExprInt(0x1234, 16), ExprId("a", 16)) & ExprInt(0xFF, 32), ExprInt(0x34, 8)),
-           (ExprCompose(ExprInt(0x12, 8), ExprInt(0x34, 8)) & ExprInt(0xFFFF, 16), ExprInt(0x3412, 16)),
+           (ExprCompose(ExprInt(0x1234, 16), ExprId("a", 16)) & ExprInt(0xFF, 32), ExprInt(0x34, 32)),
+           (ExprCompose(ExprInt(0x12, 8), ExprInt(0x34, 8)) & ExprInt(0xFFFF, 16), ExprInt(0x3412, 32)),
            (ExprCompose(ExprInt(0x12, 8), ExprInt(0x3456, 16), ExprInt(0x78, 8)) & ExprInt(0xFFFFFF, 32), ExprInt(0x345612, 32)),
            (ExprCompose(ExprInt(0x1234, 16), ExprId("a", 8), ExprInt(0x67, 8)) & ExprInt(0xFFFFFFFF, 32), ExprCompose(ExprInt(0x1234, 16), ExprId("a", 8), ExprInt(0x67, 8))),
 


### PR DESCRIPTION
First version of a simplification pass to simplify expressions like `ExprOp('&', ExprCompose(...), mask)`. This is the kind of output expected:
```
>>> from miasm.expression.simplifications import expr_simp
>>> from miasm.expression.expression import *
>>> expr_simp(ExprCompose(ExprInt(0, 24), ExprId('a', 8) & ExprInt(0xFF, 32))
0x0
```