### PR TITLE
Updt dis_block_callback; apply_splitting

### DIFF
--- a/example/disasm/callback.py
+++ b/example/disasm/callback.py
@@ -4,7 +4,7 @@ from miasm.analysis.machine import Machine
 from miasm.core.asmblock import AsmConstraint
 
 
-def cb_x86_callpop(cur_bloc, loc_db, *args, **kwargs):
+def cb_x86_callpop(mdis, cur_bloc, offset_to_dis):
     """
     1000: call 1005
     1005: pop
@@ -28,7 +28,7 @@ def cb_x86_callpop(cur_bloc, loc_db, *args, **kwargs):
         return
 
     loc_key = dst.loc_key
-    offset = loc_db.get_location_offset(loc_key)
+    offset = mdis.loc_db.get_location_offset(loc_key)
     ## The destination must be the next instruction
     if offset != last_instr.offset + last_instr.l:
         return

--- a/miasm/arch/arm/disasm.py
+++ b/miasm/arch/arm/disasm.py
@@ -4,7 +4,7 @@ from miasm.core.asmblock import AsmConstraint, disasmEngine
 from miasm.arch.arm.arch import mn_arm, mn_armt
 
 
-def cb_arm_fix_call(mn, cur_bloc, loc_db, offsets_to_dis, *args, **kwargs):
+def cb_arm_fix_call(mdis, cur_block, offsets_to_dis):
     """
     for arm:
     MOV        LR, PC
@@ -12,22 +12,22 @@ def cb_arm_fix_call(mn, cur_bloc, loc_db, offsets_to_dis, *args, **kwargs):
     * is a subcall *
 
     """
-    if len(cur_bloc.lines) < 2:
+    if len(cur_block.lines) < 2:
         return
-    l1 = cur_bloc.lines[-1]
-    l2 = cur_bloc.lines[-2]
+    l1 = cur_block.lines[-1]
+    l2 = cur_block.lines[-2]
     if l1.name != "LDR":
         return
     if l2.name != "MOV":
         return
 
-    values = viewvalues(mn.pc)
+    values = viewvalues(mdis.mn.pc)
     if not l1.args[0] in values:
         return
     if not l2.args[1] in values:
         return
-    loc_key_cst = loc_db.get_or_create_offset_location(l1.offset + 4)
-    cur_bloc.add_cst(loc_key_cst, AsmConstraint.c_next)
+    loc_key_cst = mdis.loc_db.get_or_create_offset_location(l1.offset + 4)
+    cur_block.add_cst(loc_key_cst, AsmConstraint.c_next)
     offsets_to_dis.add(l1.offset + 4)
 
 cb_arm_funcs = [cb_arm_fix_call]

--- a/miasm/arch/x86/disasm.py
+++ b/miasm/arch/x86/disasm.py
@@ -5,9 +5,9 @@ from miasm.arch.x86.arch import mn_x86
 cb_x86_funcs = []
 
 
-def cb_x86_disasm(*args, **kwargs):
+def cb_x86_disasm(mdis, cur_block, offset_to_dis):
     for func in cb_x86_funcs:
-        func(*args, **kwargs)
+        func(mdis, cur_block, offset_to_dis)
 
 
 class dis_x86(disasmEngine):

--- a/test/core/asmblock.py
+++ b/test/core/asmblock.py
@@ -274,7 +274,7 @@ assert asmcfg.successors(tob.loc_key) == [tob.loc_key]
 # Check split_block
 ## Without condition for a split, no change
 asmcfg_bef = asmcfg.copy()
-asmcfg.apply_splitting(mdis.loc_db)
+mdis.apply_splitting(asmcfg)
 assert asmcfg_bef == asmcfg
 open("graph5.dot", "w").write(asmcfg.dot())
 ## Create conditions for a block split
@@ -283,7 +283,7 @@ tob.bto.add(AsmConstraintTo(inside_firstbbl))
 asmcfg.rebuild_edges()
 assert len(asmcfg.pendings) == 1
 assert inside_firstbbl in asmcfg.pendings
-asmcfg.apply_splitting(mdis.loc_db)
+mdis.apply_splitting(asmcfg)
 ## Check result
 assert len(asmcfg) == 6
 assert len(asmcfg.pendings) == 0


### PR DESCRIPTION
* Updt `dis_block_callback`, as mostly every arguments are present in the mdis engine;
* `apply_splitting` is now member of `disasm_engine` instead of `AsmCfg`: `apply_splitting` needs offsets in the asmcfg blocks, so it seems legit to need a disasm engine. Moreover, `apply_splitting` in a purely assembled asmcfg from blocks may be useless.
