### PR TITLE
Travis: switch from trusty to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - 3.6
 addons:
   apt:
-    sources: ['llvm-toolchain-trusty-6.0', 'ubuntu-toolchain-r-test']
+    sources: ['llvm-toolchain-xenial-6.0', 'ubuntu-toolchain-r-test']
     packages:
       - llvm-6.0
       - llvm-6.0-dev


### PR DESCRIPTION
see: https://travis-ci.community/t/cannot-apt-get-install-clang-5-0/3250