### PR TITLE
Fix overflow if virtual memory page size >= 4GiB

### DIFF
--- a/miasm/jitter/vm_mngr.c
+++ b/miasm/jitter/vm_mngr.c
@@ -661,7 +661,7 @@ int is_mapped(vm_mngr_t* vm_mngr, uint64_t addr, size_t size)
        return 1;
 }
 
-struct memory_page_node * create_memory_page_node(uint64_t ad, unsigned int size, unsigned int access, const char *name)
+struct memory_page_node * create_memory_page_node(uint64_t ad, size_t size, unsigned int access, const char *name)
 {
 	struct memory_page_node * mpn;
 	void* ad_hp;
@@ -674,7 +674,7 @@ struct memory_page_node * create_memory_page_node(uint64_t ad, unsigned int size
 	ad_hp = malloc(size);
 	if (!ad_hp){
 		free(mpn);
-		fprintf(stderr, "Error: cannot alloc %d\n", size);
+		fprintf(stderr, "Error: cannot alloc %zu\n", size);
 		return NULL;
 	}
 	mpn->name = malloc(strlen(name) + 1);

--- a/miasm/jitter/vm_mngr.h
+++ b/miasm/jitter/vm_mngr.h
@@ -230,7 +230,7 @@ void hexdump(char* m, unsigned int l);
 struct code_bloc_node * create_code_bloc_node(uint64_t ad_start, uint64_t ad_stop);
 void add_code_bloc(vm_mngr_t* vm_mngr, struct code_bloc_node* cbp);
 
-struct memory_page_node * create_memory_page_node(uint64_t ad, unsigned int size, unsigned int access, const char *name);//memory_page* mp);
+struct memory_page_node * create_memory_page_node(uint64_t ad, size_t size, unsigned int access, const char *name);//memory_page* mp);
 void init_memory_page_pool(vm_mngr_t* vm_mngr);
 void init_code_bloc_pool(vm_mngr_t* vm_mngr);
 void reset_memory_page_pool(vm_mngr_t* vm_mngr);

--- a/miasm/jitter/vm_mngr_py.c
+++ b/miasm/jitter/vm_mngr_py.c
@@ -106,7 +106,7 @@ PyObject* vm_add_memory_page(VmMngr* self, PyObject* args)
 	} else {
 		PyGetStr(name_ptr, name);
 	}
-	mpn = create_memory_page_node(page_addr, (unsigned int)buf_size, (unsigned int)page_access, name_ptr);
+	mpn = create_memory_page_node(page_addr, (size_t)buf_size, (unsigned int)page_access, name_ptr);
 	if (mpn == NULL)
 		RAISE(PyExc_TypeError,"cannot create page");
 	if (is_mpn_in_tab(&self->vm_mngr, mpn)) {


### PR DESCRIPTION
VmMngr suffers of a buffer overflow (which crashes the python interpreter) if you try to allocate a virtual memory page of size >= 4GiB.