### PR TITLE
Linux x86_32: minimalist environment and syscall table

### DIFF
--- a/miasm/arch/x86/jit.py
+++ b/miasm/arch/x86/jit.py
@@ -182,6 +182,17 @@ class jitter_x86_32(Jitter):
             return getattr(self.cpu, args_regs[index])
         return self.get_stack_arg(index - len(args_regs))
 
+    def syscall_args_systemv(self, n_args):
+        # Documentation: http://man7.org/linux/man-pages/man2/syscall.2.html
+        # args: 
+        #   i386          ebx   ecx   edx   esi   edi   ebp   -
+        args = [self.cpu.EBX, self.cpu.ECX, self.cpu.EDX, self.cpu.ESI,
+                self.cpu.EDI, self.cpu.EBP][:n_args]
+        return args
+
+    def syscall_ret_systemv(self, value):
+        # Documentation: http://man7.org/linux/man-pages/man2/syscall.2.html
+        self.cpu.EAX = value
 
 
 class jitter_x86_64(Jitter):

--- a/miasm/os_dep/linux/environment.py
+++ b/miasm/os_dep/linux/environment.py
@@ -666,6 +666,19 @@ class LinuxEnvironment(object):
         return addr
 
 
+class LinuxEnvironment_x86_32(LinuxEnvironment):
+    platform_arch = b"x86_32"
+    sys_machine = b"x86_32"
+
+    # TODO FIXME
+    ## O_ACCMODE = 0x3
+    ## O_CLOEXEC = 0x80000
+    ## O_DIRECTORY = 0x10000
+    ## O_LARGEFILE = 0x8000
+    ## O_NONBLOCK = 0x800
+    ## O_RDONLY = 0
+
+
 class LinuxEnvironment_x86_64(LinuxEnvironment):
     platform_arch = b"x86_64"
     sys_machine = b"x86_64"


### PR DESCRIPTION
This PR aims to provide the minimalist environment for `x86_32` ELF binaries on Linux (based on what was done for `x86_64`. In particular:

* add a class `LinuxEnvironment_x86_32` (empty for now),
* implement calling convention for syscalls on Linux 32bit in the jitter,
* add a syscall table for `x86_32`,
* implement `syscall_x86_32_newuname` (actually copy from `x86_64`).