### PR TITLE
mmap: ignore offset if MAP_ANONYMOUS set

### DIFF
--- a/miasm/os_dep/linux/environment.py
+++ b/miasm/os_dep/linux/environment.py
@@ -623,9 +623,10 @@ class LinuxEnvironment(object):
                 "mmap allocated"
             )
 
-
         if fd == 0xffffffff:
-            if off != 0:
+            MAP_ANONYMOUS = 0x20    # mman.h
+            # fd and offset are ignored if MAP_ANONYMOUS flag is present
+            if not(flags & MAP_ANONYMOUS) and off != 0:
                 raise RuntimeError("Not implemented")
             data = b"\x00" * len_
         else:


### PR DESCRIPTION
According to ``man 2 mmap``: 

> The mapping is not backed by any file; its contents are initialized to zero.  The fd argument is ignored; however, some implementations require fd to
              be  -1  if  MAP_ANONYMOUS  (or MAP_ANON) is specified, and portable applications should ensure this.  The offset argument should be zero.  [...]

Offset parameter is ignored if MAP_ANONYMOUS is set.
