### PR TITLE
modify CreateFile to open file in binary-mode

### DIFF
--- a/miasm/os_dep/win_api_x86_32.py
+++ b/miasm/os_dep/win_api_x86_32.py
@@ -612,7 +612,7 @@ def kernel32_CreateFile(jitter, funcname, get_str):
                     winobjs.lastwin32error = 80
                 else:
                     # first create an empty file
-                    open(sb_fname, 'w').close()
+                    open(sb_fname, 'wb').close()
                     # then open
                     h = open(sb_fname, 'r+b')
                     ret = winobjs.handle_pool.add(sb_fname, h)
@@ -654,7 +654,7 @@ def kernel32_CreateFile(jitter, funcname, get_str):
                     raise NotImplementedError("Untested case")  # to test
             else:
                 # raise NotImplementedError("Untested case") # to test
-                h = open(sb_fname, 'w')
+                h = open(sb_fname, 'wb')
                 ret = winobjs.handle_pool.add(sb_fname, h)
         else:
             raise NotImplementedError("Untested case")


### PR DESCRIPTION
Hello,

I'm not really sure about this one, but `kernel32_WriteFile` seems to write bytearrays. So in case of a `GENERIC_WRITE`, the file should be open in `wb` mode.

It should correct the error:
```
[INFO]: kernel32_CreateFile(lpfilename=0x13fdd1, access=0x40000000, dwsharedmode=0x0, lpsecurityattr=0x0, dwcreationdisposition=0x2, dwflagsandattr=0x80, htemplatefile=0x0) ret addr: 0x40212b
[INFO]: kernel32_WriteFile(hwnd=0x259, lpbuffer=0x40307c, nnumberofbytestowrite=0x7600, lpnumberofbyteswrite=0x40305c, lpoverlapped=0x0) ret addr: 0x40214c
Traceback (most recent call last):
  File "sandbox.py", line 15, in <module>
    sb.run()
  File "/usr/local/lib/python3.6/dist-packages/miasm/analysis/sandbox.py", line 524, in run
    super(Sandbox_Win_x86_32, self).run(addr)
  File "/usr/local/lib/python3.6/dist-packages/miasm/analysis/sandbox.py", line 135, in run
    self.jitter.continue_run()
  File "/usr/local/lib/python3.6/dist-packages/miasm/jitter/jitload.py", line 405, in continue_run
    return next(self.run_iterator)
  File "/usr/local/lib/python3.6/dist-packages/miasm/jitter/jitload.py", line 349, in runiter_once
    for res in self.breakpoints_handler.call_callbacks(self.pc, self):
  File "/usr/local/lib/python3.6/dist-packages/miasm/jitter/jitload.py", line 125, in call_callbacks
    res = c(*args)
  File "/usr/local/lib/python3.6/dist-packages/miasm/jitter/jitload.py", line 480, in handle_lib
    ret = func(jitter)
  File "/usr/local/lib/python3.6/dist-packages/miasm/os_dep/win_api_x86_32.py", line 2668, in kernel32_WriteFile
    wh.info.write(data)
TypeError: write() argument must be str, not bytes

```