### PR TITLE
Type Error when using the DSE with Python3

### DIFF
--- a/miasm/analysis/dse.py
+++ b/miasm/analysis/dse.py
@@ -258,7 +258,7 @@ class DSEEngine(object):
 
         # lambda cannot contain statement
         def default_func(dse):
-            fname = b"%s_symb" % libimp.fad2cname[dse.jitter.pc]
+            fname = b"%s_symb" % force_bytes(libimp.fad2cname[dse.jitter.pc])
             raise RuntimeError("Symbolic stub '%s' not found" % fname)
 
         for addr, fname in viewitems(libimp.fad2cname):


### PR DESCRIPTION
Hello,

It seems there is a type error that happens only in Python3 when using the DSE.

Basically, when a lib handler is added for the DSE, the following code is executed if the function was not implemented.

https://github.com/cea-sec/miasm/blob/9f052f39ca4c72c1b6146d445f7764c57876013a/miasm/analysis/dse.py#L261

In Python3, this code raises a Type Error as `libimp.fad2cname[dse.jitter.pc]` is a `str` and not a bytes-like object.

I think this issue can be solved by adding a call to `force_bytes`.