### PR TITLE
Fix get_export_name_addr_list when there are no exports

### DIFF
--- a/miasm/jitter/loader/pe.py
+++ b/miasm/jitter/loader/pe.py
@@ -148,6 +148,9 @@ def get_export_name_addr_list(e):
         assert exports[0] == ('AcquireSRWLockExclusive', 0x6b89b22a)
     """
     out = []
+    if e.DirExport.expdesc is None:
+        return out
+
     # add func name
     for i, n in enumerate(e.DirExport.f_names):
         addr = e.DirExport.f_address[e.DirExport.f_nameordinals[i].ordinal]


### PR DESCRIPTION
When there are no exports, `get_export_name_addr_list` raises an exception at `miasm/jitter/loader/pe.py`, line 152:

```
AttributeError: 'DirExport' object has no attribute 'f_names'
```

Return an empty list instead.

