### PR TITLE
MemSparse potential read issue

### DIFF
--- a/miasm/ir/symbexec.py
+++ b/miasm/ir/symbexec.py
@@ -567,7 +567,7 @@ class MemSparse(object):
         memarray = self.base_to_memarray.get(base, None)
         if memarray is not None:
             mems = memarray.read(offset, size)
-            ret = ExprCompose(*mems)
+            ret = mems[0] if len(mems) == 1 else ExprCompose(*mems)
         else:
             ret = ExprMem(ptr, size)
         return ret


### PR DESCRIPTION
I've noticed that reading even single `Expr` from memory triggers `ExprCompose`.

For example when one writes `ExprId("R8_init")` into a memory address and subsequently reads it, I'd expect `ExprId("R8_init")` to be also returned. However the result is `"{R8_init 0 64}"`, repeating these actions creates `"{{R8_init 0 64} 0 64}"`, `"{{{R8_init 0 64} 0 64} 0 64}"`...

It doesn't seem to be intended behaviour to me, are there any legitimate reasons for it? 