### PR TITLE
Minor improvement in rebuild_edges

### DIFF
--- a/miasm/core/asmblock.py
+++ b/miasm/core/asmblock.py
@@ -628,6 +628,7 @@ class AsmCFG(DiGraph):
         This method should be called if a block's '.bto' in nodes have been
         modified without notifying this instance to resynchronize edges.
         """
+        self._pendings = {}
         for block in self.blocks:
             edges = []
             # Rebuild edges from bto


### PR DESCRIPTION
If one deletes all the direct predecessors of a pending block, it dosn't get freed even thought it's not required anymore. Since all the pendings are recalculated here, there's no reason not to cover these cases here IMHO by clearing them prior the recalculation. Another solution is to add a watcher to del_block().