### PR TITLE
Adds a missing import

### DIFF
--- a/miasm/os_dep/win_api_x86_32.py
+++ b/miasm/os_dep/win_api_x86_32.py
@@ -36,7 +36,7 @@ except ImportError:
     print("cannot find crypto, skipping")
 
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE, PAGE_EXEC
-from miasm.core.utils import pck16, pck32, hexdump, whoami
+from miasm.core.utils import pck16, pck32, hexdump, whoami, int_to_byte
 from miasm.os_dep.common import heap, windows_to_sbpath
 from miasm.os_dep.common import set_str_unic, set_str_ansi
 from miasm.os_dep.common import get_fmt_args as _get_fmt_args


### PR DESCRIPTION
It seems that a python import was missing here :
```
$ python sandbox_pe_x86_64.py ./something.dll_.bin
[WARNING]: Create dummy entry for 'kernel32.dll'
[WARNING]: Create dummy entry for 'user32.dll'
[WARNING]: Create dummy entry for 'secur32.dll'
[WARNING]: Create dummy entry for 'msvcrt.dll'
[INFO]: msvcrt_memset(addr=0x13ff78, c=0x0, size=0x18) ret addr: 0x140001e10L
Traceback (most recent call last):
  File "sandbox_pe_x86_64.py", line 15, in <module>
    sb.run()
  File "/usr/local/lib/python2.7/dist-packages/miasm/analysis/sandbox.py", line 560, in run
    super(Sandbox_Win_x86_64, self).run(addr)
  File "/usr/local/lib/python2.7/dist-packages/miasm/analysis/sandbox.py", line 135, in run
    self.jitter.continue_run()
  File "/usr/local/lib/python2.7/dist-packages/miasm/jitter/jitload.py", line 405, in continue_run
    return next(self.run_iterator)
  File "/usr/local/lib/python2.7/dist-packages/miasm/jitter/jitload.py", line 349, in runiter_once
    for res in self.breakpoints_handler.call_callbacks(self.pc, self):
  File "/usr/local/lib/python2.7/dist-packages/miasm/jitter/jitload.py", line 125, in call_callbacks
    res = c(*args)
  File "/usr/local/lib/python2.7/dist-packages/miasm/jitter/jitload.py", line 480, in handle_lib
    ret = func(jitter)
  File "/usr/local/lib/python2.7/dist-packages/miasm/os_dep/win_api_x86_32.py", line 1864, in msvcrt_memset
    jitter.vm.set_mem(args.addr, int_to_byte(args.c) * args.size)
NameError: global name 'int_to_byte' is not defined
```