### PR TITLE
sembuilder: more compatible way to construct AST module

### DIFF
--- a/miasm/core/sembuilder.py
+++ b/miasm/core/sembuilder.py
@@ -336,10 +336,11 @@ class SemBuilder(object):
                                                               ctx=ast.Load())],
                                                ctx=ast.Load())))
 
-        ret = ast.Module([ast.FunctionDef(name=fc_ast.name,
-                                          args=fc_ast.args,
-                                          body=body,
-                                          decorator_list=[])])
+        ret = ast.parse('')
+        ret.body = [ast.FunctionDef(name=fc_ast.name,
+                                    args=fc_ast.args,
+                                    body=body,
+                                    decorator_list=[])]
 
         # To display the generated function, use codegen.to_source
         # codegen: https://github.com/andreif/codegen


### PR DESCRIPTION
Python3.8 changes the signature of ast.Module by adding a
ignore_comment field which breaks this project. ast.parse("")
is a dirty but more compatible way to make it work in both
Python 3.8 and <3.8.

Fixed #1092