### PR TITLE
Int expr arg

### DIFF
--- a/example/ida/graph_ir.py
+++ b/example/ida/graph_ir.py
@@ -11,7 +11,6 @@ import idc
 import ida_funcs
 import idautils
 
-from miasm.core.asmblock import is_int
 from miasm.core.bin_stream_ida import bin_stream_ida
 from miasm.expression.simplifications import expr_simp
 from miasm.ir.ir import IRBlock, AssignBlock
@@ -83,7 +82,7 @@ Options:
 
 def label_init(self, name="", offset=None):
     self.fixedblocs = False
-    if is_int(name):
+    if isinstance(name, int_types):
         name = "loc_%X" % (int(name) & 0xFFFFFFFFFFFFFFFF)
     self.name = name
     self.attrib = None

--- a/miasm/analysis/modularintervals.py
+++ b/miasm/analysis/modularintervals.py
@@ -5,6 +5,7 @@ from builtins import int as int_types
 from itertools import product
 
 from miasm.core.interval import interval
+from miasm.core.utils import size2mask
 
 class ModularIntervals(object):
     """Intervals with a maximum size, supporting modular arithmetic"""
@@ -31,12 +32,6 @@ class ModularIntervals(object):
             assert end <= self.mask
 
     # Helpers
-
-    @staticmethod
-    def size2mask(size):
-        """Return the bit mask of size @size"""
-        return (1 << size) - 1
-
     def _range2interval(func):
         """Convert a function taking 2 ranges to a function taking a ModularIntervals
         and applying to the current instance"""
@@ -472,7 +467,7 @@ class ModularIntervals(object):
     @property
     def mask(self):
         """Return the mask corresponding to the instance size"""
-        return ModularIntervals.size2mask(self.size)
+        return size2mask(self.size)
 
     def __iter__(self):
         return iter(self.intervals)
@@ -496,7 +491,7 @@ class ModularIntervals(object):
         # Increasing size is always safe
         if new_size < self.size:
             # Check that current values are indeed included in the new range
-            assert self.intervals.hull()[1] <= ModularIntervals.size2mask(new_size)
+            assert self.intervals.hull()[1] <= size2mask(new_size)
 
         self.size = new_size
 

--- a/miasm/arch/aarch64/arch.py
+++ b/miasm/arch/aarch64/arch.py
@@ -12,7 +12,7 @@ from miasm.core.bin_stream import bin_stream
 from miasm.arch.aarch64 import regs as regs_module
 from miasm.arch.aarch64.regs import *
 from miasm.core.cpu import log as log_cpu
-from miasm.expression.modint import uint32, uint64, mod_size2int
+from miasm.core.modint import mod_size2int
 from miasm.core.asm_ast import AstInt, AstId, AstMem, AstOp
 
 log = logging.getLogger("aarch64dis")

--- a/miasm/arch/msp430/arch.py
+++ b/miasm/arch/msp430/arch.py
@@ -136,9 +136,9 @@ class instruction_msp430(instruction):
         if not isinstance(expr, ExprInt):
             return
         if self.name == "call":
-            addr = expr.arg
+            addr = int(expr)
         else:
-            addr = expr.arg + int(self.offset)
+            addr = (int(expr) + int(self.offset))  & int(expr.mask)
 
         loc_key = loc_db.get_or_create_offset_location(addr)
         self.args[0] = ExprLoc(loc_key, expr.size)

--- a/miasm/core/asmblock.py
+++ b/miasm/core/asmblock.py
@@ -12,7 +12,6 @@ from future.utils import viewitems, viewvalues
 from miasm.expression.expression import ExprId, ExprInt, get_expr_locs
 from miasm.expression.expression import LocKey
 from miasm.expression.simplifications import expr_simp
-from miasm.expression.modint import moduint, modint
 from miasm.core.utils import Disasm_Exception, pck
 from miasm.core.graph import DiGraph, DiGraphSimplifier, MatchGraphJoker
 from miasm.core.interval import interval
@@ -24,10 +23,6 @@ console_handler = logging.StreamHandler()
 console_handler.setFormatter(logging.Formatter("[%(levelname)-8s]: %(message)s"))
 log_asmblock.addHandler(console_handler)
 log_asmblock.setLevel(logging.WARNING)
-
-
-def is_int(a):
-    return isinstance(a, (modint, moduint, int_types))
 
 
 class AsmRaw(object):

--- a/miasm/core/locationdb.py
+++ b/miasm/core/locationdb.py
@@ -6,11 +6,6 @@ from future.utils import viewitems, viewvalues
 
 from miasm.core.utils import printable, force_bytes
 from miasm.expression.expression import LocKey, ExprLoc
-from miasm.expression.modint import moduint, modint
-
-
-def is_int(a):
-    return isinstance(a, (int_types, moduint, modint))
 
 
 class LocationDB(object):
@@ -246,7 +241,7 @@ class LocationDB(object):
 
         name = force_bytes(name)
         # Deprecation handling
-        if is_int(name):
+        if isinstance(name, int_types):
             assert offset is None or offset == name
             warnings.warn("Deprecated API: use 'add_location(offset=)' instead."
                           " An additional 'name=' can be provided to also "

--- a/miasm/core/modint.py
+++ b/miasm/core/modint.py
@@ -215,9 +215,6 @@ def is_modint(a):
     return isinstance(a, moduint)
 
 
-def size2mask(size):
-    return (1 << size) - 1
-
 mod_size2uint = {}
 mod_size2int = {}
 

--- a/miasm/core/utils.py
+++ b/miasm/core/utils.py
@@ -129,6 +129,9 @@ def decode_hex(value):
 def encode_hex(value):
     return _ENCODE_HEX(value)[0]
 
+def size2mask(size):
+    """Return the bit mask of size @size"""
+    return (1 << size) - 1
 
 def hexdump(src, length=16):
     lines = []

--- a/miasm/expression/expression.py
+++ b/miasm/expression/expression.py
@@ -38,8 +38,6 @@ from functools import cmp_to_key, total_ordering
 from future.utils import viewitems
 
 from miasm.core.utils import force_bytes, cmp_elts
-from miasm.expression.modint import mod_size2uint, is_modint, size2mask, \
-    define_uint
 from miasm.core.graph import DiGraph
 from functools import reduce
 
@@ -755,8 +753,8 @@ class ExprInt(Expr):
 
 
     def __init__(self, arg, size):
-        """Create an ExprInt from a modint or num/size
-        @arg: 'intable' number
+        """Create an ExprInt from num/size
+        @arg: int/long number
         @size: int size"""
         super(ExprInt, self).__init__(size)
         # Work for ._arg is done in __new__
@@ -768,8 +766,8 @@ class ExprInt(Expr):
         return self.__class__, state
 
     def __new__(cls, arg, size):
-        """Create an ExprInt from a modint or num/size
-        @arg: 'intable' number
+        """Create an ExprInt from num/size
+        @arg: int/long number
         @size: int size"""
 
         assert isinstance(arg, int_types)

--- a/miasm/expression/expression.py
+++ b/miasm/expression/expression.py
@@ -772,17 +772,8 @@ class ExprInt(Expr):
         @arg: 'intable' number
         @size: int size"""
 
-        if is_modint(arg):
-            assert size == arg.size
-        # Avoid a common blunder
-        assert not isinstance(arg, ExprInt)
-
-        # Ensure arg is always a moduint
-        arg = int(arg)
-        if size not in mod_size2uint:
-            define_uint(size)
-        arg = mod_size2uint[size](arg)
-
+        assert isinstance(arg, int_types)
+        arg  = arg & ((1 << size) - 1)
         # Get the Singleton instance
         expr = Expr.get_object(cls, (arg, size))
 
@@ -790,15 +781,8 @@ class ExprInt(Expr):
         expr._arg = arg
         return expr
 
-    def _get_int(self):
-        "Return self integer representation"
-        return int(self._arg & size2mask(self._size))
-
     def __str__(self):
-        if self._arg < 0:
-            return str("-0x%X" % (- self._get_int()))
-        else:
-            return str("0x%X" % self._get_int())
+        return str("0x%X" % self.arg)
 
     def get_w(self):
         return set()
@@ -807,7 +791,7 @@ class ExprInt(Expr):
         return hash((EXPRINT, self._arg, self._size))
 
     def _exprrepr(self):
-        return "%s(0x%X, %d)" % (self.__class__.__name__, self._get_int(),
+        return "%s(0x%X, %d)" % (self.__class__.__name__, self.arg,
                                  self._size)
 
     def copy(self):

--- a/miasm/expression/simplifications_common.py
+++ b/miasm/expression/simplifications_common.py
@@ -4,7 +4,7 @@
 
 from future.utils import viewitems
 
-from miasm.expression.modint import mod_size2int, mod_size2uint
+from miasm.core.modint import mod_size2int, mod_size2uint
 from miasm.expression.expression import ExprInt, ExprSlice, ExprMem, \
     ExprCond, ExprOp, ExprCompose, TOK_INF_SIGNED, TOK_INF_UNSIGNED, \
     TOK_INF_EQUAL_SIGNED, TOK_INF_EQUAL_UNSIGNED, TOK_EQUAL

--- a/miasm/expression/simplifications_explicit.py
+++ b/miasm/expression/simplifications_explicit.py
@@ -1,4 +1,4 @@
-from miasm.expression.modint import size2mask
+from miasm.core.utils import size2mask
 from miasm.expression.expression import ExprInt, ExprCond, ExprCompose, \
     TOK_EQUAL
 

--- a/miasm/ir/translators/C.py
+++ b/miasm/ir/translators/C.py
@@ -1,5 +1,5 @@
 from miasm.ir.translators.translator import Translator
-from miasm.expression.modint import size2mask
+from miasm.core.utils import size2mask
 from miasm.expression.expression import ExprInt, ExprCond, ExprCompose, \
     TOK_EQUAL, \
     TOK_INF_SIGNED, TOK_INF_UNSIGNED, \

--- a/miasm/ir/translators/smt2.py
+++ b/miasm/ir/translators/smt2.py
@@ -133,7 +133,7 @@ class TranslatorSMT2(Translator):
         self.loc_db = loc_db
 
     def from_ExprInt(self, expr):
-        return bit_vec_val(expr.arg.arg, expr.size)
+        return bit_vec_val(int(expr), expr.size)
 
     def from_ExprId(self, expr):
         if str(expr) not in self._bitvectors:

--- a/miasm/jitter/llvmconvert.py
+++ b/miasm/jitter/llvmconvert.py
@@ -28,6 +28,7 @@ from miasm.expression.expression import ExprId, ExprInt, ExprMem, ExprSlice, \
 
 import miasm.jitter.csts as m2_csts
 import miasm.core.asmblock as m2_asmblock
+from miasm.core.utils import size2mask
 from miasm.jitter.codegen import CGen, Attributes
 from miasm.expression.expression_helper import possible_values
 

--- a/miasm/jitter/llvmconvert.py
+++ b/miasm/jitter/llvmconvert.py
@@ -768,7 +768,7 @@ class LLVMFunction(object):
         builder = self.builder
 
         if isinstance(expr, ExprInt):
-            ret = llvm_ir.Constant(LLVMType.IntType(expr.size), int(expr.arg))
+            ret = llvm_ir.Constant(LLVMType.IntType(expr.size), int(expr))
             self.update_cache(expr, ret)
             return ret
 

--- a/test/core/modint.py
+++ b/test/core/modint.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-from miasm.expression.modint import *
+from miasm.core.modint import *
 
 a = uint8(0x42)
 b = uint8(0xFF)

--- a/test/jitter/jitload.py
+++ b/test/jitter/jitload.py
@@ -47,4 +47,4 @@ assert myjit.eval_expr(eax) == imm4
 ## Changes must be passed on myjit.cpu instance
 assert myjit.cpu.EAX == 4
 ## Memory
-assert myjit.eval_expr(memdata).arg.arg == int(encode_hex(data[::-1]), 16)
+assert int(myjit.eval_expr(memdata)) == int(encode_hex(data[::-1]), 16)

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -305,7 +305,8 @@ testset += SemanticTestExec("x86_32", "PE", 0x401000, ["bsr_bsf"],
                             depends=[test_x86_32_bsr_bsf])
 
 ## Core
-for script in ["interval.py",
+for script in ["modint.py",
+               "interval.py",
                "graph.py",
                "parse_asm.py",
                "utils.py",
@@ -318,8 +319,7 @@ testset += RegressionTest(["asmblock.py"], base_dir="core",
                           products=["graph.dot", "graph2.dot",
                                     "graph3.dot", "graph4.dot"])
 ## Expression
-for script in ["modint.py",
-               "expression.py",
+for script in ["expression.py",
                "stp.py",
                "simplifications.py",
                "expression_helper.py",


### PR DESCRIPTION
This PR cleans the `ExprInt` value. You now have two ways to retrieve the value of an `ExprInt`: 
- `int(expr)`
- `expr.arg`

The expr.arg is now a python `int`
Thus, the `Expression` modules does not depends on the `modint` modules, which is now moved to the `miasm.core` directory.
The `ExprInt` now only takes an integer/size as input, not a `modint`.