### PR TITLE
Fix bug in Microsoft x86-64 calling convention

### DIFF
--- a/miasm/arch/x86/jit.py
+++ b/miasm/arch/x86/jit.py
@@ -229,7 +229,10 @@ class jitter_x86_64(Jitter):
         for i in range(min(n_args, 4)):
             args.append(self.cpu.get_gpreg()[args_regs[i]])
         for i in range(max(0, n_args - 4)):
-            args.append(self.get_stack_arg(i))
+            # Take into account the shadow registers on the stack 
+            # (Microsoft 64bit stdcall ABI)
+            # => Skip the first 4 stack parameters
+            args.append(self.get_stack_arg(4 + i))
         return ret_ad, args
 
     def func_prepare_stdcall(self, ret_addr, *args):


### PR DESCRIPTION
In Microsoft Windows 64bit, the `stdcall` calling convention allocates some space on the stack, called shadow space, corresponding to the parameters given in registers (cf [https://en.wikipedia.org/wiki/X86_calling_conventions](https://en.wikipedia.org/wiki/X86_calling_conventions#List_of_x86_calling_conventions)).

This means that, at the entry point of a function taking more than 4 parameters, the fifth parameter is at `RSP + 0x8 + (0x8 * 4)`.