### PR TITLE
DSE: on mem_read, use parent behavior instead of no treatment

### DIFF
--- a/miasm/analysis/dse.py
+++ b/miasm/analysis/dse.py
@@ -109,7 +109,7 @@ class ESETrackModif(EmulatedSymbExec):
 
     def mem_read(self, expr_mem):
         if not expr_mem.ptr.is_int():
-            return expr_mem
+            return super(ESETrackModif, self).mem_read(expr_mem)
         dst_addr = int(expr_mem.ptr)
 
         # Split access in atomic accesses


### PR DESCRIPTION
Fix #1105 

credits @nofiv