### PR TITLE
Win_api: fix kernel32_MultiByteToWideChar

### DIFF
--- a/miasm/os_dep/win_api_x86_32.py
+++ b/miasm/os_dep/win_api_x86_32.py
@@ -1644,7 +1644,8 @@ def kernel32_MultiByteToWideChar(jitter):
                                              "cchwidechar"])
     src = get_win_str_a(jitter, args.lpmultibytestr)
     l = len(src) + 1
-    set_win_str_w(jitter, args.lpwidecharstr, src)
+    if args.cchwidechar != 0:
+        set_win_str_w(jitter, args.lpwidecharstr, src)
     jitter.func_ret_stdcall(ret_ad, l)
 
 


### PR DESCRIPTION
According to the documentation, if cchWideChar is 0, then
the required size for the buffer indicated by lpWideCharStr
is returned.