### PR TITLE
Jitter/llvm: Fix llvm Memory lookup cache

### DIFF
--- a/miasm/jitter/llvmconvert.py
+++ b/miasm/jitter/llvmconvert.py
@@ -1210,7 +1210,9 @@ class LLVMFunction(object):
         if isinstance(expr, ExprMem):
 
             addr = self.add_ir(expr.ptr)
-            return self.llvm_context.memory_lookup(self, addr, expr.size)
+            ret = self.llvm_context.memory_lookup(self, addr, expr.size)
+            self.update_cache(expr, ret)
+            return ret
 
         if isinstance(expr, ExprCond):
             # Compute cond


### PR DESCRIPTION
The caching of memory read was missing. This speeds up llvm jitter from multiple point of view:
- llvm can optimze code as no more side effects interfer with code
- avoid calling mem read multiple times

Here is the generated llvm IR for `inc byte ptr [eax]` before (note the multiple `mem_lookup_08`):
```

loc_key_3:
  %".22" = bitcast [36 x i8]* @"printf_format_1" to i8*
  %".23" = call i32 (i8*, ...) @"printf"(i8* %".22")
  %"RAX" = load i64, i64* %".15"
  %".24" = and i64 %"RAX", 4294967295
  %".25" = trunc i64 %".24" to i32
  %".26" = zext i32 %".25" to i64
  %".27" = call i8 @"MEM_LOOKUP_08"(i8* %"jitcpu", i64 %".26")
  %".28" = zext i32 %".25" to i64
  %".29" = call i8 @"MEM_LOOKUP_08"(i8* %"jitcpu", i64 %".28")
  %".30" = sub i8 0, 1
  %".31" = sub i8 0, %".30"
  %".32" = add i8 %".29", %".31"
  %".33" = icmp ne i8 %".32", 0
  %".34" = select i1 %".33", i1 0, i1 1
  %".35" = lshr i8 %".32", 7
  %".36" = and i8 %".35", 1
  %".37" = trunc i8 %".36" to i1
  %".38" = zext i32 %".25" to i64
  %".39" = call i8 @"MEM_LOOKUP_08"(i8* %"jitcpu", i64 %".38")
  %".40" = add i8 %".39", 1
  %".41" = and i8 %".40", 255
  %".42" = call i8 @"llvm.ctpop.i8"(i8 %".41")
  %".43" = trunc i8 %".42" to i1
  %".44" = xor i1 %".43", -1
  %".45" = zext i32 %".25" to i64
  %".46" = call i8 @"MEM_LOOKUP_08"(i8* %"jitcpu", i64 %".45")
  %".47" = xor i8 %".46", %".40"
  %".48" = xor i8 %".47", 1
  %".49" = lshr i8 %".48", 4
  %".50" = and i8 %".49", 1
  %".51" = trunc i8 %".50" to i1
  %".52" = zext i32 %".25" to i64
  %".53" = call i8 @"MEM_LOOKUP_08"(i8* %"jitcpu", i64 %".52")
  %".54" = xor i8 %".53", %".40"
  %".55" = zext i32 %".25" to i64
  %".56" = call i8 @"MEM_LOOKUP_08"(i8* %"jitcpu", i64 %".55")
  %".57" = xor i8 %".56", 1
  %".58" = xor i8 %".57", 255
  %".59" = and i8 %".54", %".58"
  %".60" = lshr i8 %".59", 7
  %".61" = and i8 %".60", 1
  %".62" = trunc i8 %".61" to i1
  %".63" = call i64 @"get_exception_flag"(i8* %"vmmngr")
  %".64" = and i64 %".63", 33554432
  %".65" = icmp ne i64 %".64", 0
  br i1 %".65", label %"then1", label %"ifcond1"
```

and with the fix:
```
loc_key_3:
  %".22" = bitcast [36 x i8]* @"printf_format_1" to i8*
  %".23" = call i32 (i8*, ...) @"printf"(i8* %".22")
  %"RAX" = load i64, i64* %".15"
  %".24" = and i64 %"RAX", 4294967295
  %".25" = trunc i64 %".24" to i32
  %".26" = zext i32 %".25" to i64
  %".27" = call i8 @"MEM_LOOKUP_08"(i8* %"jitcpu", i64 %".26")
  %".28" = sub i8 0, 1
  %".29" = sub i8 0, %".28"
  %".30" = add i8 %".27", %".29"
  %".31" = icmp ne i8 %".30", 0
  %".32" = select i1 %".31", i1 0, i1 1
  %".33" = lshr i8 %".30", 7
  %".34" = and i8 %".33", 1
  %".35" = trunc i8 %".34" to i1
  %".36" = add i8 %".27", 1
  %".37" = and i8 %".36", 255
  %".38" = call i8 @"llvm.ctpop.i8"(i8 %".37")
  %".39" = trunc i8 %".38" to i1
  %".40" = xor i1 %".39", -1
  %".41" = xor i8 %".27", %".36"
  %".42" = xor i8 %".41", 1
  %".43" = lshr i8 %".42", 4
  %".44" = and i8 %".43", 1
  %".45" = trunc i8 %".44" to i1
  %".46" = xor i8 %".27", %".36"
  %".47" = xor i8 %".27", 1
  %".48" = xor i8 %".47", 255
  %".49" = and i8 %".46", %".48"
  %".50" = lshr i8 %".49", 7
  %".51" = and i8 %".50", 1
  %".52" = trunc i8 %".51" to i1
  %".53" = call i64 @"get_exception_flag"(i8* %"vmmngr")
  %".54" = and i64 %".53", 33554432
  %".55" = icmp ne i64 %".54", 0
  br i1 %".55", label %"then1", label %"ifcond1"
```

