### PR TITLE
Fix collections

### DIFF
--- a/miasm/core/utils.py
+++ b/miasm/core/utils.py
@@ -3,7 +3,11 @@ import sys
 from builtins import range
 import struct
 import inspect
-from collections import MutableMapping as DictMixin
+
+try:
+    from collections.abc import MutableMapping as DictMixin
+except ImportError:
+    from collections import MutableMapping as DictMixin
 
 from operator import itemgetter
 import codecs

--- a/miasm/jitter/jitload.py
+++ b/miasm/jitter/jitload.py
@@ -1,7 +1,11 @@
 import logging
 import warnings
 from functools import wraps
-from collections import Sequence, namedtuple
+from collections import namedtuple
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from future.utils import viewitems
 


### PR DESCRIPTION
Most modules were moved from the root namespace of `collections` module to `collections.abc` since Python 3.2, and will stop work as is in the next Python 3.9 https://docs.python.org/3/library/collections.html