### PR TITLE
Path are str

### DIFF
--- a/example/jitter/unpack_upx.py
+++ b/example/jitter/unpack_upx.py
@@ -5,6 +5,8 @@ from pdb import pm
 from miasm.loader import pe
 from miasm.analysis.sandbox import Sandbox_Win_x86_32
 
+from miasm.os_dep.common import get_win_str_a
+
 # User defined methods
 
 def kernel32_GetProcAddress(jitter):
@@ -17,7 +19,7 @@ def kernel32_GetProcAddress(jitter):
 
     # Handle ordinal imports
     fname = (args.fname if args.fname < 0x10000
-             else jitter.get_str_ansi(args.fname))
+             else get_win_str_a(jitter, args.fname))
     logging.error(fname)
 
     # Get the generated address of the library, and store it in memory to

--- a/example/symbol_exec/dse_crackme.py
+++ b/example/symbol_exec/dse_crackme.py
@@ -20,6 +20,7 @@ from miasm.core.utils import int_to_byte
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
 from miasm.analysis.sandbox import Sandbox_Linux_x86_64
 from miasm.expression.expression import *
+from miasm.os_dep.win_api_x86_32 import get_win_str_a
 
 is_win = platform.system() == "Windows"
 
@@ -37,7 +38,7 @@ def xxx_fopen(jitter):
     '''
     global my_FILE_ptr
     ret_addr, args = jitter.func_args_systemv(['path', 'mode'])
-    fname = jitter.get_str_ansi(args.path)
+    fname = get_win_str_a(jitter, args.path)
     FILE_to_info[my_FILE_ptr] = FInfo(fname, open(fname, "rb"))
     my_FILE_ptr += 1
     return jitter.func_ret_stdcall(ret_addr, my_FILE_ptr - 1)
@@ -139,7 +140,7 @@ def xxx_fopen_symb(dse):
     mode = dse.eval_expr(regs.RSI)
     assert fname_addr.is_int()
     assert mode.is_int()
-    fname = dse.jitter.get_str_ansi(int(fname_addr))
+    fname = get_win_str_a(dse.jitter, int(fname_addr))
     ret_addr = ExprInt(dse.jitter.get_stack_arg(0), regs.RIP.size)
 
     assert len(FILE_to_info_symb) == 0
@@ -223,7 +224,7 @@ class FinishOn(Exception):
         super(FinishOn, self).__init__()
 
 def xxx_puts_symb(dse):
-    string = dse.jitter.get_str_ansi(dse.jitter.cpu.RDI)
+    string = get_win_str_a(dse.jitter, dse.jitter.cpu.RDI)
     raise FinishOn(string)
 
 

--- a/miasm/analysis/depgraph.py
+++ b/miasm/analysis/depgraph.py
@@ -15,7 +15,7 @@ from miasm.expression.expression_helper import possible_values
 
 try:
     import z3
-except ImportError:
+except:
     pass
 
 @total_ordering

--- a/miasm/analysis/dse.py
+++ b/miasm/analysis/dse.py
@@ -52,7 +52,7 @@ from collections import namedtuple
 
 try:
     import z3
-except ImportError:
+except:
     z3 = None
 
 from future.utils import viewitems

--- a/miasm/analysis/sandbox.py
+++ b/miasm/analysis/sandbox.py
@@ -6,13 +6,13 @@ import logging
 from argparse import ArgumentParser
 
 from future.utils import viewitems, viewvalues
+from past.builtins import basestring
 
-from miasm.core.utils import force_bytes
 from miasm.analysis.machine import Machine
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
 from miasm.analysis import debugging
 from miasm.jitter.jitload import log_func
-
+from miasm.core.utils import force_bytes
 
 
 class Sandbox(object):
@@ -51,8 +51,7 @@ class Sandbox(object):
         """
 
         # Initialize
-        if not isinstance(fname, bytes):
-            fname = fname.encode('utf8')
+        assert isinstance(fname, basestring)
         self.fname = fname
         self.options = options
         if custom_methods is None:
@@ -183,17 +182,18 @@ class Arch(object):
 
 class OS_Win(OS):
     # DLL to import
-    ALL_IMP_DLL = ["ntdll.dll", "kernel32.dll", "user32.dll",
-                   "ole32.dll", "urlmon.dll",
-                   "ws2_32.dll", 'advapi32.dll', "psapi.dll",
-                   ]
-    modules_path = b"win_dll"
+    ALL_IMP_DLL = [
+        "ntdll.dll", "kernel32.dll", "user32.dll",
+        "ole32.dll", "urlmon.dll",
+        "ws2_32.dll", 'advapi32.dll', "psapi.dll",
+    ]
+    modules_path = "win_dll"
 
     def __init__(self, custom_methods, *args, **kwargs):
         from miasm.jitter.loader.pe import vm_load_pe, vm_load_pe_libs,\
             preload_pe, libimp_pe, vm_load_pe_and_dependencies
         from miasm.os_dep import win_api_x86_32, win_api_x86_32_seh
-        methods = dict((name.encode(),func) for name, func in viewitems(win_api_x86_32.__dict__))
+        methods = dict((name, func) for name, func in viewitems(win_api_x86_32.__dict__))
         methods.update(custom_methods)
 
         super(OS_Win, self).__init__(methods, *args, **kwargs)

--- a/miasm/core/utils.py
+++ b/miasm/core/utils.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import sys
 from builtins import range
 import struct
 import inspect
@@ -84,6 +85,21 @@ def force_bytes(value):
         return value.encode()
     except AttributeError:
         return value
+
+
+def force_str(value):
+    if isinstance(value, str):
+        return value
+    elif isinstance(value, bytes):
+        out = ""
+        for i in range(len(value)):
+            # For Python2/Python3 compatibility
+            c = ord(value[i:i+1])
+            out += chr(c)
+        value = out
+    else:
+        raise ValueError("Unsupported type")
+    return value
 
 
 def iterbytes(string):

--- a/miasm/jitter/jitload.py
+++ b/miasm/jitter/jitload.py
@@ -429,8 +429,8 @@ class Jitter(object):
         return self.cpu.get_exception() | self.vm.get_exception()
 
     # commun functions
-    def get_str_ansi(self, addr, max_char=None):
-        """Get ansi str from vm.
+    def get_c_str(self, addr, max_char=None):
+        """Get C str from vm.
         @addr: address in memory
         @max_char: maximum len"""
         l = 0
@@ -440,31 +440,21 @@ class Jitter(object):
             tmp += 1
             l += 1
         value = self.vm.get_mem(addr, l)
-        return value.decode('utf8')
+        value = force_str(value)
+        return value
+
+    def set_c_str(self, addr, value):
+        """Set C str str from vm.
+        @addr: address in memory
+        @value: str"""
+        value = force_bytes(value)
+        self.vm.set_mem(addr, value + b'\x00')
+
+    def get_str_ansi(self, addr, max_char=None):
+        raise NotImplementedError("Deprecated: use os_dep.win_api_x86_32.get_win_str_a")
 
     def get_str_unic(self, addr, max_char=None):
-        """Get unicode str from vm.
-        @addr: address in memory
-        @max_char: maximum len"""
-        l = 0
-        tmp = addr
-        while ((max_char is None or l < max_char) and
-               self.vm.get_mem(tmp, 2) != b"\x00\x00"):
-            tmp += 2
-            l += 2
-        s = self.vm.get_mem(addr, l)
-        s = s.decode("utf-16le")
-        return s
-
-    def set_str_ansi(self, addr, string):
-        """Set an ansi string in memory"""
-        string = (string + "\x00").encode('utf8')
-        self.vm.set_mem(addr, string)
-
-    def set_str_unic(self, addr, string):
-        """Set an unicode string in memory"""
-        s = (string + "\x00").encode('utf-16le')
-        self.vm.set_mem(addr, s)
+        raise NotImplementedError("Deprecated: use os_dep.win_api_x86_32.get_win_str_a")
 
     @staticmethod
     def handle_lib(jitter):
@@ -501,7 +491,6 @@ class Jitter(object):
         self.libs = libs
         out = {}
         for name, func in viewitems(user_globals):
-            name = force_bytes(name)
             out[name] = func
         self.user_globals = out
 

--- a/miasm/jitter/loader/elf.py
+++ b/miasm/jitter/loader/elf.py
@@ -9,6 +9,7 @@ import miasm.loader.elf as elf_csts
 
 from miasm.jitter.csts import *
 from miasm.jitter.loader.utils import canon_libname_libfunc, libimp
+from miasm.core.utils import force_str
 from miasm.core.interval import interval
 
 import logging
@@ -26,6 +27,7 @@ def get_import_address_elf(e):
         if not hasattr(sh, 'rel'):
             continue
         for k, v in viewitems(sh.rel):
+            k = force_str(k)
             import2addr[('xxx', k)].add(v.offset)
     return import2addr
 

--- a/miasm/jitter/loader/utils.py
+++ b/miasm/jitter/loader/utils.py
@@ -2,24 +2,23 @@ from builtins import int as int_types
 import logging
 
 from future.utils import viewitems, viewvalues
-
-from miasm.core.utils import force_bytes
+from past.builtins import basestring
 
 log = logging.getLogger('loader_common')
 hnd = logging.StreamHandler()
 hnd.setFormatter(logging.Formatter("[%(levelname)s]: %(message)s"))
 log.addHandler(hnd)
-log.setLevel(logging.INFO)
+log.setLevel(logging.DEBUG)
 
 
 def canon_libname_libfunc(libname, libfunc):
-    libname = force_bytes(libname)
-    dn = libname.split(b'.')[0]
+    assert isinstance(libname, basestring)
+    assert isinstance(libfunc, basestring) or isinstance(libfunc, int)
+    dn = libname.split('.')[0]
     if isinstance(libfunc, int_types):
         return str(dn), libfunc
     else:
-        libfunc = force_bytes(libfunc)
-        return b"%s_%s" % (dn, libfunc)
+        return "%s_%s" % (dn, libfunc)
 
 
 class libimp(object):
@@ -37,11 +36,11 @@ class libimp(object):
         self.fake_libs = set()
 
     def lib_get_add_base(self, name):
-        name = force_bytes(name)
-        name = name.lower().strip(b' ')
-        if not b"." in name:
+        assert isinstance(name, basestring)
+        name = name.lower().strip(' ')
+        if not "." in name:
             log.debug('warning adding .dll to modulename')
-            name += b'.dll'
+            name += '.dll'
             log.debug(name)
 
         if name in self.name2off:
@@ -74,7 +73,7 @@ class libimp(object):
 
         if imp_ord_or_name in self.lib_imp2ad[libad]:
             return self.lib_imp2ad[libad][imp_ord_or_name]
-        # log.debug('new imp %s %s' % (imp_ord_or_name, dst_ad))
+        log.debug('new imp %s %s' % (imp_ord_or_name, dst_ad))
         ad = self.libbase2lastad[libad]
         self.libbase2lastad[libad] += 0x10  # arbitrary
         self.lib_imp2ad[libad][imp_ord_or_name] = ad

--- a/miasm/os_dep/linux/syscall.py
+++ b/miasm/os_dep/linux/syscall.py
@@ -154,7 +154,7 @@ def sys_arml_newuname(jitter, linux_env):
 def sys_generic_access(jitter, linux_env):
     # Parse arguments
     pathname, mode = jitter.syscall_args_systemv(2)
-    rpathname = jitter.get_str_ansi(pathname)
+    rpathname = jitter.get_c_str(pathname)
     rmode = mode
     if mode == 1:
         rmode = "F_OK"
@@ -173,7 +173,7 @@ def sys_generic_access(jitter, linux_env):
 def sys_x86_64_openat(jitter, linux_env):
     # Parse arguments
     dfd, filename, flags, mode = jitter.syscall_args_systemv(4)
-    rpathname = jitter.get_str_ansi(filename)
+    rpathname = jitter.get_c_str(filename)
     log.debug("sys_openat(%x, %r, %x, %x)", dfd, rpathname, flags, mode)
 
     # Stub
@@ -184,7 +184,7 @@ def sys_x86_64_openat(jitter, linux_env):
 def sys_x86_64_newstat(jitter, linux_env):
     # Parse arguments
     filename, statbuf = jitter.syscall_args_systemv(2)
-    rpathname = jitter.get_str_ansi(filename)
+    rpathname = jitter.get_c_str(filename)
     log.debug("sys_newstat(%r, %x)", rpathname, statbuf)
 
     # Stub
@@ -201,7 +201,7 @@ def sys_x86_64_newstat(jitter, linux_env):
 def sys_arml_stat64(jitter, linux_env):
     # Parse arguments
     filename, statbuf = jitter.syscall_args_systemv(2)
-    rpathname = jitter.get_str_ansi(filename)
+    rpathname = jitter.get_c_str(filename)
     log.debug("sys_newstat(%r, %x)", rpathname, statbuf)
 
     # Stub
@@ -229,7 +229,7 @@ def sys_x86_64_writev(jitter, linux_env):
         # };
         iovec = jitter.vm.get_mem(vec + iovec_num * 8 * 2, 8*2)
         iov_base, iov_len = struct.unpack("QQ", iovec)
-        fdesc.write(jitter.get_str_ansi(iov_base)[:iov_len])
+        fdesc.write(jitter.get_c_str(iov_base)[:iov_len])
 
     jitter.syscall_ret_systemv(vlen)
 
@@ -248,7 +248,7 @@ def sys_arml_writev(jitter, linux_env):
         # };
         iovec = jitter.vm.get_mem(vec + iovec_num * 4 * 2, 4*2)
         iov_base, iov_len = struct.unpack("II", iovec)
-        fdesc.write(jitter.get_str_ansi(iov_base)[:iov_len])
+        fdesc.write(jitter.get_c_str(iov_base)[:iov_len])
 
     jitter.syscall_ret_systemv(vlen)
 
@@ -433,7 +433,7 @@ def sys_x86_64_statfs(jitter, linux_env):
     # Parse arguments
     pathname = jitter.cpu.RDI
     buf = jitter.cpu.RSI
-    rpathname = jitter.get_str_ansi(pathname)
+    rpathname = jitter.get_c_str(pathname)
     log.debug("sys_statfs(%r, %x)", rpathname, buf)
 
     # Stub
@@ -486,7 +486,7 @@ def sys_arml_ioctl(jitter, linux_env):
 def sys_generic_open(jitter, linux_env):
     # Parse arguments
     filename, flags, mode = jitter.syscall_args_systemv(3)
-    rpathname = jitter.get_str_ansi(filename)
+    rpathname = jitter.get_c_str(filename)
     log.debug("sys_open(%r, %x, %x)", rpathname, flags, mode)
     # Stub
     # 'mode' is ignored
@@ -569,7 +569,7 @@ def sys_x86_64_newlstat(jitter, linux_env):
     # Parse arguments
     filename = jitter.cpu.RDI
     statbuf = jitter.cpu.RSI
-    rpathname = jitter.get_str_ansi(filename)
+    rpathname = jitter.get_c_str(filename)
     log.debug("sys_newlstat(%s, %x)", rpathname, statbuf)
 
     # Stub
@@ -587,7 +587,7 @@ def sys_arml_lstat64(jitter, linux_env):
     # Parse arguments
     filename = jitter.cpu.R0
     statbuf = jitter.cpu.R1
-    rpathname = jitter.get_str_ansi(filename)
+    rpathname = jitter.get_c_str(filename)
     log.debug("sys_newlstat(%s, %x)", rpathname, statbuf)
 
     # Stub
@@ -607,8 +607,8 @@ def sys_x86_64_lgetxattr(jitter, linux_env):
     name = jitter.cpu.RSI
     value = jitter.cpu.RDX
     size = jitter.cpu.R10
-    rpathname = jitter.get_str_ansi(pathname)
-    rname = jitter.get_str_ansi(name)
+    rpathname = jitter.get_c_str(pathname)
+    rname = jitter.get_c_str(name)
     log.debug("sys_lgetxattr(%r, %r, %x, %x)", rpathname, rname, value, size)
 
     # Stub
@@ -622,8 +622,8 @@ def sys_x86_64_getxattr(jitter, linux_env):
     name = jitter.cpu.RSI
     value = jitter.cpu.RDX
     size = jitter.cpu.R10
-    rpathname = jitter.get_str_ansi(pathname)
-    rname = jitter.get_str_ansi(name)
+    rpathname = jitter.get_c_str(pathname)
+    rname = jitter.get_c_str(name)
     log.debug("sys_getxattr(%r, %r, %x, %x)", rpathname, rname, value, size)
 
     # Stub
@@ -646,7 +646,7 @@ def sys_x86_64_connect(jitter, linux_env):
     fd = jitter.cpu.RDI
     uservaddr = jitter.cpu.RSI
     addrlen = jitter.cpu.RDX
-    raddr = jitter.get_str_ansi(uservaddr + 2)
+    raddr = jitter.get_c_str(uservaddr + 2)
     log.debug("sys_connect(%x, %r, %x)", fd, raddr, addrlen)
 
     # Stub
@@ -698,7 +698,7 @@ def sys_x86_64_readlink(jitter, linux_env):
     path = jitter.cpu.RDI
     buf = jitter.cpu.RSI
     bufsize = jitter.cpu.RDX
-    rpath = jitter.get_str_ansi(path)
+    rpath = jitter.get_c_str(path)
     log.debug("sys_readlink(%r, %x, %x)", rpath, buf, bufsize)
 
     # Stub

--- a/miasm/os_dep/linux_stdlib.py
+++ b/miasm/os_dep/linux_stdlib.py
@@ -143,7 +143,7 @@ def xxx_puts(jitter):
 
 
 def get_fmt_args(jitter, fmt, cur_arg):
-    return _get_fmt_args(fmt, cur_arg, jitter.get_str_ansi, jitter.get_arg_n_systemv)
+    return _get_fmt_args(fmt, cur_arg, jitter.get_c_str, jitter.get_arg_n_systemv)
 
 
 def xxx_snprintf(jitter):
@@ -153,7 +153,7 @@ def xxx_snprintf(jitter):
     output = get_fmt_args(jitter, fmt, cur_arg)
     output = output[:size - 1]
     ret = len(output)
-    jitter.vm.set_mem(args.string, (output + '\x00').encode('utf8'))
+    jitter.set_c_str(args.string, output)
     return jitter.func_ret_systemv(ret_addr, ret)
 
 
@@ -162,7 +162,7 @@ def xxx_sprintf(jitter):
     cur_arg, fmt = 2, args.fmt
     output = get_fmt_args(jitter, fmt, cur_arg)
     ret = len(output)
-    jitter.vm.set_mem(args.string, (output + '\x00').encode('utf8'))
+    jitter.set_c_str(args.string, output)
     return jitter.func_ret_systemv(ret_addr, ret)
 
 
@@ -177,14 +177,14 @@ def xxx_printf(jitter):
 
 def xxx_strcpy(jitter):
     ret_ad, args = jitter.func_args_systemv(["dst", "src"])
-    str_src = jitter.get_str_ansi(args.src) + '\x00'
-    jitter.vm.set_mem(args.dst, str_src.encode('utf8'))
+    str_src = jitter.get_c_str(args.src)
+    jitter.set_c_str(args.dst, str_src)
     jitter.func_ret_systemv(ret_ad, args.dst)
 
 
 def xxx_strlen(jitter):
     ret_ad, args = jitter.func_args_systemv(["src"])
-    str_src = jitter.get_str_ansi(args.src)
+    str_src = jitter.get_c_str(args.src)
     jitter.func_ret_systemv(ret_ad, len(str_src))
 
 
@@ -201,13 +201,13 @@ def xxx_free(jitter):
 
 def xxx_strcmp(jitter):
     ret_ad, args = jitter.func_args_systemv(["ptr_str1", "ptr_str2"])
-    s1 = jitter.get_str_ansi(args.ptr_str1)
-    s2 = jitter.get_str_ansi(args.ptr_str2)
+    s1 = jitter.get_c_str(args.ptr_str1)
+    s2 = jitter.get_c_str(args.ptr_str2)
     jitter.func_ret_systemv(ret_ad, cmp_elts(s1, s2))
 
 
 def xxx_strncmp(jitter):
     ret_ad, args = jitter.func_args_systemv(["ptr_str1", "ptr_str2", "size"])
-    s1 = jitter.get_str_ansi(args.ptr_str1, args.size)
-    s2 = jitter.get_str_ansi(args.ptr_str2, args.size)
+    s1 = jitter.get_c_str(args.ptr_str1, args.size)
+    s2 = jitter.get_c_str(args.ptr_str2, args.size)
     jitter.func_ret_systemv(ret_ad, cmp_elts(s1, s2))

--- a/miasm/os_dep/win_api_x86_32_seh.py
+++ b/miasm/os_dep/win_api_x86_32_seh.py
@@ -81,7 +81,7 @@ return_from_exception = 0x6eadbeef
 
 name2module = []
 main_pe = None
-main_pe_name = b"c:\\xxx\\toto.exe"
+main_pe_name = "c:\\xxx\\toto.exe"
 
 MAX_SEH = 5
 
@@ -254,9 +254,9 @@ def create_modules_chain(jitter, name2module):
                         fname)
             continue
         addr = base_addr + i * 0x1000
-        bpath = fname.replace(b'/', b'\\')
+        bpath = fname.replace('/', '\\')
         bname_str = os.path.split(fname)[1].lower()
-        bname_unicode = bname_str.decode('utf8').encode("utf-16le")
+        bname_unicode = bname_str.encode("utf-16le")
         log.info("Add module %x %r", pe_obj.NThdr.ImageBase, bname_str)
 
         modules_info.add(bname_str, pe_obj, addr)

--- a/test/arch/x86/qemu/testqemu.py
+++ b/test/arch/x86/qemu/testqemu.py
@@ -48,7 +48,7 @@ def xxx___printf_chk(jitter):
     ret_ad, args = jitter.func_args_systemv(["out", "format"])
     if args.out != 1:
         raise RuntimeError("Not implemented")
-    fmt = jitter.get_str_ansi(args.format)
+    fmt = jitter.get_c_str(args.format)
     # Manage llx
     fmt = fmt.replace("llx", "lx")
     fmt = fmt.replace("%016lx", "%016z")
@@ -60,7 +60,7 @@ def xxx___printf_chk(jitter):
     for x in fmt_a:
         a = jitter.vm.get_u32(esp + 8 + 4*i)
         if x == "s":
-            a = jitter.get_str_ansi(a)
+            a = jitter.get_c_str(a)
         elif x in ("x", 'X', "d"):
             pass
         elif x.lower() in ("f", "l"):
@@ -102,7 +102,7 @@ def xxx_puts(jitter):
     writes the string s and a trailing newline to stdout.
     '''
     ret_addr, args = jitter.func_args_systemv(['target'])
-    output = jitter.get_str_ansi(args.target)
+    output = jitter.get_c_str(args.target)
     # Check with expected result
     line = next(expected)
     if output != line.rstrip():

--- a/test/arch/x86/qemu/testqemu64.py
+++ b/test/arch/x86/qemu/testqemu64.py
@@ -48,7 +48,7 @@ def xxx___printf_chk(jitter):
     ret_ad, args = jitter.func_args_systemv(["out", "format"])
     if args.out != 1:
         raise RuntimeError("Not implemented")
-    fmt = jitter.get_str_ansi(args.format)
+    fmt = jitter.get_c_str(args.format)
     # Manage llx
     fmt = fmt.replace("llx", "lx")
     fmt = fmt.replace("%016lx", "%016z")
@@ -60,7 +60,7 @@ def xxx___printf_chk(jitter):
     for x in fmt_a:
         a = jitter.get_arg_n_systemv(2 + i)
         if x == "s":
-            a = jitter.get_str_ansi(a)
+            a = jitter.get_c_str(a)
         elif x in ("x", 'X', 'd', 'z', 'Z'):
             pass
         elif x.lower() in ("f","l"):
@@ -98,7 +98,7 @@ def xxx_puts(jitter):
     writes the string s and a trailing newline to stdout.
     '''
     ret_addr, args = jitter.func_args_systemv(['target'])
-    output = jitter.get_str_ansi(args.target)
+    output = jitter.get_c_str(args.target)
     # Check with expected result
     line = next(expected)
     if output != line.rstrip():

--- a/test/os_dep/linux/stdlib.py
+++ b/test/os_dep/linux/stdlib.py
@@ -33,7 +33,7 @@ class TestLinuxStdlib(unittest.TestCase):
         jit.push_uint32_t(buf)
         jit.push_uint32_t(0) # ret_ad
         stdlib.xxx_sprintf(jit)
-        ret = jit.get_str_ansi(buf)
+        ret = jit.get_c_str(buf)
         self.assertEqual(ret, "'coucou' 1111")
 
 

--- a/test/os_dep/win_api_x86_32.py
+++ b/test/os_dep/win_api_x86_32.py
@@ -6,6 +6,7 @@ import unittest
 import logging
 from miasm.analysis.machine import Machine
 import miasm.os_dep.win_api_x86_32 as winapi
+from miasm.os_dep.win_api_x86_32 import get_win_str_a, get_win_str_w
 from miasm.core.utils import pck32
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
 
@@ -42,7 +43,7 @@ class TestWinAPI(unittest.TestCase):
         jit.push_uint32_t(buf)
         jit.push_uint32_t(0) # ret_ad
         winapi.msvcrt_sprintf(jit)
-        ret = jit.get_str_ansi(buf)
+        ret = get_win_str_a(jit, buf)
         self.assertEqual(ret, "'coucou' 1111")
 
 
@@ -63,7 +64,7 @@ class TestWinAPI(unittest.TestCase):
         jit.push_uint32_t(buf)
         jit.push_uint32_t(0) # ret_ad
         winapi.msvcrt_swprintf(jit)
-        ret = jit.get_str_unic(buf)
+        ret = get_win_str_w(jit, buf)
         self.assertEqual(ret, u"'coucou' 1111")
 
 
@@ -94,7 +95,7 @@ class TestWinAPI(unittest.TestCase):
         jit.push_uint32_t(size)   # size
         jit.push_uint32_t(0)      # @return
         winapi.kernel32_GetCurrentDirectoryA(jit)
-        dir_ = jit.get_str_ansi(addr)
+        dir_ = get_win_str_a(jit, addr)
         size_ret = jit.cpu.EAX
         self.assertEqual(len(dir_), size_ret)
 
@@ -106,7 +107,7 @@ class TestWinAPI(unittest.TestCase):
         winapi.kernel32_GetCurrentDirectoryA(jit)
         size_ret = jit.cpu.EAX
         self.assertEqual(len(dir_)+1, size_ret)
-        dir_short = jit.get_str_ansi(addr)
+        dir_short = get_win_str_a(jit, addr)
         self.assertEqual(dir_short, dir_[:4])
 
     def test_MemoryManagementFunctions(self):

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -923,7 +923,7 @@ By default, all tag are considered." % ", ".join(list(TAGS)), default="")
     # Handle Z3 dependency
     try:
         import z3
-    except ImportError:
+    except:
         print("%(red)s[Z3]%(end)s " % cosmetics.colors + \
             "Z3 and its python binding are necessary for TranslatorZ3.")
         if TAGS["z3"] not in exclude_tags:


### PR DESCRIPTION
 Clean `get_str_*` API

`get_str_ansi` decoded strings using utf8 and was blindly used for pure
windows function (`LoadLibraryA`) and for `stdlib` functions (printf,
strlen, ...) even if strlen does not use utf8...

New API is:

`get_win_str_a`/`get_win_str_w` and `set_win_str_a`/`set_win_str_w` for
windows (respectively `codepage1252`/`windows utf16`) .Those functions
should only be used in windows strings manipulations, so there are taken
out of the jitter.

`get_c_str`/`set_c_str`: as those functions are "classic" in OSes, they are
keeped in the jitter.


The z3 fix is there to cover Attribute error in z3 import for some distribs. 