### PR TITLE
Add Expression visitor

### DIFF
--- a/miasm/analysis/data_flow.py
+++ b/miasm/analysis/data_flow.py
@@ -6,8 +6,8 @@ from future.utils import viewitems, viewvalues
 from miasm.core.utils import encode_hex
 from miasm.core.graph import DiGraph
 from miasm.ir.ir import AssignBlock, IRBlock
-from miasm.expression.expression import ExprLoc, ExprMem, ExprId, ExprInt,\
-    ExprAssign, ExprOp
+from miasm.expression.expression import ExprLoc, ExprMem, ExprSlice, ExprId, \
+    ExprInt, ExprAssign, ExprOp, ExprCompose, ExprCond, ExprWalk
 from miasm.expression.simplifications import expr_simp
 from miasm.core.interval import interval
 from miasm.expression.expression_helper import possible_values
@@ -736,22 +736,16 @@ def expr_test_visit(expr, test):
         return False
 
 
-def expr_has_mem_test(expr, result):
-    if result:
-        # Don't analyse if we already found a candidate
-        return False
-    if expr.is_mem():
-        result.add(expr)
-        return False
-    return True
-
-
 def expr_has_mem(expr):
     """
     Return True if expr contains at least one memory access
     @expr: Expr instance
     """
-    return expr_test_visit(expr, expr_has_mem_test)
+
+    def has_mem(self):
+        return self.is_mem()
+    visitor = ExprWalk(has_mem)
+    return visitor.visit(expr)
 
 
 class PropagateThroughExprId(object):

--- a/miasm/analysis/dse.py
+++ b/miasm/analysis/dse.py
@@ -333,8 +333,8 @@ class DSEEngine(object):
         self.handle(ExprInt(cur_addr, self.ir_arch.IRDst.size))
 
         # Avoid memory issue in ExpressionSimplifier
-        if len(self.symb.expr_simp.simplified_exprs) > 100000:
-            self.symb.expr_simp.simplified_exprs.clear()
+        if len(self.symb.expr_simp.cache) > 100000:
+            self.symb.expr_simp.cache.clear()
 
         # Get IR blocks
         if cur_addr in self.addr_to_cacheblocks:

--- a/miasm/expression/simplifications_common.py
+++ b/miasm/expression/simplifications_common.py
@@ -450,8 +450,8 @@ def simp_cond_factor(e_s, expr):
     for cond, vals in viewitems(conds):
         new_src1 = [x.src1 for x in vals]
         new_src2 = [x.src2 for x in vals]
-        src1 = e_s.expr_simp_wrapper(ExprOp(expr.op, *new_src1))
-        src2 = e_s.expr_simp_wrapper(ExprOp(expr.op, *new_src2))
+        src1 = e_s.expr_simp(ExprOp(expr.op, *new_src1))
+        src2 = e_s.expr_simp(ExprOp(expr.op, *new_src2))
         c_out.append(ExprCond(cond, src1, src2))
 
     if len(c_out) == 1:
@@ -521,7 +521,7 @@ def simp_slice(e_s, expr):
     # distributivity of slice and &
     # (a & int)[x:y] => 0 if int[x:y] == 0
     if expr.arg.is_op("&") and expr.arg.args[-1].is_int():
-        tmp = e_s.expr_simp_wrapper(expr.arg.args[-1][expr.start:expr.stop])
+        tmp = e_s.expr_simp(expr.arg.args[-1][expr.start:expr.stop])
         if tmp.is_int(0):
             return tmp
     # distributivity of slice and exprcond
@@ -536,7 +536,7 @@ def simp_slice(e_s, expr):
 
     # (a * int)[0:y] => (a[0:y] * int[0:y])
     if expr.start == 0 and expr.arg.is_op("*") and expr.arg.args[-1].is_int():
-        args = [e_s.expr_simp_wrapper(a[expr.start:expr.stop]) for a in expr.arg.args]
+        args = [e_s.expr_simp(a[expr.start:expr.stop]) for a in expr.arg.args]
         return ExprOp(expr.arg.op, *args)
 
     # (a >> int)[x:y] => a[x+int:y+int] with int+y <= a.size

--- a/test/expression/expression.py
+++ b/test/expression/expression.py
@@ -17,6 +17,7 @@ assert big_cst.size == 0x1000
 # Possible values
 #- Common constants
 A = ExprId("A", 32)
+B = ExprId("B", 32)
 cond1 = ExprId("cond1", 1)
 cond2 = ExprId("cond2", 16)
 cst1 = ExprInt(1, 32)
@@ -71,3 +72,47 @@ for expr in [
 aff = ExprAssign(A[0:32], cst1)
 
 assert aff.dst == A and aff.src == cst1
+
+
+mem = ExprMem(A, 32)
+assert mem.get_r() == set([mem])
+assert mem.get_r(mem_read=True) == set([mem, A])
+
+C = A+B
+D = C + A
+
+assert A in A
+assert A in C
+assert B in C
+assert C in C
+
+assert A in D
+assert B in D
+assert C in D
+assert D in D
+
+assert C not in A
+assert C not in B
+
+assert D not in A
+assert D not in B
+assert D not in C
+
+
+assert cst1.get_r(cst_read=True) == set([cst1])
+mem1 = ExprMem(A, 32)
+mem2 = ExprMem(mem1 + B, 32)
+assert mem2.get_r() == set([mem2])
+
+assign1 = ExprAssign(A, cst1)
+assert assign1.get_r() == set([])
+
+assign2 = ExprAssign(mem1, D)
+assert assign2.get_r() == set([A, B])
+assert assign2.get_r(mem_read=True) == set([A, B])
+assert assign2.get_w() == set([mem1])
+
+assign3 = ExprAssign(mem1, mem2)
+assert assign3.get_r() == set([mem2])
+assert assign3.get_r(mem_read=True) == set([mem1, mem2, A, B])
+assert assign3.get_w() == set([mem1])


### PR DESCRIPTION
**Expression visit order**

In the current Expression visitor, some implementations errors
result in usage limits.

First, the default behavior. Let analyse the following code:
```python
from miasm.expression.expression import *

a = ExprId('a', 32)
b = ExprId('b', 32)
c = ExprId('c', 32)

j1 = ExprId('j1', 32)
j2 = ExprId('j2', 32)

d = a + b
e = d * a

print("expr: %s" % e)
result = e.replace_expr({d:j1, a: j2})

print("result: %s" % result)


```
which gives:
```
expr: (a + b) * a
result: (j2 + b) * j2
```

We can ask ourselves why we didn't reduce first:
```(a*b) -> j1```
instead of
```a -> j2```
(which eliminates the possibility of the first reduction rule)

The general question is:
- When visiting an expression, must we apply reductions rules from top to bottom
  or bottom to top?
- must we re-apply modifications on freshly modified expressions ?


This job is done by `ExprVisitor`

**Expression caching**
Another point is the work we need to do during an expression replacement. When
we are doing an expression replacement, we have to rebuild all its parents. But
if some sub-expressions of the original expression are equals, we don't need to
revisit them and use a cache.

If we have the reduction a -> b, and have the expression:
```(a*2) | ((a*2) + 1)```

When updating the first `(a*2)`, we can cache the fact that `(a*2)` gives `(b*2)`. So
when we visit the `((a*2) + 1)`, we immediately known that `(a*2)` gives `(b*2)` and
we won't visit every sub expression.


**Expression walking**
In some cases, you don't want to rebuild a new expression, but just walking it
to find a property. This walk may early stop if you find your needle.

This job is done by `ExprWalk`


This PR allows to simplify or symbexec "complex" codes like cryptographics
functions.
