### PR TITLE
Change the returned value of OUT argument bool_ptr

### DIFF
--- a/miasm/os_dep/win_api_x86_32.py
+++ b/miasm/os_dep/win_api_x86_32.py
@@ -1047,7 +1047,7 @@ def kernel32_GetSystemInfo(jitter):
 
 def kernel32_IsWow64Process(jitter):
     ret_ad, args = jitter.func_args_stdcall(["process", "bool_ptr"])
-    jitter.vm.set_u32(args.bool_ptr, 0)
+    jitter.vm.set_u32(args.bool_ptr, 1)
     jitter.func_ret_stdcall(ret_ad, 1)
 
 


### PR DESCRIPTION
Hello!

I may be wrong, but I think that the value of bool_ptr is set to 1 in a case of a Win32 application running under SysWOW64. It's more detailed [here](https://docs.microsoft.com/en-us/windows/win32/api/wow64apiset/nf-wow64apiset-iswow64process).

Have a good day!
