### PR TITLE
DepGraph minor improvement

### DIFF
--- a/miasm/analysis/depgraph.py
+++ b/miasm/analysis/depgraph.py
@@ -615,12 +615,9 @@ class DependencyGraph(object):
             if done_state in done:
                 continue
             done.add(done_state)
-            if (not state.pending or
-                    state.loc_key in heads or
-                    not self._ircfg.predecessors(state.loc_key)):
+            if not state.pending or state.loc_key in heads:
                 yield dpResultcls(self._ircfg, initial_state, state, elements)
-                if not state.pending:
-                    continue
+                continue
 
             if self._implicit:
                 # Force IRDst to be tracked, except in the input block


### PR DESCRIPTION
Reaching a head with predecesors didn't stop dependency check(only yielded a result) and there's also no need to explicitly check for empty predecessors since there won't be any new states to process and the loop will just continue anyway I think, but I could be wrong. I'll also add that I recon that nodes with no predecessors are always included in the heads(it's required to yield a result in them now).