### PR TITLE
Fix jitter on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,6 +19,17 @@ environment:
       PYTHON: c:\Python27-x64
       PYTHON_VERSION: "2.7.x"
 
+    - platform: Win32
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      PLATFORM_TOOLSET: v141
+      PYTHON: c:\Python38
+      PYTHON_VERSION: "3.8.x"
+
+    - platform: x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      PLATFORM_TOOLSET: v141
+      PYTHON: c:\Python38-x64
+      PYTHON_VERSION: "3.8.x"
       # on_finish:
       #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 

--- a/miasm/jitter/jitcore_cc_base.py
+++ b/miasm/jitter/jitcore_cc_base.py
@@ -79,7 +79,7 @@ class JitCore_Cc_Base(JitCore):
             ext = ".so" if not is_win else ".lib"
         if is_win:
             # sysconfig.get_config_var('EXT_SUFFIX') is .pyd on Windows and need to be forced to .lib
-            # Additionaly windows built libraries may have a name like VmMngr.cp38-win_amd64.lib
+            # Additionally windows built libraries may have a name like VmMngr.cp38-win_amd64.lib
             ext_files = glob.glob(os.path.join(lib_dir, "VmMngr.*lib"))
             if len(ext_files) == 1:
                 ext = os.path.basename(ext_files[0]).replace("VmMngr", "")

--- a/miasm/jitter/jitcore_cc_base.py
+++ b/miasm/jitter/jitcore_cc_base.py
@@ -1,5 +1,6 @@
 #-*- coding:utf-8 -*-
 
+import glob
 import os
 import tempfile
 import platform
@@ -76,6 +77,12 @@ class JitCore_Cc_Base(JitCore):
         ext = sysconfig.get_config_var('EXT_SUFFIX')
         if ext is None:
             ext = ".so" if not is_win else ".lib"
+        if is_win:
+            # sysconfig.get_config_var('EXT_SUFFIX') is .pyd on Windows and need to be forced to .lib
+            # Additionaly windows built libraries may have a name like VmMngr.cp38-win_amd64.lib
+            ext_files = glob.glob(os.path.join(lib_dir, "VmMngr.*lib"))
+            if len(ext_files) == 1:
+                ext = os.path.basename(ext_files[0]).replace("VmMngr", "")
 
         libs = [
             os.path.join(lib_dir, "VmMngr" + ext),

--- a/miasm/jitter/jitcore_gcc.py
+++ b/miasm/jitter/jitcore_gcc.py
@@ -1,5 +1,6 @@
 #-*- coding:utf-8 -*-
 
+import sys
 import os
 import tempfile
 import ctypes
@@ -70,7 +71,7 @@ class JitCore_Gcc(JitCore_Cc_Base):
                         get_python_inc(),
                         "..",
                         "libs",
-                        "python27.lib"
+                        "python%d%d.lib" % (sys.version_info.major, sys.version_info.minor)
                     )
                 )
                 cl = [

--- a/miasm/jitter/jitcore_llvm.py
+++ b/miasm/jitter/jitcore_llvm.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+import glob
 import importlib
 import tempfile
 import sysconfig
@@ -56,10 +57,16 @@ class JitCore_LLVM(jitcore.JitCore):
 
         # Get architecture dependent Jitcore library (if any)
         lib_dir = os.path.dirname(os.path.realpath(__file__))
-        lib_dir = os.path.join(lib_dir, 'arch')
         ext = sysconfig.get_config_var('EXT_SUFFIX')
         if ext is None:
             ext = ".so" if not is_win else ".pyd"
+        if is_win:
+            # sysconfig.get_config_var('EXT_SUFFIX') is .pyd on Windows and need to be forced to .lib
+            # Additionally windows built libraries may have a name like VmMngr.cp38-win_amd64.lib
+            ext_files = glob.glob(os.path.join(lib_dir, "VmMngr.*pyd"))
+            if len(ext_files) == 1:
+                ext = os.path.basename(ext_files[0]).replace("VmMngr", "")
+        lib_dir = os.path.join(lib_dir, 'arch')
         try:
             jit_lib = os.path.join(
                 lib_dir, self.arch_dependent_libs[self.ir_arch.arch.name] + ext

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -1,3 +1,3 @@
 pycparser
 z3-solver==4.8.7.0
-llvmlite==0.26.0
+llvmlite==0.31.0

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from distutils.sysconfig import get_python_lib, get_config_vars
 from distutils.dist import DistributionMetadata
 from distutils.command.install_data import install_data
 from tempfile import TemporaryFile
+import fnmatch
 import io
 import os
 import platform
@@ -248,7 +249,8 @@ def buil_all():
         for lib in libs:
             filename = os.path.basename(lib)
             dst = os.path.join(build_base, lib_dirname, "miasm", "jitter")
-            if filename not in ["VmMngr.lib", "Jitgcc.lib", "Jitllvm.lib"]:
+            # Windows built libraries may have a name like VmMngr.cp38-win_amd64.lib
+            if not any([fnmatch.fnmatch(filename, pattern) for pattern in ["VmMngr.*lib", "Jitgcc.*lib", "Jitllvm.*lib"]]):
                 dst = os.path.join(dst, "arch")
             dst = os.path.join(dst, filename)
             if not os.path.isfile(dst):


### PR DESCRIPTION
On Windows with Python38 the Jitter fails to compile mostly because of the native extension filenames `.cp38-win_amd64.lib`.
Therefore:
- during setup, some libs are misplaced
- bad extension in `jitcore_cc_base.py` (`sysconfig.get_config_var('EXT_SUFFIX')` is `.pyd` but we need `.lib` here)
- use hardcoded `python27.lib`