### PR TITLE
Add roundss/roundsd

### DIFF
--- a/miasm/arch/x86/arch.py
+++ b/miasm/arch/x86/arch.py
@@ -3807,6 +3807,10 @@ addop("mulsd", [bs8(0x0f), bs8(0x59), pref_f2] + rmmod(xmm_reg, rm_arg_xmm_m64))
 addop("divss", [bs8(0x0f), bs8(0x5e), pref_f3] + rmmod(xmm_reg, rm_arg_xmm_m32))
 addop("divsd", [bs8(0x0f), bs8(0x5e), pref_f2] + rmmod(xmm_reg, rm_arg_xmm_m64))
 
+addop("roundss", [bs8(0x0f), bs8(0x3a), bs8(0x0a), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m32) + [u08])
+addop("roundsd", [bs8(0x0f), bs8(0x3a), bs8(0x0b), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m64) + [u08])
 
 addop("pminsw", [bs8(0x0f), bs8(0xea), no_xmm_pref] + rmmod(mm_reg, rm_arg_mm))
 addop("pminsw", [bs8(0x0f), bs8(0xea), pref_66] + rmmod(xmm_reg, rm_arg_xmm))


### PR DESCRIPTION
This change adds support for [`roundss`](https://www.felixcloutier.com/x86/roundss) and [`roundsd`](https://www.felixcloutier.com/x86/roundsd) instruction.

Three new ops are added for rounding:
- 'fpround_towardsnearest': rounds to nearest int, even for ties
- 'fpround_down': rounds to nearest int <= float
- 'fpround_up': rounds to nearest int >= float
- 'fpround_towardszero'(existing): rounds to nearest int s.t. |int| <=
                                       |float|
    
For a variant of roundsd that uses mxcsr register as the rounding mode,
currently we assume it's fpround_towardsnearest. This may cause trouble
if the program modifies MXCSR register.

Fix #1069 