### PR TITLE
Avoid generate default locationdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Import the shellcode thanks to the `Container` abstraction:
 
 ```pycon
 >>> from miasm.analysis.binary import Container
->>> c = Container.from_string(s)
+>>> c = Container.from_string(s, loc_db)
 >>> c
 <miasm.analysis.binary.ContainerUnknown object at 0x7f34cefe6090>
 ```
@@ -182,7 +182,7 @@ Disassembling the shellcode at address `0`:
 ```pycon
 >>> from miasm.analysis.machine import Machine
 >>> machine = Machine('x86_32')
->>> mdis = machine.dis_engine(c.bin_stream)
+>>> mdis = machine.dis_engine(c.bin_stream, loc_db=loc_db)
 >>> asmcfg = mdis.dis_multiblock(0)
 >>> for block in asmcfg.blocks:
 ...  print(block.to_string(asmcfg.loc_db))
@@ -208,7 +208,7 @@ RET
 Initializing the Jit engine with a stack:
 
 ```pycon
->>> jitter = machine.jitter(jit_type='python')
+>>> jitter = machine.jitter(loc_db, jit_type='python')
 >>> jitter.init_stack()
 ```
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Add instruction to the pool:
 Print current pool:
 ```pycon
 >>> for lbl, irblock in ircfg.blocks.items():
-...     print(irblock.to_string(loc_db))
+...     print(irblock)
 loc_0:
 R2 = R8 + R0
 
@@ -134,10 +134,10 @@ IRDst = loc_4
 ```
 Working with IR, for instance by getting side effects:
 ```pycon
->>> for lbl, irblock in ircfg.blocks.iteritems():
+>>> for lbl, irblock in ircfg.blocks.items():
 ...     for assignblk in irblock:
 ...         rw = assignblk.get_rw()
-...         for dst, reads in rw.iteritems():
+...         for dst, reads in rw.items():
 ...             print('read:   ', [str(x) for x in reads])
 ...             print('written:', dst)
 ...             print()
@@ -166,7 +166,7 @@ Giving a shellcode:
 00000010 8d5b01      lea    ebx, [ebx+0x1]
 00000013 89d8        mov    eax, ebx
 00000015 c3          ret
->>> s = '\x8dI\x04\x8d[\x01\x80\xf9\x01t\x05\x8d[\xff\xeb\x03\x8d[\x01\x89\xd8\xc3'
+>>> s = b'\x8dI\x04\x8d[\x01\x80\xf9\x01t\x05\x8d[\xff\xeb\x03\x8d[\x01\x89\xd8\xc3'
 ```
 Import the shellcode thanks to the `Container` abstraction:
 
@@ -185,7 +185,7 @@ Disassembling the shellcode at address `0`:
 >>> mdis = machine.dis_engine(c.bin_stream, loc_db=loc_db)
 >>> asmcfg = mdis.dis_multiblock(0)
 >>> for block in asmcfg.blocks:
-...  print(block.to_string(asmcfg.loc_db))
+...  print(block)
 ...
 loc_0
 LEA        ECX, DWORD PTR [ECX + 0x4]

--- a/example/asm/shellcode.py
+++ b/example/asm/shellcode.py
@@ -106,7 +106,6 @@ open("graph.dot", "w").write(asmcfg.dot())
 patches = asmblock.asm_resolve_final(
     machine.mn,
     asmcfg,
-    loc_db,
     dst_interval
 )
 if args.encrypt:

--- a/example/asm/shellcode.py
+++ b/example/asm/shellcode.py
@@ -83,7 +83,7 @@ with open(args.source) as fstream:
 
 loc_db = LocationDB()
 
-asmcfg, loc_db = parse_asm.parse_txt(machine.mn, attrib, source, loc_db)
+asmcfg = parse_asm.parse_txt(machine.mn, attrib, source, loc_db)
 
 # Fix shellcode addrs
 loc_db.set_location_offset(loc_db.get_name_location("main"), addr_main)

--- a/example/asm/simple.py
+++ b/example/asm/simple.py
@@ -30,7 +30,7 @@ loop:
 loc_db.set_location_offset(loc_db.get_name_location("main"), 0x0)
 
 # Spread information and resolve instructions offset
-patches = asmblock.asm_resolve_final(mn_x86, asmcfg, loc_db)
+patches = asmblock.asm_resolve_final(mn_x86, asmcfg)
 
 # Show resolved asmcfg
 for block in asmcfg.blocks:

--- a/example/asm/simple.py
+++ b/example/asm/simple.py
@@ -4,10 +4,12 @@ from pprint import pprint
 
 from miasm.arch.x86.arch import mn_x86
 from miasm.core import parse_asm, asmblock
-
+from miasm.core.locationdb import LocationDB
 
 # Assemble code
-asmcfg, loc_db = parse_asm.parse_txt(mn_x86, 32, '''
+loc_db = LocationDB()
+asmcfg = parse_asm.parse_txt(
+    mn_x86, 32, '''
 main:
    MOV    EAX, 1
    MOV    EBX, 2
@@ -20,7 +22,9 @@ loop:
    ADD    EAX, ECX
    JZ     loop
    RET
-''')
+''',
+    loc_db
+)
 
 # Set 'main' loc_key's offset
 loc_db.set_location_offset(loc_db.get_name_location("main"), 0x0)

--- a/example/disasm/callback.py
+++ b/example/disasm/callback.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 from miasm.analysis.binary import Container
 from miasm.analysis.machine import Machine
 from miasm.core.asmblock import AsmConstraint
+from miasm.core.locationdb import LocationDB
 
 
 def cb_x86_callpop(mdis, cur_bloc, offset_to_dis):
@@ -50,8 +51,9 @@ shellcode = (
 
 # Instantiate a x86 32 bit architecture
 machine = Machine("x86_32")
-cont = Container.from_string(shellcode)
-mdis = machine.dis_engine(cont.bin_stream, loc_db=cont.loc_db)
+loc_db = LocationDB()
+cont = Container.from_string(shellcode, loc_db)
+mdis = machine.dis_engine(cont.bin_stream, loc_db=loc_db)
 
 print("Without callback:\n")
 asmcfg = mdis.dis_multiblock(0)

--- a/example/disasm/dis_binary.py
+++ b/example/disasm/dis_binary.py
@@ -2,12 +2,14 @@ from __future__ import print_function
 import sys
 from miasm.analysis.binary import Container
 from miasm.analysis.machine import Machine
+from miasm.core.locationdb import LocationDB
 
 fdesc = open(sys.argv[1], 'rb')
+loc_db = LocationDB()
 
 # The Container will provide a *bin_stream*, bytes source for the disasm engine
 # It will prodive a view from a PE or an ELF.
-cont = Container.from_stream(fdesc)
+cont = Container.from_stream(fdesc, loc_db)
 
 # The Machine, instantiated with the detected architecture, will provide tools
 # (disassembler, etc.) to work with this architecture

--- a/example/disasm/dis_binary_ir.py
+++ b/example/disasm/dis_binary_ir.py
@@ -3,14 +3,16 @@ import sys
 from future.utils import viewvalues
 from miasm.analysis.binary import Container
 from miasm.analysis.machine import Machine
+from miasm.core.locationdb import LocationDB
 
 #####################################
 # Common section from dis_binary.py #
 #####################################
 
 fdesc = open(sys.argv[1], 'rb')
+loc_db = LocationDB()
 
-cont = Container.from_stream(fdesc)
+cont = Container.from_stream(fdesc, loc_db)
 
 machine = Machine(cont.arch)
 

--- a/example/disasm/dis_binary_ira.py
+++ b/example/disasm/dis_binary_ira.py
@@ -4,14 +4,16 @@ import sys
 from future.utils import viewvalues
 from miasm.analysis.binary import Container
 from miasm.analysis.machine import Machine
+from miasm.core.locationdb import LocationDB
 
 #####################################
 # Common section from dis_binary.py #
 #####################################
 
 fdesc = open(sys.argv[1], 'rb')
+loc_db = LocationDB()
 
-cont = Container.from_stream(fdesc)
+cont = Container.from_stream(fdesc, loc_db)
 
 machine = Machine(cont.arch)
 

--- a/example/disasm/dis_x86_string.py
+++ b/example/disasm/dis_x86_string.py
@@ -1,16 +1,21 @@
 from __future__ import print_function
 from miasm.analysis.binary import Container
 from miasm.analysis.machine import Machine
+from miasm.core.locationdb import LocationDB
 
 # The Container will provide a *bin_stream*, bytes source for the disasm engine
-cont = Container.from_string(b"\x83\xf8\x10\x74\x07\x89\xc6\x0f\x47\xc3\xeb\x08\x89\xc8\xe8\x31\x33\x22\x11\x40\xc3")
+loc_db = LocationDB()
+cont = Container.from_string(
+    b"\x83\xf8\x10\x74\x07\x89\xc6\x0f\x47\xc3\xeb\x08\x89\xc8\xe8\x31\x33\x22\x11\x40\xc3",
+    loc_db
+)
 
 # Instantiate a x86 32 bit architecture
 machine = Machine("x86_32")
 
 # Instantiate a disassembler engine, using the previous bin_stream and its
 # associated location DB.
-mdis = machine.dis_engine(cont.bin_stream, loc_db=cont.loc_db)
+mdis = machine.dis_engine(cont.bin_stream, loc_db=loc_db)
 
 # Run a recursive traversal disassembling from address 0
 asmcfg = mdis.dis_multiblock(0)

--- a/example/disasm/full.py
+++ b/example/disasm/full.py
@@ -15,6 +15,7 @@ from miasm.expression.simplifications import expr_simp
 from miasm.analysis.ssa import SSADiGraph
 from miasm.ir.ir import AssignBlock, IRBlock
 from miasm.analysis.simplifier import IRCFGSimplifierCommon, IRCFGSimplifierSSA
+from miasm.core.locationdb import LocationDB
 
 log = logging.getLogger("dis")
 console_handler = logging.StreamHandler()
@@ -75,13 +76,20 @@ args = parser.parse_args()
 if args.verbose:
     log_asmblock.setLevel(logging.DEBUG)
 
+loc_db = LocationDB()
 log.info('Load binary')
 if args.rawbinary:
-    cont = Container.fallback_container(open(args.filename, "rb").read(),
-                                        vm=None, addr=args.base_address)
+    cont = Container.fallback_container(
+        open(args.filename, "rb").read(),
+        vm=None, addr=args.base_address,
+        loc_db=loc_db,
+    )
 else:
     with open(args.filename, "rb") as fdesc:
-        cont = Container.from_stream(fdesc, addr=args.base_address)
+        cont = Container.from_stream(
+            fdesc, addr=args.base_address,
+            loc_db=loc_db,
+        )
 
 default_addr = cont.entry_point
 bs = cont.bin_stream

--- a/example/expression/access_c.py
+++ b/example/expression/access_c.py
@@ -55,6 +55,8 @@ from miasm.arch.x86.ctype import CTypeAMD64_unk
 from miasm.core.objc import ExprToAccessC, CHandler
 from miasm.core.objc import CTypesManagerNotPacked
 from miasm.core.ctypesmngr import CAstTypes, CTypePtr, CTypeStruct
+from miasm.core.locationdb import LocationDB
+
 
 def find_call(ircfg):
     """Returns (irb, index) which call"""
@@ -116,6 +118,7 @@ class MyCHandler(CHandler):
 
 
 
+loc_db = LocationDB()
 data = open(sys.argv[1], 'rb').read()
 # Digest C information
 text = """
@@ -143,12 +146,12 @@ cont = Container.fallback_container(data, None, addr=0)
 machine = Machine("x86_64")
 dis_engine, ira = machine.dis_engine, machine.ira
 
-mdis = dis_engine(cont.bin_stream, loc_db=cont.loc_db)
+mdis = dis_engine(cont.bin_stream, loc_db=loc_db)
 addr_head = 0
 asmcfg = mdis.dis_multiblock(addr_head)
-lbl_head = mdis.loc_db.get_offset_location(addr_head)
+lbl_head = loc_db.get_offset_location(addr_head)
 
-ir_arch_a = ira(mdis.loc_db)
+ir_arch_a = ira(loc_db)
 ircfg = ir_arch_a.new_ircfg_from_asmcfg(asmcfg)
 
 open('graph_irflow.dot', 'w').write(ircfg.dot())

--- a/example/expression/asm_to_ir.py
+++ b/example/expression/asm_to_ir.py
@@ -9,10 +9,13 @@ from miasm.expression.expression import *
 from miasm.core import asmblock
 from miasm.arch.x86.ira import ir_a_x86_32
 from miasm.analysis.data_flow import DeadRemoval
+from miasm.core.locationdb import LocationDB
 
 
 # First, asm code
-asmcfg, loc_db = parse_asm.parse_txt(mn_x86, 32, '''
+loc_db = LocationDB()
+asmcfg = parse_asm.parse_txt(
+    mn_x86, 32, '''
 main:
    MOV    EAX, 1
    MOV    EBX, 2
@@ -25,7 +28,9 @@ loop:
    ADD    EAX, ECX
    JZ     loop
    RET
-''')
+''',
+    loc_db
+)
 
 
 loc_db.set_location_offset(loc_db.get_name_location("main"), 0x0)

--- a/example/expression/asm_to_ir.py
+++ b/example/expression/asm_to_ir.py
@@ -40,7 +40,7 @@ for block in asmcfg.blocks:
 
 print("symbols:")
 print(loc_db)
-patches = asmblock.asm_resolve_final(mn_x86, asmcfg, loc_db)
+patches = asmblock.asm_resolve_final(mn_x86, asmcfg)
 
 # Translate to IR
 ir_arch = ir_a_x86_32(loc_db)

--- a/example/expression/constant_propagation.py
+++ b/example/expression/constant_propagation.py
@@ -12,6 +12,8 @@ from miasm.analysis.cst_propag import propagate_cst_expr
 from miasm.analysis.data_flow import DeadRemoval, \
     merge_blocks, remove_empty_assignblks
 from miasm.expression.simplifications import expr_simp
+from miasm.core.locationdb import LocationDB
+
 
 
 parser = ArgumentParser("Constant expression propagation")
@@ -25,8 +27,9 @@ args = parser.parse_args()
 
 machine = Machine("x86_32")
 
-cont = Container.from_stream(open(args.filename, 'rb'))
-mdis = machine.dis_engine(cont.bin_stream, loc_db=cont.loc_db)
+loc_db = LocationDB()
+cont = Container.from_stream(open(args.filename, 'rb'), loc_db)
+mdis = machine.dis_engine(cont.bin_stream, loc_db=loc_db)
 ir_arch = machine.ira(mdis.loc_db)
 addr = int(args.address, 0)
 deadrm = DeadRemoval(ir_arch)

--- a/example/expression/export_llvm.py
+++ b/example/expression/export_llvm.py
@@ -6,18 +6,19 @@ from miasm.analysis.machine import Machine
 from miasm.jitter.llvmconvert import LLVMType, LLVMContext_IRCompilation, LLVMFunction_IRCompilation
 from llvmlite import ir as llvm_ir
 from miasm.expression.simplifications import expr_simp_high_to_explicit
+from miasm.core.locationdb import LocationDB
 
 parser = ArgumentParser("LLVM export example")
 parser.add_argument("target", help="Target binary")
 parser.add_argument("addr", help="Target address")
 parser.add_argument("--architecture", "-a", help="Force architecture")
 args = parser.parse_args()
-
+loc_db = LocationDB()
 # This part focus on obtaining an IRCFG to transform #
-cont = Container.from_stream(open(args.target, 'rb'))
+cont = Container.from_stream(open(args.target, 'rb'), loc_db)
 machine = Machine(args.architecture if args.architecture else cont.arch)
-ir = machine.ir(cont.loc_db)
-dis = machine.dis_engine(cont.bin_stream, loc_db=cont.loc_db)
+ir = machine.ir(loc_db)
+dis = machine.dis_engine(cont.bin_stream, loc_db=loc_db)
 asmcfg = dis.dis_multiblock(int(args.addr, 0))
 ircfg = ir.new_ircfg_from_asmcfg(asmcfg)
 ircfg.simplify(expr_simp_high_to_explicit)

--- a/example/expression/graph_dataflow.py
+++ b/example/expression/graph_dataflow.py
@@ -10,6 +10,7 @@ from miasm.analysis.data_analysis import intra_block_flow_raw, inter_block_flow
 from miasm.core.graph import DiGraph
 from miasm.ir.symbexec import SymbolicExecutionEngine
 from miasm.analysis.data_flow import DeadRemoval
+from miasm.core.locationdb import LocationDB
 
 
 parser = ArgumentParser("Simple expression use for generating dataflow graph")
@@ -126,19 +127,19 @@ def gen_block_data_flow_graph(ir_arch, ircfg, ad, block_flow_cb):
 
 
 ad = int(args.addr, 16)
-
+loc_db = LocationDB()
 print('disasm...')
-cont = Container.from_stream(open(args.filename, 'rb'))
+cont = Container.from_stream(open(args.filename, 'rb'), loc_db)
 machine = Machine("x86_32")
 
-mdis = machine.dis_engine(cont.bin_stream, loc_db=cont.loc_db)
+mdis = machine.dis_engine(cont.bin_stream, loc_db=loc_db)
 mdis.follow_call = True
 asmcfg = mdis.dis_multiblock(ad)
 print('ok')
 
 
 print('generating dataflow graph for:')
-ir_arch_analysis = machine.ira(mdis.loc_db)
+ir_arch_analysis = machine.ira(loc_db)
 ircfg = ir_arch_analysis.new_ircfg_from_asmcfg(asmcfg)
 deadrm = DeadRemoval(ir_arch_analysis)
 

--- a/example/expression/solve_condition_stp.py
+++ b/example/expression/solve_condition_stp.py
@@ -15,6 +15,7 @@ from miasm.ir.symbexec import SymbolicExecutionEngine, get_block
 from miasm.expression.simplifications import expr_simp
 from miasm.core import parse_asm
 from miasm.ir.translators.translator  import Translator
+from miasm.core.locationdb import LocationDB
 
 machine = Machine("x86_32")
 
@@ -79,24 +80,26 @@ def emul_symb(ir_arch, ircfg, mdis, states_todo, states_done):
 
 
 if __name__ == '__main__':
-
+    loc_db = LocationDB()
     translator_smt2 = Translator.to_language("smt2")
 
     addr = int(options.address, 16)
 
-    cont = Container.from_stream(open(args[0], 'rb'))
-    mdis = machine.dis_engine(cont.bin_stream, loc_db=cont.loc_db)
+    cont = Container.from_stream(open(args[0], 'rb'), loc_db)
+    mdis = machine.dis_engine(cont.bin_stream, loc_db=loc_db)
     ir_arch = machine.ir(mdis.loc_db)
     ircfg = ir_arch.new_ircfg()
     symbexec = SymbolicExecutionEngine(ir_arch)
 
-    asmcfg, loc_db = parse_asm.parse_txt(machine.mn, 32, '''
+    asmcfg = parse_asm.parse_txt(
+        machine.mn, 32, '''
     init:
     PUSH argv
     PUSH argc
     PUSH ret_addr
     ''',
-    loc_db=mdis.loc_db)
+        loc_db
+    )
 
 
     argc_lbl = loc_db.get_name_location('argc')

--- a/example/ida/depgraph.py
+++ b/example/ida/depgraph.py
@@ -254,7 +254,7 @@ def launch_depgraph():
                 dst, src = expr_simp(dst), expr_simp(src)
                 new_assignblk[dst] = src
             irs.append(AssignBlock(new_assignblk, instr=assignblk.instr))
-        ircfg.blocks[irb.loc_key] = IRBlock(irb.loc_key, irs)
+        ircfg.blocks[irb.loc_key] = IRBlock(irb.loc_db, irb.loc_key, irs)
 
     # Get dependency graphs
     dg = settings.depgraph

--- a/example/ida/graph_ir.py
+++ b/example/ida/graph_ir.py
@@ -239,7 +239,7 @@ def build_graph(start_addr, type_graph, simplify=False, dontmodstack=True, loadi
                 for dst, src in viewitems(assignblk)
             }
             irs.append(AssignBlock(new_assignblk, instr=assignblk.instr))
-        ircfg.blocks[irb.loc_key] = IRBlock(irb.loc_key, irs)
+        ircfg.blocks[irb.loc_key] = IRBlock(irb.loc_db, irb.loc_key, irs)
 
     if verbose:
         out = ircfg.dot()
@@ -286,7 +286,7 @@ def build_graph(start_addr, type_graph, simplify=False, dontmodstack=True, loadi
         assignblks = list(irblock)
         new_assiblk = AssignBlock(regs, assignblks[-1].instr)
         assignblks.append(new_assiblk)
-        new_irblock = IRBlock(irblock.loc_key, assignblks)
+        new_irblock = IRBlock(irblock.loc_db, irblock.loc_key, assignblks)
         ircfg.blocks[loc] = new_irblock
 
 

--- a/example/jitter/arm.py
+++ b/example/jitter/arm.py
@@ -5,6 +5,7 @@ import logging
 from pdb import pm
 
 from miasm.analysis.sandbox import Sandbox_Linux_arml
+from miasm.core.locationdb import LocationDB
 
 # Get arguments
 parser = Sandbox_Linux_arml.parser(description="""Sandbox an elf binary with arm
@@ -14,7 +15,8 @@ parser.add_argument('-v', "--verbose", help="verbose mode", action="store_true")
 options = parser.parse_args()
 
 # Prepare the sandbox
-sb = Sandbox_Linux_arml(options.filename, options, globals())
+loc_db = LocationDB()
+sb = Sandbox_Linux_arml(loc_db, options.filename, options, globals())
 
 # Handle 'verbose' option
 if options.verbose is True:

--- a/example/jitter/arm_sc.py
+++ b/example/jitter/arm_sc.py
@@ -4,6 +4,7 @@ from miasm.core.utils import int_to_byte
 from miasm.analysis.sandbox import Sandbox_Linux_armb_str
 from miasm.analysis.sandbox import Sandbox_Linux_arml_str
 from miasm.loader.strpatchwork import StrPatchwork
+from miasm.core.locationdb import LocationDB
 
 from pdb import pm
 
@@ -23,7 +24,8 @@ elif options.endianness == 'l':
 else:
     raise ValueError("Bad endianness!")
 
-sb = sandbox(options.filename, options, globals())
+loc_db = LocationDB()
+sb = sandbox(loc_db, options.filename, options, globals())
 
 if options.address is None:
     raise ValueError('invalid address')

--- a/example/jitter/example_types.py
+++ b/example/jitter/example_types.py
@@ -11,6 +11,9 @@ from miasm.analysis.machine import Machine
 from miasm.core.types import MemStruct, Self, Void, Str, Array, Ptr, \
                               Num, Array, set_allocator
 from miasm.os_dep.common import heap
+from miasm.core.locationdb import LocationDB
+
+loc_db = LocationDB()
 
 # Instantiate a heap
 my_heap = heap()
@@ -154,7 +157,7 @@ print()
 # A random jitter
 # You can also use miasm.jitter.VmMngr.Vm(), but it does not happen in real
 # life scripts, so here is the usual way:
-jitter = Machine("x86_32").jitter("python")
+jitter = Machine("x86_32").jitter(loc_db, "python")
 vm = jitter.vm
 
 # Auto-allocated by my_heap. If you allocate memory at `addr`,

--- a/example/jitter/mips32.py
+++ b/example/jitter/mips32.py
@@ -5,6 +5,8 @@ from argparse import ArgumentParser
 from miasm.analysis import debugging
 from miasm.jitter.csts import *
 from miasm.analysis.machine import Machine
+from miasm.core.locationdb import LocationDB
+
 
 parser = ArgumentParser(
     description="""Sandbox raw binary with mips32 engine
@@ -34,8 +36,9 @@ def code_sentinelle(jitter):
     return True
 
 def jit_mips32_binary(args):
+    loc_db = LocationDB()
     filepath, entryp = args.binary, int(args.addr, 0)
-    myjit = machine.jitter(jit_type = args.jitter)
+    myjit = machine.jitter(loc_db, jit_type = args.jitter)
     myjit.init_stack()
 
     # Log level (if available with jitter engine)

--- a/example/jitter/msp430.py
+++ b/example/jitter/msp430.py
@@ -5,6 +5,7 @@ from argparse import ArgumentParser
 from miasm.analysis import debugging
 from miasm.jitter.csts import *
 from miasm.analysis.machine import Machine
+from miasm.core.locationdb import LocationDB
 
 parser = ArgumentParser(
     description="""Sandbox raw binary with msp430 engine
@@ -29,8 +30,9 @@ parser.add_argument("addr",
 machine = Machine("msp430")
 
 def jit_msp430_binary(args):
+    loc_db = LocationDB()
     filepath, entryp = args.binary, int(args.addr, 0)
-    myjit = machine.jitter(jit_type = args.jitter)
+    myjit = machine.jitter(loc_db, jit_type = args.jitter)
 
     # Log level (if available with jitter engine)
     myjit.set_trace_log(

--- a/example/jitter/sandbox_call.py
+++ b/example/jitter/sandbox_call.py
@@ -5,16 +5,18 @@ from miasm.analysis.sandbox import Sandbox_Linux_arml
 from miasm.analysis.binary import Container
 from miasm.os_dep.linux_stdlib import linobjs
 from miasm.core.utils import hexdump
+from miasm.core.locationdb import LocationDB
 
 # Parse arguments
 parser = Sandbox_Linux_arml.parser(description="ELF sandboxer")
 parser.add_argument("filename", help="ELF Filename")
 options = parser.parse_args()
 
-sb = Sandbox_Linux_arml(options.filename, options, globals())
+loc_db = LocationDB()
+sb = Sandbox_Linux_arml(loc_db, options.filename, options, globals())
 
 with open(options.filename, "rb") as fdesc:
-    cont = Container.from_stream(fdesc)
+    cont = Container.from_stream(fdesc, loc_db)
     loc_key = cont.loc_db.get_name_location("md5_starts")
     addr_to_call = cont.loc_db.get_location_offset(loc_key)
 

--- a/example/jitter/sandbox_elf_aarch64l.py
+++ b/example/jitter/sandbox_elf_aarch64l.py
@@ -1,6 +1,7 @@
 import logging
 from pdb import pm
 from miasm.analysis.sandbox import Sandbox_Linux_aarch64l
+from miasm.core.locationdb import LocationDB
 from miasm.jitter.jitload import log_func
 
 # Insert here user defined methods
@@ -11,7 +12,8 @@ parser.add_argument("filename", help="ELF Filename")
 options = parser.parse_args()
 
 # Create sandbox
-sb = Sandbox_Linux_aarch64l(options.filename, options, globals())
+loc_db = LocationDB()
+sb = Sandbox_Linux_aarch64l(loc_db, options.filename, options, globals())
 
 log_func.setLevel(logging.ERROR)
 

--- a/example/jitter/sandbox_elf_ppc32.py
+++ b/example/jitter/sandbox_elf_ppc32.py
@@ -1,6 +1,7 @@
 import os
 from pdb import pm
 from miasm.analysis.sandbox import Sandbox_Linux_ppc32b
+from miasm.core.locationdb import LocationDB
 from miasm.jitter.csts import *
 from miasm.jitter.jitload import log_func
 import logging
@@ -13,7 +14,8 @@ parser.add_argument("filename", help="ELF Filename")
 options = parser.parse_args()
 
 # Create sandbox
-sb = Sandbox_Linux_ppc32b(options.filename, options, globals())
+loc_db = LocationDB()
+sb = Sandbox_Linux_ppc32b(loc_db, options.filename, options, globals())
 log_func.setLevel(logging.ERROR)
 
 sb.run()

--- a/example/jitter/sandbox_pe_x86_32.py
+++ b/example/jitter/sandbox_pe_x86_32.py
@@ -1,6 +1,6 @@
 from pdb import pm
 from miasm.analysis.sandbox import Sandbox_Win_x86_32
-
+from miasm.core.locationdb import LocationDB
 # Insert here user defined methods
 
 # Parse arguments
@@ -9,7 +9,8 @@ parser.add_argument("filename", help="PE Filename")
 options = parser.parse_args()
 
 # Create sandbox
-sb = Sandbox_Win_x86_32(options.filename, options, globals())
+loc_db = LocationDB()
+sb = Sandbox_Win_x86_32(loc_db, options.filename, options, globals())
 
 # Run
 sb.run()

--- a/example/jitter/sandbox_pe_x86_64.py
+++ b/example/jitter/sandbox_pe_x86_64.py
@@ -1,5 +1,6 @@
 from pdb import pm
 from miasm.analysis.sandbox import Sandbox_Win_x86_64
+from miasm.core.locationdb import LocationDB
 
 # Insert here user defined methods
 
@@ -9,7 +10,8 @@ parser.add_argument("filename", help="PE Filename")
 options = parser.parse_args()
 
 # Create sandbox
-sb = Sandbox_Win_x86_64(options.filename, options, globals())
+loc_db = LocationDB()
+sb = Sandbox_Win_x86_64(loc_db, options.filename, options, globals())
 
 # Run
 sb.run()

--- a/example/jitter/test_x86_32_seh.py
+++ b/example/jitter/test_x86_32_seh.py
@@ -1,6 +1,7 @@
 import os
 from pdb import pm
 from miasm.analysis.sandbox import Sandbox_Win_x86_32
+from miasm.core.locationdb import LocationDB
 from miasm.os_dep import win_api_x86_32_seh
 from miasm.jitter.csts import *
 
@@ -42,7 +43,8 @@ options.usesegm = True
 options.use_windows_structs = True
 
 # Create sandbox
-sb = Sandbox_Win_x86_32(options.filename, options, globals())
+loc_db = LocationDB()
+sb = Sandbox_Win_x86_32(loc_db, options.filename, options, globals())
 
 # Install Windows SEH callbacks
 sb.jitter.add_exception_handler(EXCEPT_ACCESS_VIOL, deal_exception_access_violation)

--- a/example/jitter/trace.py
+++ b/example/jitter/trace.py
@@ -14,6 +14,7 @@ from pdb import pm
 from miasm.analysis.sandbox import Sandbox_Linux_arml
 from miasm.jitter.emulatedsymbexec import EmulatedSymbExec
 from miasm.jitter.jitcore_python import JitCore_Python
+from miasm.core.locationdb import LocationDB
 
 # Function called at each instruction
 instr_count = 0
@@ -45,7 +46,8 @@ JitCore_Python.SymbExecClass = ESETrackMemory
 
 # Create sandbox, forcing Python jitter
 options.jitter = "python"
-sb = Sandbox_Linux_arml(options.filename, options, globals())
+loc_db = LocationDB()
+sb = Sandbox_Linux_arml(loc_db, options.filename, options, globals())
 
 # Force jit one instr per call, and register our callback
 sb.jitter.jit.set_options(jit_maxline=1, max_exec_per_call=1)

--- a/example/jitter/unpack_upx.py
+++ b/example/jitter/unpack_upx.py
@@ -3,6 +3,7 @@ import os
 import logging
 from miasm.analysis.sandbox import Sandbox_Win_x86_32
 from miasm.jitter.loader.pe import vm2pe
+from miasm.core.locationdb import LocationDB
 
 from miasm.os_dep.common import get_win_str_a
 
@@ -41,8 +42,11 @@ parser.add_argument("--graph",
 options = parser.parse_args()
 options.load_hdr = True
 
-sb = Sandbox_Win_x86_32(options.filename, options, globals(),
-                        parse_reloc=False)
+loc_db = LocationDB()
+sb = Sandbox_Win_x86_32(
+    loc_db, options.filename, options, globals(),
+    parse_reloc=False
+)
 
 
 if options.verbose is True:
@@ -54,7 +58,7 @@ if options.verbose is True:
     print(sb.jitter.vm)
 
 # Ensure there is one and only one leave (for OEP discovering)
-mdis = sb.machine.dis_engine(sb.jitter.bs)
+mdis = sb.machine.dis_engine(sb.jitter.bs, loc_db=loc_db)
 mdis.dont_dis_nulstart_bloc = True
 asmcfg = mdis.dis_multiblock(sb.entry_point)
 

--- a/example/jitter/x86_32.py
+++ b/example/jitter/x86_32.py
@@ -1,6 +1,7 @@
 from argparse import ArgumentParser
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
 from miasm.analysis.machine import Machine
+from miasm.core.locationdb import LocationDB
 
 from pdb import pm
 
@@ -16,8 +17,9 @@ def code_sentinelle(jitter):
     jitter.pc = 0
     return True
 
+loc_db = LocationDB()
 
-myjit = Machine("x86_32").jitter(args.jitter)
+myjit = Machine("x86_32").jitter(loc_db, args.jitter)
 myjit.init_stack()
 
 data = open(args.filename, 'rb').read()

--- a/example/jitter/x86_64.py
+++ b/example/jitter/x86_64.py
@@ -2,6 +2,7 @@ from argparse import ArgumentParser
 from pdb import pm
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE, EXCEPT_SYSCALL
 from miasm.analysis.machine import Machine
+from miasm.core.locationdb import LocationDB
 
 
 # Some syscalls often used by shellcodes
@@ -76,8 +77,9 @@ if __name__ == "__main__":
     parser.add_argument("--verbose", "-v", action="store_true",
                         help="Verbose mode")
     args = parser.parse_args()
+    loc_db = LocationDB()
 
-    myjit = Machine("x86_64").jitter(args.jitter)
+    myjit = Machine("x86_64").jitter(loc_db, args.jitter)
     myjit.init_stack()
 
     with open(args.filename, 'rb') as f:

--- a/example/symbol_exec/depgraph.py
+++ b/example/symbol_exec/depgraph.py
@@ -10,6 +10,7 @@ from miasm.analysis.machine import Machine
 from miasm.analysis.binary import Container
 from miasm.analysis.depgraph import DependencyGraph
 from miasm.expression.expression import ExprMem, ExprId, ExprInt
+from miasm.core.locationdb import LocationDB
 
 parser = ArgumentParser("Dependency grapher")
 parser.add_argument("filename", help="Binary to analyse")
@@ -33,10 +34,10 @@ parser.add_argument("--json",
                     help="Output solution in JSON",
                     action="store_true")
 args = parser.parse_args()
-
+loc_db = LocationDB()
 # Get architecture
 with open(args.filename, "rb") as fstream:
-    cont = Container.from_stream(fstream)
+    cont = Container.from_stream(fstream, loc_db)
 
 arch = args.architecture if args.architecture else cont.arch
 machine = Machine(arch)
@@ -50,8 +51,8 @@ for element in args.element:
     except KeyError:
         raise ValueError("Unknown element '%s'" % element)
 
-mdis = machine.dis_engine(cont.bin_stream, dont_dis_nulstart_bloc=True)
-ir_arch = machine.ira(mdis.loc_db)
+mdis = machine.dis_engine(cont.bin_stream, dont_dis_nulstart_bloc=True, loc_db=loc_db)
+ir_arch = machine.ira(loc_db)
 
 # Common argument forms
 init_ctx = {}

--- a/example/symbol_exec/dse_crackme.py
+++ b/example/symbol_exec/dse_crackme.py
@@ -21,6 +21,7 @@ from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
 from miasm.analysis.sandbox import Sandbox_Linux_x86_64
 from miasm.expression.expression import *
 from miasm.os_dep.win_api_x86_32 import get_win_str_a
+from miasm.core.locationdb import LocationDB
 
 is_win = platform.system() == "Windows"
 
@@ -75,7 +76,8 @@ parser.add_argument("--strategy",
 options = parser.parse_args()
 options.mimic_env = True
 options.command_line = ["%s" % TEMP_FILE.name]
-sb = Sandbox_Linux_x86_64(options.filename, options, globals())
+loc_db = LocationDB()
+sb = Sandbox_Linux_x86_64(loc_db, options.filename, options, globals())
 
 # Init segment
 sb.jitter.ir_arch.do_stk_segm = True
@@ -238,7 +240,7 @@ strategy = {
     "branch-cov": DSEPathConstraint.PRODUCE_SOLUTION_BRANCH_COV,
     "path-cov": DSEPathConstraint.PRODUCE_SOLUTION_PATH_COV,
 }[options.strategy]
-dse = DSEPathConstraint(machine, produce_solution=strategy)
+dse = DSEPathConstraint(machine, loc_db, produce_solution=strategy)
 
 # Attach to the jitter
 dse.attach(sb.jitter)

--- a/example/symbol_exec/dse_strategies.py
+++ b/example/symbol_exec/dse_strategies.py
@@ -26,6 +26,7 @@ from miasm.analysis.machine import Machine
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
 from miasm.analysis.dse import DSEPathConstraint
 from miasm.expression.expression import ExprMem, ExprId, ExprInt, ExprAssign
+from miasm.core.locationdb import LocationDB
 
 # Argument handling
 parser = ArgumentParser("DSE Example")
@@ -41,10 +42,12 @@ strategy = {
     "path-cov": DSEPathConstraint.PRODUCE_SOLUTION_PATH_COV,
 }[args.strategy]
 
+loc_db = LocationDB()
+
 # Map the shellcode
 run_addr = 0x40000
 machine = Machine("x86_32")
-jitter = machine.jitter("python")
+jitter = machine.jitter(loc_db, "python")
 with open(args.filename, "rb") as fdesc:
     jitter.vm.add_memory_page(
         run_addr,
@@ -72,7 +75,7 @@ jitter.push_uint32_t(ret_addr)
 jitter.init_run(run_addr)
 
 # Init a DSE instance with a given strategy
-dse = DSEPathConstraint(machine, produce_solution=strategy)
+dse = DSEPathConstraint(machine, loc_db, produce_solution=strategy)
 dse.attach(jitter)
 # Concretize everything except the argument
 dse.update_state_from_concrete()

--- a/miasm/analysis/cst_propag.py
+++ b/miasm/analysis/cst_propag.py
@@ -113,7 +113,7 @@ class SymbExecStateFix(SymbolicExecutionEngine):
 
             self.eval_updt_assignblk(assignblk)
             assignblks.append(AssignBlock(new_assignblk, assignblk.instr))
-        self.ircfg.blocks[irb.loc_key] = IRBlock(irb.loc_key, assignblks)
+        self.ircfg.blocks[irb.loc_key] = IRBlock(irb.loc_db, irb.loc_key, assignblks)
 
 
 def compute_cst_propagation_states(ir_arch, ircfg, init_addr, init_infos):

--- a/miasm/analysis/data_flow.py
+++ b/miasm/analysis/data_flow.py
@@ -1062,10 +1062,10 @@ class DiGraphLiveness(DiGraph):
     DiGraph representing variable liveness
     """
 
-    def __init__(self, ircfg, loc_db=None):
+    def __init__(self, ircfg):
         super(DiGraphLiveness, self).__init__()
         self.ircfg = ircfg
-        self.loc_db = loc_db
+        self.loc_db = ircfg.loc_db
         self._blocks = {}
         # Add irblocks gen/kill
         for node in ircfg.nodes():
@@ -1092,14 +1092,11 @@ class DiGraphLiveness(DiGraph):
         """
         Output liveness information in dot format
         """
-        if self.loc_db is None:
-            node_name = str(node)
+        names = self.loc_db.get_location_names(node)
+        if not names:
+            node_name = self.loc_db.pretty_str(node)
         else:
-            names = self.loc_db.get_location_names(node)
-            if not names:
-                node_name = self.loc_db.pretty_str(node)
-            else:
-                node_name = "".join("%s:\n" % name for name in names)
+            node_name = "".join("%s:\n" % name for name in names)
         yield self.DotCellDescription(
             text="%s" % node_name,
             attr={

--- a/miasm/analysis/data_flow.py
+++ b/miasm/analysis/data_flow.py
@@ -387,7 +387,7 @@ class DeadRemoval(object):
                         del new_assignblk[lval]
                         modified = True
                 irs.append(AssignBlock(new_assignblk, assignblk.instr))
-            ircfg.blocks[block.loc_key] = IRBlock(block.loc_key, irs)
+            ircfg.blocks[block.loc_key] = IRBlock(block.loc_db, block.loc_key, irs)
         return modified
 
     def __call__(self, ircfg):
@@ -438,7 +438,7 @@ def _do_merge_blocks(ircfg, loc_key, son_loc_key):
             assignblks.append(AssignBlock(affs, assignblk.instr))
 
     assignblks += ircfg.blocks[son_loc_key].assignblks
-    new_block = IRBlock(loc_key, assignblks)
+    new_block = IRBlock(ircfg.loc_db, loc_key, assignblks)
 
     ircfg.discard_edge(loc_key, son_loc_key)
 
@@ -564,7 +564,7 @@ def _remove_to_parent(ircfg, loc_key, son_loc_key):
     ircfg.del_edge(loc_key, son_loc_key)
 
     old_irblock = ircfg.blocks[son_loc_key]
-    new_irblock = IRBlock(loc_key, old_irblock.assignblks)
+    new_irblock = IRBlock(ircfg.loc_db, loc_key, old_irblock.assignblks)
 
     ircfg.blocks[son_loc_key] = new_irblock
 
@@ -657,7 +657,7 @@ def remove_empty_assignblks(ircfg):
             else:
                 block_modified = True
         if block_modified:
-            new_irblock = IRBlock(loc_key, irs)
+            new_irblock = IRBlock(ircfg.loc_db, loc_key, irs)
             ircfg.blocks[loc_key] = new_irblock
             modified = True
     return modified
@@ -909,7 +909,7 @@ def replace_stack_vars(ir_arch_a, ircfg):
 
             out = AssignBlock(out, assignblk.instr)
             assignblks.append(out)
-        new_block = IRBlock(block.loc_key, assignblks)
+        new_block = IRBlock(block.loc_db, block.loc_key, assignblks)
         ircfg.blocks[block.loc_key] = new_block
     return modified
 
@@ -987,7 +987,7 @@ def load_from_int(ir_arch, bs, is_addr_ro_variable):
                 out[dst] = src_new
             out = AssignBlock(out, assignblk.instr)
             assignblks.append(out)
-        block = IRBlock(block.loc_key, assignblks)
+        block = IRBlock(block.loc_db, block.loc_key, assignblks)
         ir_arch.blocks[block.loc_key] = block
     return modified
 
@@ -1233,7 +1233,7 @@ def discard_phi_sources(ircfg, deleted_vars):
         assignblk.update(todo)
         assignblk = AssignBlock(assignblk, assignblks[0].instr)
         assignblks[0] = assignblk
-        new_irblock = IRBlock(block.loc_key, assignblks)
+        new_irblock = IRBlock(block.loc_db, block.loc_key, assignblks)
         ircfg.blocks[block.loc_key] = new_irblock
     return True
 
@@ -1312,7 +1312,7 @@ def update_phi_with_deleted_edges(ircfg, edges_to_del):
                 out[dst] = ExprOp('Phi', *to_keep)
         assignblk = AssignBlock(out, assignblks[0].instr)
         assignblks[0] = assignblk
-        new_irblock = IRBlock(loc_dst, assignblks)
+        new_irblock = IRBlock(block.loc_db, loc_dst, assignblks)
         blocks[block.loc_key] = new_irblock
 
     for loc_key, block in viewitems(blocks):
@@ -1490,7 +1490,7 @@ class DelDummyPhi(object):
                 assignblks = list(block)
                 assignblks[0] = AssignBlock(fixed_phis, assignblk.instr)
                 assignblks[1:1] = [AssignBlock({dst: true_value}, assignblk.instr)]
-                new_irblock = IRBlock(block.loc_key, assignblks)
+                new_irblock = IRBlock(block.loc_db, block.loc_key, assignblks)
                 ssa.graph.blocks[block.loc_key] = new_irblock
 
         return modified
@@ -2152,7 +2152,7 @@ class PropagateExpressions(object):
             if new_assignblk != assignblock:
                 modified = True
 
-        new_irblock = IRBlock(irblock.loc_key, new_assignblocks)
+        new_irblock = IRBlock(irblock.loc_db, irblock.loc_key, new_assignblocks)
 
         return new_irblock, modified
 

--- a/miasm/analysis/depgraph.py
+++ b/miasm/analysis/depgraph.py
@@ -7,7 +7,6 @@ from future.utils import viewitems
 from miasm.expression.expression import ExprInt, ExprLoc, ExprAssign, \
     ExprWalk, canonize_to_exprloc
 from miasm.core.graph import DiGraph
-from miasm.core.locationdb import LocationDB
 from miasm.expression.simplifications import expr_simp_explicit
 from miasm.ir.symbexec import SymbolicExecutionEngine
 from miasm.ir.ir import IRBlock, AssignBlock
@@ -309,7 +308,7 @@ class DependencyResult(DependencyState):
                                              line_nb).assignblks
 
         # Eval the block
-        loc_db = LocationDB()
+        loc_db = ir_arch.loc_db
         temp_loc = loc_db.get_or_create_name_location("Temp")
         symb_exec = SymbolicExecutionEngine(ir_arch, ctx_init)
         symb_exec.eval_updt_irblock(IRBlock(temp_loc, assignblks), step=step)

--- a/miasm/analysis/depgraph.py
+++ b/miasm/analysis/depgraph.py
@@ -280,7 +280,7 @@ class DependencyResult(DependencyState):
                     assignmnts[element] = irb[line_nb][element]
             assignblks.append(AssignBlock(assignmnts))
 
-        return IRBlock(irb.loc_key, assignblks)
+        return IRBlock(irb.loc_db, irb.loc_key, assignblks)
 
     def emul(self, ir_arch, ctx=None, step=False):
         """Symbolic execution of relevant nodes according to the history
@@ -311,7 +311,7 @@ class DependencyResult(DependencyState):
         loc_db = ir_arch.loc_db
         temp_loc = loc_db.get_or_create_name_location("Temp")
         symb_exec = SymbolicExecutionEngine(ir_arch, ctx_init)
-        symb_exec.eval_updt_irblock(IRBlock(temp_loc, assignblks), step=step)
+        symb_exec.eval_updt_irblock(IRBlock(loc_db, temp_loc, assignblks), step=step)
 
         # Return only inputs values (others could be wrongs)
         return {element: symb_exec.symbols[element]

--- a/miasm/analysis/dse.py
+++ b/miasm/analysis/dse.py
@@ -66,7 +66,6 @@ from miasm.expression.expression_helper import possible_values
 from miasm.ir.translators import Translator
 from miasm.analysis.expression_range import expr_range
 from miasm.analysis.modularintervals import ModularIntervals
-from miasm.core.locationdb import LocationDB
 
 DriftInfo = namedtuple("DriftInfo", ["symbol", "computed", "expected"])
 
@@ -162,9 +161,9 @@ class DSEEngine(object):
     """
     SYMB_ENGINE = ESETrackModif
 
-    def __init__(self, machine):
+    def __init__(self, machine, loc_db):
         self.machine = machine
-        self.loc_db = LocationDB()
+        self.loc_db = loc_db
         self.handler = {} # addr -> callback(DSEEngine instance)
         self.instrumentation = {} # addr -> callback(DSEEngine instance)
         self.addr_to_cacheblocks = {} # addr -> {label -> IRBlock}
@@ -527,13 +526,13 @@ class DSEPathConstraint(DSEEngine):
     PRODUCE_SOLUTION_BRANCH_COV = 2
     PRODUCE_SOLUTION_PATH_COV = 3
 
-    def __init__(self, machine, produce_solution=PRODUCE_SOLUTION_CODE_COV,
+    def __init__(self, machine, loc_db, produce_solution=PRODUCE_SOLUTION_CODE_COV,
                  known_solutions=None,
                  **kwargs):
         """Init a DSEPathConstraint
         @machine: Machine of the targeted architecture instance
         @produce_solution: (optional) if set, new solutions will be computed"""
-        super(DSEPathConstraint, self).__init__(machine, **kwargs)
+        super(DSEPathConstraint, self).__init__(machine, loc_db, **kwargs)
 
         # Dependency check
         assert z3 is not None

--- a/miasm/analysis/outofssa.py
+++ b/miasm/analysis/outofssa.py
@@ -73,7 +73,7 @@ class UnSSADiGraph(object):
 
             assignblks = list(irblock)
             assignblks[0] = AssignBlock(parallel_copies, irblock[0].instr)
-            new_irblock = IRBlock(irblock.loc_key, assignblks)
+            new_irblock = IRBlock(irblock.loc_db, irblock.loc_key, assignblks)
             ircfg.blocks[irblock.loc_key] = new_irblock
 
             # Insert new_var = src in each Phi's parent, at the end of the block
@@ -88,7 +88,7 @@ class UnSSADiGraph(object):
                 parent = ircfg.blocks[parent]
                 assignblks = list(parent)
                 assignblks.append(AssignBlock(parallel_copies, parent[-1].instr))
-                new_irblock = IRBlock(parent.loc_key, assignblks)
+                new_irblock = IRBlock(parent.loc_db, parent.loc_key, assignblks)
                 ircfg.blocks[parent.loc_key] = new_irblock
 
     def create_copy_var(self, var):
@@ -397,7 +397,7 @@ class UnSSADiGraph(object):
                     continue
                 out[dst] = src
             assignblks[0] = AssignBlock(out, assignblks[0].instr)
-            self.ssa.graph.blocks[irblock.loc_key] = IRBlock(irblock.loc_key, assignblks)
+            self.ssa.graph.blocks[irblock.loc_key] = IRBlock(irblock.loc_db, irblock.loc_key, assignblks)
 
     def remove_assign_eq(self):
         """
@@ -412,4 +412,4 @@ class UnSSADiGraph(object):
                         continue
                     out[dst] = src
                 assignblks[i] = AssignBlock(out, assignblk.instr)
-            self.ssa.graph.blocks[irblock.loc_key] = IRBlock(irblock.loc_key, assignblks)
+            self.ssa.graph.blocks[irblock.loc_key] = IRBlock(irblock.loc_db, irblock.loc_key, assignblks)

--- a/miasm/analysis/sandbox.py
+++ b/miasm/analysis/sandbox.py
@@ -42,7 +42,7 @@ class Sandbox(object):
 
     classes = property(lambda x: x.__class__._classes_())
 
-    def __init__(self, fname, options, custom_methods=None, **kwargs):
+    def __init__(self, loc_db, fname, options, custom_methods=None, **kwargs):
         """
         Initialize a sandbox
         @fname: str file name
@@ -54,8 +54,10 @@ class Sandbox(object):
         assert isinstance(fname, basestring)
         self.fname = fname
         self.options = options
+        self.loc_db = loc_db
         if custom_methods is None:
             custom_methods = {}
+        kwargs["loc_db"] = loc_db
         for cls in self.classes:
             if cls == Sandbox:
                 continue
@@ -171,9 +173,9 @@ class Arch(object):
     # Architecture name
     _ARCH_ = None
 
-    def __init__(self, **kwargs):
+    def __init__(self, loc_db, **kwargs):
         self.machine = Machine(self._ARCH_)
-        self.jitter = self.machine.jitter(self.options.jitter)
+        self.jitter = self.machine.jitter(loc_db, self.options.jitter)
 
     @classmethod
     def update_parser(cls, parser):
@@ -384,8 +386,8 @@ class Arch_x86(Arch):
     STACK_SIZE = 0x10000
     STACK_BASE = 0x130000
 
-    def __init__(self, **kwargs):
-        super(Arch_x86, self).__init__(**kwargs)
+    def __init__(self, loc_db, **kwargs):
+        super(Arch_x86, self).__init__(loc_db, **kwargs)
 
         if self.options.usesegm:
             self.jitter.ir_arch.do_stk_segm = True
@@ -417,8 +419,8 @@ class Arch_arml(Arch):
     STACK_SIZE = 0x100000
     STACK_BASE = 0x100000
 
-    def __init__(self, **kwargs):
-        super(Arch_arml, self).__init__(**kwargs)
+    def __init__(self, loc_db, **kwargs):
+        super(Arch_arml, self).__init__(loc_db, **kwargs)
 
         # Init stack
         self.jitter.stack_size = self.STACK_SIZE
@@ -431,8 +433,8 @@ class Arch_armb(Arch):
     STACK_SIZE = 0x100000
     STACK_BASE = 0x100000
 
-    def __init__(self, **kwargs):
-        super(Arch_armb, self).__init__(**kwargs)
+    def __init__(self, loc_db, **kwargs):
+        super(Arch_armb, self).__init__(loc_db, **kwargs)
 
         # Init stack
         self.jitter.stack_size = self.STACK_SIZE
@@ -445,8 +447,8 @@ class Arch_armtl(Arch):
     STACK_SIZE = 0x100000
     STACK_BASE = 0x100000
 
-    def __init__(self, **kwargs):
-        super(Arch_armtl, self).__init__(**kwargs)
+    def __init__(self, loc_db, **kwargs):
+        super(Arch_armtl, self).__init__(loc_db, **kwargs)
 
         # Init stack
         self.jitter.stack_size = self.STACK_SIZE
@@ -459,8 +461,8 @@ class Arch_mips32b(Arch):
     STACK_SIZE = 0x100000
     STACK_BASE = 0x100000
 
-    def __init__(self, **kwargs):
-        super(Arch_mips32b, self).__init__(**kwargs)
+    def __init__(self, loc_db, **kwargs):
+        super(Arch_mips32b, self).__init__(loc_db, **kwargs)
 
         # Init stack
         self.jitter.stack_size = self.STACK_SIZE
@@ -473,8 +475,8 @@ class Arch_aarch64l(Arch):
     STACK_SIZE = 0x100000
     STACK_BASE = 0x100000
 
-    def __init__(self, **kwargs):
-        super(Arch_aarch64l, self).__init__(**kwargs)
+    def __init__(self, loc_db, **kwargs):
+        super(Arch_aarch64l, self).__init__(loc_db, **kwargs)
 
         # Init stack
         self.jitter.stack_size = self.STACK_SIZE
@@ -487,8 +489,8 @@ class Arch_aarch64b(Arch):
     STACK_SIZE = 0x100000
     STACK_BASE = 0x100000
 
-    def __init__(self, **kwargs):
-        super(Arch_aarch64b, self).__init__(**kwargs)
+    def __init__(self, loc_db, **kwargs):
+        super(Arch_aarch64b, self).__init__(loc_db, **kwargs)
 
         # Init stack
         self.jitter.stack_size = self.STACK_SIZE
@@ -506,8 +508,8 @@ class Arch_ppc32b(Arch_ppc32):
 
 class Sandbox_Win_x86_32(Sandbox, Arch_x86_32, OS_Win):
 
-    def __init__(self, *args, **kwargs):
-        Sandbox.__init__(self, *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Sandbox.__init__(self, loc_db, *args, **kwargs)
 
         # Pre-stack some arguments
         self.jitter.push_uint32_t(2)
@@ -538,8 +540,8 @@ class Sandbox_Win_x86_32(Sandbox, Arch_x86_32, OS_Win):
 
 class Sandbox_Win_x86_64(Sandbox, Arch_x86_64, OS_Win):
 
-    def __init__(self, *args, **kwargs):
-        Sandbox.__init__(self, *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Sandbox.__init__(self, loc_db, *args, **kwargs)
 
         # reserve stack for local reg
         for _ in range(0x4):
@@ -574,8 +576,8 @@ class Sandbox_Win_x86_64(Sandbox, Arch_x86_64, OS_Win):
 
 class Sandbox_Linux_x86_32(Sandbox, Arch_x86_32, OS_Linux):
 
-    def __init__(self, *args, **kwargs):
-        Sandbox.__init__(self, *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Sandbox.__init__(self, loc_db, *args, **kwargs)
 
         # Pre-stack some arguments
         if self.options.mimic_env:
@@ -634,8 +636,8 @@ class Sandbox_Linux_x86_32(Sandbox, Arch_x86_32, OS_Linux):
 
 class Sandbox_Linux_x86_64(Sandbox, Arch_x86_64, OS_Linux):
 
-    def __init__(self, *args, **kwargs):
-        Sandbox.__init__(self, *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Sandbox.__init__(self, loc_db, *args, **kwargs)
 
         # Pre-stack some arguments
         if self.options.mimic_env:
@@ -693,8 +695,8 @@ class Sandbox_Linux_x86_64(Sandbox, Arch_x86_64, OS_Linux):
 
 class Sandbox_Linux_arml(Sandbox, Arch_arml, OS_Linux):
 
-    def __init__(self, *args, **kwargs):
-        Sandbox.__init__(self, *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Sandbox.__init__(self, loc_db, *args, **kwargs)
 
         # Pre-stack some arguments
         if self.options.mimic_env:
@@ -751,8 +753,8 @@ class Sandbox_Linux_arml(Sandbox, Arch_arml, OS_Linux):
 
 class Sandbox_Linux_armtl(Sandbox, Arch_armtl, OS_Linux):
 
-    def __init__(self, *args, **kwargs):
-        Sandbox.__init__(self, *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Sandbox.__init__(self, loc_db, *args, **kwargs)
 
         # Pre-stack some arguments
         if self.options.mimic_env:
@@ -810,8 +812,8 @@ class Sandbox_Linux_armtl(Sandbox, Arch_armtl, OS_Linux):
 
 class Sandbox_Linux_mips32b(Sandbox, Arch_mips32b, OS_Linux):
 
-    def __init__(self, *args, **kwargs):
-        Sandbox.__init__(self, *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Sandbox.__init__(self, loc_db, *args, **kwargs)
 
         # Pre-stack some arguments
         if self.options.mimic_env:
@@ -865,8 +867,8 @@ class Sandbox_Linux_mips32b(Sandbox, Arch_mips32b, OS_Linux):
 
 class Sandbox_Linux_armb_str(Sandbox, Arch_armb, OS_Linux_str):
 
-    def __init__(self, *args, **kwargs):
-        Sandbox.__init__(self, *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Sandbox.__init__(self, loc_db, *args, **kwargs)
 
         self.jitter.cpu.LR = self.CALL_FINISH_ADDR
 
@@ -881,8 +883,8 @@ class Sandbox_Linux_armb_str(Sandbox, Arch_armb, OS_Linux_str):
 
 class Sandbox_Linux_arml_str(Sandbox, Arch_arml, OS_Linux_str):
 
-    def __init__(self, *args, **kwargs):
-        Sandbox.__init__(self, *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Sandbox.__init__(self, loc_db, *args, **kwargs)
 
         self.jitter.cpu.LR = self.CALL_FINISH_ADDR
 
@@ -897,8 +899,8 @@ class Sandbox_Linux_arml_str(Sandbox, Arch_arml, OS_Linux_str):
 
 class Sandbox_Linux_aarch64l(Sandbox, Arch_aarch64l, OS_Linux):
 
-    def __init__(self, *args, **kwargs):
-        Sandbox.__init__(self, *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Sandbox.__init__(self, loc_db, *args, **kwargs)
 
         # Pre-stack some arguments
         if self.options.mimic_env:
@@ -957,8 +959,8 @@ class Sandbox_Linux_ppc32b(Sandbox, Arch_ppc32b, OS_Linux):
     # The glue between the kernel and the ELF ABI on Linux/PowerPC is
     # implemented in glibc/sysdeps/powerpc/powerpc32/dl-start.S, so we
     # have to play the role of ld.so here.
-    def __init__(self, *args, **kwargs):
-        super(Sandbox_Linux_ppc32b, self).__init__(*args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        super(Sandbox_Linux_ppc32b, self).__init__(loc_db, *args, **kwargs)
 
         # Init stack
         self.jitter.stack_size = self.STACK_SIZE

--- a/miasm/arch/aarch64/ira.py
+++ b/miasm/arch/aarch64/ira.py
@@ -6,21 +6,21 @@ from miasm.arch.aarch64.sem import ir_aarch64l, ir_aarch64b
 
 class ir_a_aarch64l_base(ir_aarch64l, ira):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_aarch64l.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.X0
 
 
 class ir_a_aarch64b_base(ir_aarch64b, ira):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_aarch64b.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.X0
 
 
 class ir_a_aarch64l(ir_a_aarch64l_base):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_a_aarch64l_base.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.X0
 
@@ -45,6 +45,6 @@ class ir_a_aarch64l(ir_a_aarch64l_base):
 
 class ir_a_aarch64b(ir_a_aarch64b_base, ir_a_aarch64l):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_a_aarch64b_base.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.X0

--- a/miasm/arch/aarch64/jit.py
+++ b/miasm/arch/aarch64/jit.py
@@ -2,7 +2,6 @@ from builtins import range
 import logging
 
 from miasm.jitter.jitload import Jitter, named_arguments
-from miasm.core.locationdb import LocationDB
 from miasm.core.utils import pck64, upck64
 from miasm.arch.aarch64.sem import ir_aarch64b, ir_aarch64l
 
@@ -15,8 +14,8 @@ log.setLevel(logging.CRITICAL)
 class jitter_aarch64l(Jitter):
     max_reg_arg = 8
 
-    def __init__(self, *args, **kwargs):
-        Jitter.__init__(self, ir_aarch64l(LocationDB()), *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Jitter.__init__(self, ir_aarch64l(loc_db), *args, **kwargs)
         self.vm.set_little_endian()
 
     def push_uint64_t(self, value):
@@ -75,6 +74,6 @@ class jitter_aarch64l(Jitter):
 
 class jitter_aarch64b(jitter_aarch64l):
 
-    def __init__(self, *args, **kwargs):
-        Jitter.__init__(self, ir_aarch64b(LocationDB()), *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Jitter.__init__(self, ir_aarch64b(loc_db), *args, **kwargs)
         self.vm.set_big_endian()

--- a/miasm/arch/aarch64/sem.py
+++ b/miasm/arch/aarch64/sem.py
@@ -2228,7 +2228,7 @@ class aarch64info(object):
 
 class ir_aarch64l(IntermediateRepresentation):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         IntermediateRepresentation.__init__(self, mn_aarch64, "l", loc_db)
         self.pc = PC
         self.sp = SP
@@ -2314,7 +2314,7 @@ class ir_aarch64l(IntermediateRepresentation):
 
 class ir_aarch64b(ir_aarch64l):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         IntermediateRepresentation.__init__(self, mn_aarch64, "b", loc_db)
         self.pc = PC
         self.sp = SP

--- a/miasm/arch/aarch64/sem.py
+++ b/miasm/arch/aarch64/sem.py
@@ -2065,13 +2065,13 @@ def casp(ir, instr, arg1, arg2, arg3):
     e_store = []
     e_store.append(ExprAssign(data, new_value))
     e_store.append(ExprAssign(ir.IRDst, loc_do))
-    blk_store = IRBlock(loc_store.loc_key, [AssignBlock(e_store, instr)])
+    blk_store = IRBlock(ir.loc_db, loc_store.loc_key, [AssignBlock(e_store, instr)])
 
     e_do = []
     e_do.append(ExprAssign(regs[index1], data[:data.size // 2]))
     e_do.append(ExprAssign(regs[index1 + 1], data[data.size // 2:]))
     e_do.append(ExprAssign(ir.IRDst, loc_next))
-    blk_do = IRBlock(loc_do.loc_key, [AssignBlock(e_do, instr)])
+    blk_do = IRBlock(ir.loc_db, loc_do.loc_key, [AssignBlock(e_do, instr)])
 
     return e, [blk_store, blk_do]
 
@@ -2274,7 +2274,7 @@ class ir_aarch64l(IntermediateRepresentation):
                 src = self.expr_fix_regs_for_mode(src)
                 new_assignblk[dst] = src
             irs.append(AssignBlock(new_assignblk, assignblk.instr))
-        return IRBlock(irblock.loc_key, irs)
+        return IRBlock(self.loc_db, irblock.loc_key, irs)
 
     def mod_pc(self, instr, instr_ir, extra_ir):
         "Replace PC by the instruction's offset"
@@ -2307,7 +2307,7 @@ class ir_aarch64l(IntermediateRepresentation):
                     if dst not in regs_to_fix
                 }
                 irs.append(AssignBlock(new_dsts, assignblk.instr))
-            new_irblocks.append(IRBlock(irblock.loc_key, irs))
+            new_irblocks.append(IRBlock(self.loc_db, irblock.loc_key, irs))
 
         return instr_ir, new_irblocks
 

--- a/miasm/arch/arm/ira.py
+++ b/miasm/arch/arm/ira.py
@@ -7,19 +7,19 @@ from miasm.expression.expression import ExprAssign, ExprOp, ExprLoc, ExprCond
 from miasm.ir.ir import AssignBlock
 
 class ir_a_arml_base(ir_arml, ira):
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_arml.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.R0
 
 class ir_a_armb_base(ir_armb, ira):
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_armb.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.R0
 
 
 class ir_a_arml(ir_a_arml_base):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_a_arml_base.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.R0
 
@@ -90,17 +90,17 @@ class ir_a_arml(ir_a_arml_base):
 
 class ir_a_armb(ir_a_armb_base, ir_a_arml):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_a_armb_base.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.R0
 
 
 class ir_a_armtl(ir_armtl, ir_a_arml):
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_armtl.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.R0
 
 class ir_a_armtb(ir_a_armtl, ir_armtb, ir_a_armb):
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_armtb.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.R0

--- a/miasm/arch/arm/jit.py
+++ b/miasm/arch/arm/jit.py
@@ -2,7 +2,6 @@ from builtins import range
 import logging
 
 from miasm.jitter.jitload import Jitter, named_arguments
-from miasm.core.locationdb import LocationDB
 from miasm.core.utils import pck32, upck32
 from miasm.arch.arm.sem import ir_armb, ir_arml, ir_armtl, ir_armtb, cond_dct_inv, tab_cond
 from miasm.jitter.codegen import CGen
@@ -65,9 +64,8 @@ class arm_CGen(CGen):
 class jitter_arml(Jitter):
     C_Gen = arm_CGen
 
-    def __init__(self, *args, **kwargs):
-        sp = LocationDB()
-        Jitter.__init__(self, ir_arml(sp), *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Jitter.__init__(self, ir_arml(loc_db), *args, **kwargs)
         self.vm.set_little_endian()
 
     def push_uint32_t(self, value):
@@ -133,16 +131,14 @@ class jitter_arml(Jitter):
 class jitter_armb(jitter_arml):
     C_Gen = arm_CGen
 
-    def __init__(self, *args, **kwargs):
-        sp = LocationDB()
-        Jitter.__init__(self, ir_armb(sp), *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Jitter.__init__(self, ir_armb(loc_db), *args, **kwargs)
         self.vm.set_big_endian()
 
 
 class jitter_armtl(jitter_arml):
     C_Gen = arm_CGen
 
-    def __init__(self, *args, **kwargs):
-        sp = LocationDB()
-        Jitter.__init__(self, ir_armtl(sp), *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Jitter.__init__(self, ir_armtl(loc_db), *args, **kwargs)
         self.vm.set_little_endian()

--- a/miasm/arch/arm/sem.py
+++ b/miasm/arch/arm/sem.py
@@ -804,7 +804,7 @@ def sdiv(ir, instr, a, b, c=None):
     do_except = []
     do_except.append(ExprAssign(exception_flags, ExprInt(EXCEPT_DIV_BY_ZERO, exception_flags.size)))
     do_except.append(ExprAssign(ir.IRDst, loc_next))
-    blk_except = IRBlock(loc_except.loc_key, [AssignBlock(do_except, instr)])
+    blk_except = IRBlock(ir.loc_db, loc_except.loc_key, [AssignBlock(do_except, instr)])
 
 
 
@@ -816,7 +816,7 @@ def sdiv(ir, instr, a, b, c=None):
         do_div.append(ExprAssign(ir.IRDst, r))
 
     do_div.append(ExprAssign(ir.IRDst, loc_next))
-    blk_div = IRBlock(loc_div.loc_key, [AssignBlock(do_div, instr)])
+    blk_div = IRBlock(ir.loc_db, loc_div.loc_key, [AssignBlock(do_div, instr)])
 
     return e, [blk_div, blk_except]
 
@@ -837,7 +837,7 @@ def udiv(ir, instr, a, b, c=None):
     do_except = []
     do_except.append(ExprAssign(exception_flags, ExprInt(EXCEPT_DIV_BY_ZERO, exception_flags.size)))
     do_except.append(ExprAssign(ir.IRDst, loc_next))
-    blk_except = IRBlock(loc_except.loc_key, [AssignBlock(do_except, instr)])
+    blk_except = IRBlock(ir.loc_db, loc_except.loc_key, [AssignBlock(do_except, instr)])
 
 
     r = ExprOp("udiv", b, c)
@@ -848,7 +848,7 @@ def udiv(ir, instr, a, b, c=None):
         do_div.append(ExprAssign(ir.IRDst, r))
 
     do_div.append(ExprAssign(ir.IRDst, loc_next))
-    blk_div = IRBlock(loc_div.loc_key, [AssignBlock(do_div, instr)])
+    blk_div = IRBlock(ir.loc_db, loc_div.loc_key, [AssignBlock(do_div, instr)])
 
     return e, [blk_div, blk_except]
 
@@ -1723,7 +1723,7 @@ def add_condition_expr(ir, instr, cond, instr_ir, extra_ir):
             break
     if not has_irdst:
         instr_ir.append(ExprAssign(ir.IRDst, loc_next_expr))
-    e_do = IRBlock(loc_do, [AssignBlock(instr_ir, instr)])
+    e_do = IRBlock(ir.loc_db, loc_do, [AssignBlock(instr_ir, instr)])
     e = [ExprAssign(ir.IRDst, dst_cond)]
     return e, [e_do] + extra_ir
 
@@ -2004,7 +2004,7 @@ class ir_arml(IntermediateRepresentation):
         dst = ExprAssign(self.IRDst, ExprLoc(loc_next, 32))
         dst_blk = AssignBlock([dst], instr)
         assignments.append(dst_blk)
-        irblock = IRBlock(loc, assignments)
+        irblock = IRBlock(self.loc_db, loc, assignments)
         ir_blocks_all.append([irblock])
 
         loc = loc_next
@@ -2025,7 +2025,7 @@ class ir_arml(IntermediateRepresentation):
             dst = ExprAssign(self.IRDst, ExprCond(local_cond, ExprLoc(loc_do, 32), ExprLoc(loc_next, 32)))
             dst_blk = AssignBlock([dst], instr)
             assignments.append(dst_blk)
-            irblock = IRBlock(loc, assignments)
+            irblock = IRBlock(self.loc_db, loc, assignments)
 
             irblocks.append(irblock)
 
@@ -2070,7 +2070,7 @@ class ir_arml(IntermediateRepresentation):
                             assignment.instr
                         )
                         out.append(assignment)
-                    new_irblock = IRBlock(irblock.loc_key, out)
+                    new_irblock = IRBlock(self.loc_db, irblock.loc_key, out)
                     new_irblocks.append(new_irblock)
                 it_instr_irblocks = new_irblocks
 
@@ -2078,7 +2078,7 @@ class ir_arml(IntermediateRepresentation):
             dst = ExprAssign(self.IRDst, ExprLoc(loc_next, 32))
             dst_blk = AssignBlock([dst], instr)
             assignments.append(dst_blk)
-            irblock = IRBlock(loc, assignments)
+            irblock = IRBlock(self.loc_db, loc, assignments)
             irblocks.append(irblock)
             loc = loc_next
             assignments = []
@@ -2116,11 +2116,11 @@ class ir_arml(IntermediateRepresentation):
                 ir_blocks_all, gen_pc_updt
             )
             if split:
-                ir_blocks_all.append(IRBlock(label, assignments))
+                ir_blocks_all.append(IRBlock(self.loc_db, label, assignments))
                 label = None
                 assignments = []
         if label is not None:
-            ir_blocks_all.append(IRBlock(label, assignments))
+            ir_blocks_all.append(IRBlock(self.loc_db, label, assignments))
 
         new_ir_blocks_all = self.post_add_asmblock_to_ircfg(block, ircfg, ir_blocks_all)
         for irblock in new_ir_blocks_all:

--- a/miasm/arch/arm/sem.py
+++ b/miasm/arch/arm/sem.py
@@ -1933,7 +1933,7 @@ class arminfo(object):
 
 
 class ir_arml(IntermediateRepresentation):
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         IntermediateRepresentation.__init__(self, mn_arm, "l", loc_db)
         self.pc = PC
         self.sp = SP
@@ -2130,7 +2130,7 @@ class ir_arml(IntermediateRepresentation):
 
 
 class ir_armb(ir_arml):
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         IntermediateRepresentation.__init__(self, mn_arm, "b", loc_db)
         self.pc = PC
         self.sp = SP
@@ -2139,7 +2139,7 @@ class ir_armb(ir_arml):
 
 
 class ir_armtl(ir_arml):
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         IntermediateRepresentation.__init__(self, mn_armt, "l", loc_db)
         self.pc = PC
         self.sp = SP
@@ -2165,7 +2165,7 @@ class ir_armtl(ir_arml):
 
 
 class ir_armtb(ir_armtl):
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         IntermediateRepresentation.__init__(self, mn_armt, "b", loc_db)
         self.pc = PC
         self.sp = SP

--- a/miasm/arch/mep/ira.py
+++ b/miasm/arch/mep/ira.py
@@ -12,7 +12,7 @@ class ir_a_mepb(ir_mepb, ira):
         - it is mandatory for symbolic execution.
     """
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_mepb.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.R0
 
@@ -41,5 +41,5 @@ class ir_a_mepb(ir_mepb, ira):
 class ir_a_mepl(ir_mepl, ir_a_mepb):
     """MeP high level IR manipulations - Little Endian"""
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_a_mepb.__init__(self, loc_db)

--- a/miasm/arch/mep/jit.py
+++ b/miasm/arch/mep/jit.py
@@ -3,7 +3,6 @@
 # Note: inspiration from msp430/jit.py
 
 from miasm.jitter.jitload import Jitter
-from miasm.core.locationdb import LocationDB
 from miasm.core.utils import *
 from miasm.jitter.codegen import CGen
 from miasm.ir.translators.C import TranslatorC
@@ -77,9 +76,8 @@ class jitter_mepl(Jitter):
 
     C_Gen = mep_CGen
 
-    def __init__(self, *args, **kwargs):
-        sp = LocationDB()
-        Jitter.__init__(self, ir_mepl(sp), *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Jitter.__init__(self, ir_mepl(loc_db), *args, **kwargs)
         self.vm.set_little_endian()
         self.ir_arch.jit_pc = self.ir_arch.arch.regs.PC
 
@@ -108,8 +106,7 @@ class jitter_mepl(Jitter):
 
 class jitter_mepb(jitter_mepl):
 
-    def __init__(self, *args, **kwargs):
-        sp = LocationDB()
-        Jitter.__init__(self, ir_mepb(sp), *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Jitter.__init__(self, ir_mepb(loc_db), *args, **kwargs)
         self.vm.set_big_endian()
         self.ir_arch.jit_pc = self.ir_arch.arch.regs.PC

--- a/miasm/arch/mep/sem.py
+++ b/miasm/arch/mep/sem.py
@@ -1146,7 +1146,7 @@ class ir_mepb(IntermediateRepresentation):
 
     addrsize = 32
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         IntermediateRepresentation.__init__(self, mn_mep, "b", loc_db)
         self.pc = mn_mep.getpc()
         self.sp = mn_mep.getsp()
@@ -1172,7 +1172,7 @@ class ir_mepb(IntermediateRepresentation):
 class ir_mepl(ir_mepb):
     """Toshiba MeP miasm IR - Little Endian"""
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         IntermediateRepresentation.__init__(self, mn_mep, "l", loc_db)
         self.pc = mn_mep.getpc()
         self.sp = mn_mep.getsp()

--- a/miasm/arch/mips32/ira.py
+++ b/miasm/arch/mips32/ira.py
@@ -67,11 +67,11 @@ class ir_a_mips32l(ir_mips32l, ira):
                 ir_blocks_all, gen_pc_updt
             )
             if split:
-                ir_blocks_all.append(IRBlock(loc_key, assignments))
+                ir_blocks_all.append(IRBlock(self.loc_db, loc_key, assignments))
                 loc_key = None
                 assignments = []
         if loc_key is not None:
-            ir_blocks_all.append(IRBlock(loc_key, assignments))
+            ir_blocks_all.append(IRBlock(self.loc_db, loc_key, assignments))
 
         new_ir_blocks_all = self.post_add_asmblock_to_ircfg(block, ircfg, ir_blocks_all)
         for irblock in new_ir_blocks_all:

--- a/miasm/arch/mips32/ira.py
+++ b/miasm/arch/mips32/ira.py
@@ -6,7 +6,7 @@ from miasm.ir.analysis import ira
 from miasm.arch.mips32.sem import ir_mips32l, ir_mips32b
 
 class ir_a_mips32l(ir_mips32l, ira):
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_mips32l.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.V0
 
@@ -99,6 +99,6 @@ class ir_a_mips32l(ir_mips32l, ira):
 
 
 class ir_a_mips32b(ir_mips32b, ir_a_mips32l):
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_mips32b.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.V0

--- a/miasm/arch/mips32/jit.py
+++ b/miasm/arch/mips32/jit.py
@@ -85,9 +85,8 @@ class jitter_mips32l(Jitter):
 
     C_Gen = mipsCGen
 
-    def __init__(self, *args, **kwargs):
-        sp = LocationDB()
-        Jitter.__init__(self, ir_mips32l(sp), *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Jitter.__init__(self, ir_mips32l(loc_db), *args, **kwargs)
         self.vm.set_little_endian()
 
     def push_uint32_t(self, value):
@@ -145,7 +144,6 @@ class jitter_mips32l(Jitter):
 
 class jitter_mips32b(jitter_mips32l):
 
-    def __init__(self, *args, **kwargs):
-        sp = LocationDB()
-        Jitter.__init__(self, ir_mips32b(sp), *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Jitter.__init__(self, ir_mips32b(loc_db), *args, **kwargs)
         self.vm.set_big_endian()

--- a/miasm/arch/mips32/jit.py
+++ b/miasm/arch/mips32/jit.py
@@ -61,7 +61,7 @@ class mipsCGen(CGen):
                     dst_loc_key = self.ir_arch.get_next_instr(assignblock.instr)
                     assignments[self.ir_arch.IRDst] = m2_expr.ExprLoc(dst_loc_key, 32)
                     irs.append(AssignBlock(assignments, assignblock.instr))
-                irblocks[blk_idx] = IRBlock(irblock.loc_key, irs)
+                irblocks[blk_idx] = IRBlock(irblock.loc_db, irblock.loc_key, irs)
 
         return irblocks_list
 

--- a/miasm/arch/mips32/sem.py
+++ b/miasm/arch/mips32/sem.py
@@ -538,7 +538,7 @@ def teq(ir, instr, arg1, arg2):
     do_except.append(m2_expr.ExprAssign(exception_flags, m2_expr.ExprInt(
         EXCEPT_DIV_BY_ZERO, exception_flags.size)))
     do_except.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
-    blk_except = IRBlock(loc_except, [AssignBlock(do_except, instr)])
+    blk_except = IRBlock(ir.loc_db, loc_except, [AssignBlock(do_except, instr)])
 
     cond = arg1 - arg2
 
@@ -560,7 +560,7 @@ def tne(ir, instr, arg1, arg2):
     do_except.append(m2_expr.ExprAssign(exception_flags, m2_expr.ExprInt(
         EXCEPT_DIV_BY_ZERO, exception_flags.size)))
     do_except.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
-    blk_except = IRBlock(loc_except, [AssignBlock(do_except, instr)])
+    blk_except = IRBlock(ir.loc_db, loc_except, [AssignBlock(do_except, instr)])
 
     cond = arg1 ^ arg2
 

--- a/miasm/arch/mips32/sem.py
+++ b/miasm/arch/mips32/sem.py
@@ -608,7 +608,7 @@ def get_mnemo_expr(ir, instr, *args):
 
 class ir_mips32l(IntermediateRepresentation):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         IntermediateRepresentation.__init__(self, mn_mips32, 'l', loc_db)
         self.pc = mn_mips32.getpc()
         self.sp = mn_mips32.getsp()
@@ -641,7 +641,7 @@ class ir_mips32l(IntermediateRepresentation):
         return self.loc_db.get_or_create_offset_location(instr.offset + 16)
 
 class ir_mips32b(ir_mips32l):
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         self.addrsize = 32
         IntermediateRepresentation.__init__(self, mn_mips32, 'b', loc_db)
         self.pc = mn_mips32.getpc()

--- a/miasm/arch/msp430/ira.py
+++ b/miasm/arch/msp430/ira.py
@@ -7,7 +7,7 @@ from miasm.expression.expression import *
 
 class ir_a_msp430_base(ir_msp430, ira):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_msp430.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.R15
 
@@ -23,7 +23,7 @@ class ir_a_msp430_base(ir_msp430, ira):
 
 class ir_a_msp430(ir_a_msp430_base):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_a_msp430_base.__init__(self, loc_db)
 
     def get_out_regs(self, _):

--- a/miasm/arch/msp430/jit.py
+++ b/miasm/arch/msp430/jit.py
@@ -13,9 +13,8 @@ log.setLevel(logging.CRITICAL)
 
 class jitter_msp430(Jitter):
 
-    def __init__(self, *args, **kwargs):
-        sp = LocationDB()
-        Jitter.__init__(self, ir_msp430(sp), *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Jitter.__init__(self, ir_msp430(loc_db), *args, **kwargs)
         self.vm.set_little_endian()
 
     def push_uint16_t(self, value):

--- a/miasm/arch/msp430/sem.py
+++ b/miasm/arch/msp430/sem.py
@@ -475,7 +475,7 @@ def ComposeExprAssign(dst, src):
 
 class ir_msp430(IntermediateRepresentation):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         IntermediateRepresentation.__init__(self, mn_msp430, None, loc_db)
         self.pc = PC
         self.sp = SP

--- a/miasm/arch/ppc/ira.py
+++ b/miasm/arch/ppc/ira.py
@@ -6,8 +6,8 @@ from miasm.arch.ppc.sem import ir_ppc32b
 
 class ir_a_ppc32b(ir_ppc32b, ira):
 
-    def __init__(self, *args):
-        super(ir_a_ppc32b, self).__init__(*args)
+    def __init__(self, loc_db, *args):
+        super(ir_a_ppc32b, self).__init__(loc_db, *args)
         self.ret_reg = self.arch.regs.R3
 
     # for test XXX TODO

--- a/miasm/arch/ppc/jit.py
+++ b/miasm/arch/ppc/jit.py
@@ -1,6 +1,5 @@
 from builtins import range
 from miasm.jitter.jitload import Jitter, named_arguments
-from miasm.core.locationdb import LocationDB
 from miasm.arch.ppc.sem import ir_ppc32b
 import struct
 
@@ -15,8 +14,8 @@ log.setLevel(logging.CRITICAL)
 class jitter_ppc32b(Jitter):
     max_reg_arg = 8
 
-    def __init__(self, *args, **kwargs):
-        super(jitter_ppc32b, self).__init__(ir_ppc32b(LocationDB()),
+    def __init__(self, loc_db, *args, **kwargs):
+        super(jitter_ppc32b, self).__init__(ir_ppc32b(loc_db),
                                             *args, **kwargs)
         self.vm.set_big_endian()
 

--- a/miasm/arch/ppc/sem.py
+++ b/miasm/arch/ppc/sem.py
@@ -899,7 +899,7 @@ sem_dir = {
 
 class ir_ppc32b(IntermediateRepresentation):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         super(ir_ppc32b, self).__init__(mn_ppc, 'b', loc_db)
         self.pc = mn_ppc.getpc()
         self.sp = mn_ppc.getsp()

--- a/miasm/arch/ppc/sem.py
+++ b/miasm/arch/ppc/sem.py
@@ -675,8 +675,8 @@ def mn_do_store(ir, instr, arg1, arg2, arg3=None):
         ret.append(ExprAssign(ir.IRDst, loc_next))
         dont = flags + [ ExprAssign(CR0_EQ, ExprInt(0,1)),
                          ExprAssign(ir.IRDst, loc_next) ]
-        additional_ir = [ IRBlock(loc_do.loc_key, [ AssignBlock(ret) ]),
-                          IRBlock(loc_dont.loc_key, [ AssignBlock(dont) ]) ]
+        additional_ir = [ IRBlock(ir.loc_db, loc_do.loc_key, [ AssignBlock(ret) ]),
+                          IRBlock(ir.loc_db, loc_dont.loc_key, [ AssignBlock(dont) ]) ]
         ret = [ ExprAssign(reserve, ExprInt(0, 1)),
                 ExprAssign(ir.IRDst, ExprCond(reserve, loc_do, loc_dont)) ]
 

--- a/miasm/arch/x86/ira.py
+++ b/miasm/arch/x86/ira.py
@@ -8,7 +8,7 @@ from miasm.arch.x86.sem import ir_x86_16, ir_x86_32, ir_x86_64
 
 class ir_a_x86_16(ir_x86_16, ira):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_x86_16.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.AX
 
@@ -17,7 +17,7 @@ class ir_a_x86_16(ir_x86_16, ira):
 
 class ir_a_x86_32(ir_x86_32, ir_a_x86_16):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_x86_32.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.EAX
 
@@ -39,7 +39,7 @@ class ir_a_x86_32(ir_x86_32, ir_a_x86_16):
 
 class ir_a_x86_64(ir_x86_64, ir_a_x86_16):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         ir_x86_64.__init__(self, loc_db)
         self.ret_reg = self.arch.regs.RAX
 

--- a/miasm/arch/x86/jit.py
+++ b/miasm/arch/x86/jit.py
@@ -4,7 +4,6 @@ import logging
 from miasm.jitter.jitload import Jitter, named_arguments
 from miasm.arch.x86.sem import ir_x86_16, ir_x86_32, ir_x86_64
 from miasm.jitter.codegen import CGen
-from miasm.core.locationdb import LocationDB
 from miasm.ir.translators.C import TranslatorC
 
 log = logging.getLogger('jit_x86')
@@ -42,9 +41,8 @@ class jitter_x86_16(Jitter):
 
     C_Gen = x86_32_CGen
 
-    def __init__(self, *args, **kwargs):
-        sp = LocationDB()
-        Jitter.__init__(self, ir_x86_16(sp), *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Jitter.__init__(self, ir_x86_16(loc_db), *args, **kwargs)
         self.vm.set_little_endian()
         self.ir_arch.do_stk_segm = False
         self.orig_irbloc_fix_regs_for_mode = self.ir_arch.irbloc_fix_regs_for_mode
@@ -74,9 +72,8 @@ class jitter_x86_32(Jitter):
 
     C_Gen = x86_32_CGen
 
-    def __init__(self, *args, **kwargs):
-        sp = LocationDB()
-        Jitter.__init__(self, ir_x86_32(sp), *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Jitter.__init__(self, ir_x86_32(loc_db), *args, **kwargs)
         self.vm.set_little_endian()
         self.ir_arch.do_stk_segm = False
 
@@ -201,9 +198,8 @@ class jitter_x86_64(Jitter):
     args_regs_systemv = ['RDI', 'RSI', 'RDX', 'RCX', 'R8', 'R9']
     args_regs_stdcall = ['RCX', 'RDX', 'R8', 'R9']
 
-    def __init__(self, *args, **kwargs):
-        sp = LocationDB()
-        Jitter.__init__(self, ir_x86_64(sp), *args, **kwargs)
+    def __init__(self, loc_db, *args, **kwargs):
+        Jitter.__init__(self, ir_x86_64(loc_db), *args, **kwargs)
         self.vm.set_little_endian()
         self.ir_arch.do_stk_segm = False
 

--- a/miasm/arch/x86/sem.py
+++ b/miasm/arch/x86/sem.py
@@ -5733,7 +5733,7 @@ mnemo_func = {'mov': mov,
 
 class ir_x86_16(IntermediateRepresentation):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         IntermediateRepresentation.__init__(self, mn_x86, 16, loc_db)
         self.do_stk_segm = False
         self.do_ds_segm = False
@@ -5876,7 +5876,7 @@ class ir_x86_16(IntermediateRepresentation):
 
 class ir_x86_32(ir_x86_16):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         IntermediateRepresentation.__init__(self, mn_x86, 32, loc_db)
         self.do_stk_segm = False
         self.do_ds_segm = False
@@ -5890,7 +5890,7 @@ class ir_x86_32(ir_x86_16):
 
 class ir_x86_64(ir_x86_16):
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         IntermediateRepresentation.__init__(self, mn_x86, 64, loc_db)
         self.do_stk_segm = False
         self.do_ds_segm = False

--- a/miasm/arch/x86/sem.py
+++ b/miasm/arch/x86/sem.py
@@ -386,7 +386,7 @@ def gen_fcmov(ir, instr, cond, arg1, arg2, mov_if):
     e_do, extra_irs = [m2_expr.ExprAssign(arg1, arg2)], []
     e_do.append(m2_expr.ExprAssign(ir.IRDst, loc_skip_expr))
     e.append(m2_expr.ExprAssign(ir.IRDst, m2_expr.ExprCond(cond, dstA, dstB)))
-    return e, [IRBlock(loc_do, [AssignBlock(e_do, instr)])]
+    return e, [IRBlock(ir.loc_db, loc_do, [AssignBlock(e_do, instr)])]
 
 
 def gen_cmov(ir, instr, cond, dst, src, mov_if):
@@ -408,7 +408,7 @@ def gen_cmov(ir, instr, cond, dst, src, mov_if):
     e_do.append(m2_expr.ExprAssign(ir.IRDst, loc_skip_expr))
     e.append(m2_expr.ExprAssign(ir.IRDst, m2_expr.ExprCond(cond, dstA, dstB)))
     e += set_float_cs_eip(instr)
-    return e, [IRBlock(loc_do, [AssignBlock(e_do, instr)])]
+    return e, [IRBlock(ir.loc_db, loc_do, [AssignBlock(e_do, instr)])]
 
 
 def mov(_, instr, dst, src):
@@ -655,7 +655,7 @@ def _rotate_tpl(ir, instr, dst, src, op, left=False):
     e_do.append(m2_expr.ExprAssign(ir.IRDst, loc_skip_expr))
     e.append(m2_expr.ExprAssign(
         ir.IRDst, m2_expr.ExprCond(shifter, loc_do_expr, loc_skip_expr)))
-    return (e, [IRBlock(loc_do, [AssignBlock(e_do, instr)])])
+    return (e, [IRBlock(ir.loc_db, loc_do, [AssignBlock(e_do, instr)])])
 
 
 def l_rol(ir, instr, dst, src):
@@ -703,7 +703,7 @@ def rotate_with_carry_tpl(ir, instr, op, dst, src):
     e_do.append(m2_expr.ExprAssign(ir.IRDst, loc_skip_expr))
     e.append(m2_expr.ExprAssign(
         ir.IRDst, m2_expr.ExprCond(shifter, loc_do_expr, loc_skip_expr)))
-    return (e, [IRBlock(loc_do, [AssignBlock(e_do, instr)])])
+    return (e, [IRBlock(ir.loc_db, loc_do, [AssignBlock(e_do, instr)])])
 
 def rcl(ir, instr, dst, src):
     return rotate_with_carry_tpl(ir, instr, '<<<', dst, src)
@@ -789,7 +789,7 @@ def _shift_tpl(op, ir, instr, a, b, c=None, op_inv=None, left=False,
     e_do.append(m2_expr.ExprAssign(ir.IRDst, loc_skip_expr))
     e.append(m2_expr.ExprAssign(ir.IRDst, m2_expr.ExprCond(shifter, loc_do_expr,
                                                         loc_skip_expr)))
-    return e, [IRBlock(loc_do, [AssignBlock(e_do, instr)])]
+    return e, [IRBlock(ir.loc_db, loc_do, [AssignBlock(e_do, instr)])]
 
 
 def sar(ir, instr, dst, src):
@@ -1206,13 +1206,13 @@ def cmps(ir, instr, size):
     e0.append(m2_expr.ExprAssign(src1, src1 + offset))
     e0.append(m2_expr.ExprAssign(src2, src2 + offset))
     e0.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
-    e0 = IRBlock(loc_df_0, [AssignBlock(e0, instr)])
+    e0 = IRBlock(ir.loc_db, loc_df_0, [AssignBlock(e0, instr)])
 
     e1 = []
     e1.append(m2_expr.ExprAssign(src1, src1 - offset))
     e1.append(m2_expr.ExprAssign(src2, src2 - offset))
     e1.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
-    e1 = IRBlock(loc_df_1, [AssignBlock(e1, instr)])
+    e1 = IRBlock(ir.loc_db, loc_df_1, [AssignBlock(e1, instr)])
 
     e.append(m2_expr.ExprAssign(ir.IRDst,
                              m2_expr.ExprCond(df, loc_df_1_expr, loc_df_0_expr)))
@@ -1243,12 +1243,12 @@ def scas(ir, instr, size):
     e0.append(m2_expr.ExprAssign(src, src + offset))
 
     e0.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
-    e0 = IRBlock(loc_df_0, [AssignBlock(e0, instr)])
+    e0 = IRBlock(ir.loc_db, loc_df_0, [AssignBlock(e0, instr)])
 
     e1 = []
     e1.append(m2_expr.ExprAssign(src, src - offset))
     e1.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
-    e1 = IRBlock(loc_df_1, [AssignBlock(e1, instr)])
+    e1 = IRBlock(ir.loc_db, loc_df_1, [AssignBlock(e1, instr)])
 
     e.append(m2_expr.ExprAssign(ir.IRDst,
                              m2_expr.ExprCond(df, loc_df_1_expr, loc_df_0_expr)))
@@ -1733,13 +1733,13 @@ def div(ir, instr, src1):
     do_div = []
     do_div += e
     do_div.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
-    blk_div = IRBlock(loc_div, [AssignBlock(do_div, instr)])
+    blk_div = IRBlock(ir.loc_db, loc_div, [AssignBlock(do_div, instr)])
 
     do_except = []
     do_except.append(m2_expr.ExprAssign(exception_flags, m2_expr.ExprInt(
         EXCEPT_DIV_BY_ZERO, exception_flags.size)))
     do_except.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
-    blk_except = IRBlock(loc_except, [AssignBlock(do_except, instr)])
+    blk_except = IRBlock(ir.loc_db, loc_except, [AssignBlock(do_except, instr)])
 
     e = []
     e.append(m2_expr.ExprAssign(ir.IRDst,
@@ -1780,13 +1780,13 @@ def idiv(ir, instr, src1):
     do_div = []
     do_div += e
     do_div.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
-    blk_div = IRBlock(loc_div, [AssignBlock(do_div, instr)])
+    blk_div = IRBlock(ir.loc_db, loc_div, [AssignBlock(do_div, instr)])
 
     do_except = []
     do_except.append(m2_expr.ExprAssign(exception_flags, m2_expr.ExprInt(
         EXCEPT_DIV_BY_ZERO, exception_flags.size)))
     do_except.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
-    blk_except = IRBlock(loc_except, [AssignBlock(do_except, instr)])
+    blk_except = IRBlock(ir.loc_db, loc_except, [AssignBlock(do_except, instr)])
 
     e = []
     e.append(m2_expr.ExprAssign(ir.IRDst,
@@ -1952,12 +1952,12 @@ def stos(ir, instr, size):
     e0 = []
     e0.append(m2_expr.ExprAssign(addr_o, addr_p))
     e0.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
-    e0 = IRBlock(loc_df_0, [AssignBlock(e0, instr)])
+    e0 = IRBlock(ir.loc_db, loc_df_0, [AssignBlock(e0, instr)])
 
     e1 = []
     e1.append(m2_expr.ExprAssign(addr_o, addr_m))
     e1.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
-    e1 = IRBlock(loc_df_1, [AssignBlock(e1, instr)])
+    e1 = IRBlock(ir.loc_db, loc_df_1, [AssignBlock(e1, instr)])
 
     e = []
     e.append(m2_expr.ExprAssign(ir.ExprMem(addr, size), b))
@@ -1988,12 +1988,12 @@ def lods(ir, instr, size):
     e0 = []
     e0.append(m2_expr.ExprAssign(addr_o, addr_p))
     e0.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
-    e0 = IRBlock(loc_df_0, [AssignBlock(e0, instr)])
+    e0 = IRBlock(ir.loc_db, loc_df_0, [AssignBlock(e0, instr)])
 
     e1 = []
     e1.append(m2_expr.ExprAssign(addr_o, addr_m))
     e1.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
-    e1 = IRBlock(loc_df_1, [AssignBlock(e1, instr)])
+    e1 = IRBlock(ir.loc_db, loc_df_1, [AssignBlock(e1, instr)])
 
     e = []
     if instr.mode == 64 and b.size == 32:
@@ -2035,13 +2035,13 @@ def movs(ir, instr, size):
     e0.append(m2_expr.ExprAssign(src, src + offset))
     e0.append(m2_expr.ExprAssign(dst, dst + offset))
     e0.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
-    e0 = IRBlock(loc_df_0, [AssignBlock(e0, instr)])
+    e0 = IRBlock(ir.loc_db, loc_df_0, [AssignBlock(e0, instr)])
 
     e1 = []
     e1.append(m2_expr.ExprAssign(src, src - offset))
     e1.append(m2_expr.ExprAssign(dst, dst - offset))
     e1.append(m2_expr.ExprAssign(ir.IRDst, loc_next_expr))
-    e1 = IRBlock(loc_df_1, [AssignBlock(e1, instr)])
+    e1 = IRBlock(ir.loc_db, loc_df_1, [AssignBlock(e1, instr)])
 
     e.append(m2_expr.ExprAssign(ir.IRDst,
                              m2_expr.ExprCond(df, loc_df_1_expr, loc_df_0_expr)))
@@ -2198,31 +2198,31 @@ def fxam(ir, instr):
     base += set_float_cs_eip(instr)
 
     out = [
-        IRBlock(locs["Zero"][0], [AssignBlock({
+        IRBlock(ir.loc_db, locs["Zero"][0], [AssignBlock({
             float_c0: m2_expr.ExprInt(0, float_c0.size),
             float_c2: m2_expr.ExprInt(0, float_c2.size),
             float_c3: m2_expr.ExprInt(1, float_c3.size),
             ir.IRDst: loc_next_expr,
         }, instr)]),
-        IRBlock(locs["Denormal"][0], [AssignBlock({
+        IRBlock(ir.loc_db, locs["Denormal"][0], [AssignBlock({
             float_c0: m2_expr.ExprInt(0, float_c0.size),
             float_c2: m2_expr.ExprInt(1, float_c2.size),
             float_c3: m2_expr.ExprInt(1, float_c3.size),
             ir.IRDst: loc_next_expr,
         }, instr)]),
-        IRBlock(locs["NaN"][0], [AssignBlock({
+        IRBlock(ir.loc_db, locs["NaN"][0], [AssignBlock({
             float_c0: m2_expr.ExprInt(1, float_c0.size),
             float_c2: m2_expr.ExprInt(0, float_c2.size),
             float_c3: m2_expr.ExprInt(0, float_c3.size),
             ir.IRDst: loc_next_expr,
         }, instr)]),
-        IRBlock(locs["Infinity"][0], [AssignBlock({
+        IRBlock(ir.loc_db, locs["Infinity"][0], [AssignBlock({
             float_c0: m2_expr.ExprInt(1, float_c0.size),
             float_c2: m2_expr.ExprInt(1, float_c2.size),
             float_c3: m2_expr.ExprInt(0, float_c3.size),
             ir.IRDst: loc_next_expr,
         }, instr)]),
-        IRBlock(locs["Normal"][0], [AssignBlock({
+        IRBlock(ir.loc_db, locs["Normal"][0], [AssignBlock({
             float_c0: m2_expr.ExprInt(0, float_c0.size),
             float_c2: m2_expr.ExprInt(1, float_c2.size),
             float_c3: m2_expr.ExprInt(0, float_c3.size),
@@ -3255,8 +3255,8 @@ def bsr_bsf(ir, instr, dst, src, op_func):
     e_src_not_null.append(m2_expr.ExprAssign(dst, op_func(src)))
     e_src_not_null.append(aff_dst)
 
-    return e, [IRBlock(loc_src_null, [AssignBlock(e_src_null, instr)]),
-               IRBlock(loc_src_not_null, [AssignBlock(e_src_not_null, instr)])]
+    return e, [IRBlock(ir.loc_db, loc_src_null, [AssignBlock(e_src_null, instr)]),
+               IRBlock(ir.loc_db, loc_src_not_null, [AssignBlock(e_src_not_null, instr)])]
 
 
 def bsf(ir, instr, dst, src):
@@ -4963,7 +4963,7 @@ def maskmovq(ir, instr, src, mask):
                                 m2_expr.ExprCond(bit,
                                                  write_label,
                                                  next_check_label))
-        blks.append(IRBlock(cur_label.loc_key, [AssignBlock([check], instr)]))
+        blks.append(IRBlock(ir.loc_db, cur_label.loc_key, [AssignBlock([check], instr)]))
 
     # Build write blocks
     dst_addr = mRDI[instr.mode]
@@ -4976,7 +4976,7 @@ def maskmovq(ir, instr, src, mask):
         write_mem = m2_expr.ExprAssign(m2_expr.ExprMem(write_addr, 8),
                                     src[start: start + 8])
         jump = m2_expr.ExprAssign(ir.IRDst, next_check_label)
-        blks.append(IRBlock(cur_label.loc_key, [AssignBlock([write_mem, jump], instr)]))
+        blks.append(IRBlock(ir.loc_db, cur_label.loc_key, [AssignBlock([write_mem, jump], instr)]))
 
     # If mask is null, bypass all
     e = [m2_expr.ExprAssign(ir.IRDst, m2_expr.ExprCond(mask,
@@ -5837,10 +5837,10 @@ class ir_x86_16(IntermediateRepresentation):
         cond_bloc.append(m2_expr.ExprAssign(self.IRDst, m2_expr.ExprCond(c_cond,
                                                                       loc_skip_expr,
                                                                       loc_do_expr)))
-        cond_bloc = IRBlock(loc_end, [AssignBlock(cond_bloc, instr)])
+        cond_bloc = IRBlock(self.loc_db, loc_end, [AssignBlock(cond_bloc, instr)])
         e_do = instr_ir
 
-        c = IRBlock(loc_do, [AssignBlock(e_do, instr)])
+        c = IRBlock(self.loc_db, loc_do, [AssignBlock(e_do, instr)])
         e_n = [m2_expr.ExprAssign(self.IRDst, m2_expr.ExprCond(c_reg, loc_do_expr,
                                                             loc_skip_expr))]
         return e_n, [cond_bloc, c] + new_extra_ir
@@ -5871,7 +5871,7 @@ class ir_x86_16(IntermediateRepresentation):
                 src = self.expr_fix_regs_for_mode(src, mode)
                 new_assignblk[dst] = src
             irs.append(AssignBlock(new_assignblk, assignblk.instr))
-        return IRBlock(irblock.loc_key, irs)
+        return IRBlock(self.loc_db, irblock.loc_key, irs)
 
 
 class ir_x86_32(ir_x86_16):

--- a/miasm/core/asmblock.py
+++ b/miasm/core/asmblock.py
@@ -91,22 +91,19 @@ class AsmBlock(object):
 
     loc_key = property(lambda self:self._loc_key)
 
-    def to_string(self, loc_db=None):
+    def to_string(self):
         out = []
-        if loc_db is None:
-            out.append(str(self.loc_key))
-        else:
-            out.append(loc_db.pretty_str(self.loc_key))
+        out.append(self.loc_db.pretty_str(self.loc_key))
 
         for instr in self.lines:
-            out.append(instr.to_string(loc_db))
+            out.append(instr.to_string(self.loc_db))
         if self.bto:
             lbls = ["->"]
             for dst in self.bto:
                 if dst is None:
                     lbls.append("Unknown? ")
                 else:
-                    lbls.append(dst.to_string(loc_db) + " ")
+                    lbls.append(dst.to_string(self.loc_db) + " ")
             lbls = '\t'.join(sorted(lbls))
             out.append(lbls)
         return '\n'.join(out)
@@ -121,18 +118,18 @@ class AsmBlock(object):
         assert isinstance(self.bto, set)
         self.bto.add(c)
 
-    def split(self, loc_db, offset):
-        loc_key = loc_db.get_or_create_offset_location(offset)
+    def split(self, offset):
+        loc_key = self.loc_db.get_or_create_offset_location(offset)
         log_asmblock.debug('split at %x', offset)
         offsets = [x.offset for x in self.lines]
-        offset = loc_db.get_location_offset(loc_key)
+        offset = self.loc_db.get_location_offset(loc_key)
         if offset not in offsets:
             log_asmblock.warning(
                 'cannot split block at %X ' % offset +
                 'middle instruction? default middle')
             offsets.sort()
             return None
-        new_block = AsmBlock(loc_db, loc_key)
+        new_block = AsmBlock(self.loc_db, loc_key)
         i = offsets.index(offset)
 
         self.lines, new_block.lines = self.lines[:i], self.lines[i:]
@@ -444,10 +441,7 @@ class AsmCFG(DiGraph):
 
 
     def node2lines(self, node):
-        if self.loc_db is None:
-            loc_key_name = node
-        else:
-            loc_key_name = self.loc_db.pretty_str(node)
+        loc_key_name = self.loc_db.pretty_str(node)
         yield self.DotCellDescription(text=loc_key_name,
                                       attr={'align': 'center',
                                             'colspan': 2,
@@ -903,7 +897,7 @@ class BlockChainWedge(object):
         return [self, chain]
 
 
-def group_constrained_blocks(loc_db, asmcfg):
+def group_constrained_blocks(asmcfg):
     """
     Return the BlockChains list built from grouped blocks in asmcfg linked by
     asm_constraint_next
@@ -942,7 +936,7 @@ def group_constrained_blocks(loc_db, asmcfg):
 
     out_block_chains = []
     for loc_key in known_block_chains:
-        chain = BlockChain(loc_db, known_block_chains[loc_key])
+        chain = BlockChain(asmcfg.loc_db, known_block_chains[loc_key])
         out_block_chains.append(chain)
     return out_block_chains
 
@@ -1023,8 +1017,8 @@ def get_block_loc_keys(block):
     return symbols
 
 
-def assemble_block(mnemo, block, loc_db, conservative=False):
-    """Assemble a @block using @loc_db
+def assemble_block(mnemo, block, conservative=False):
+    """Assemble a @block
     @conservative: (optional) use original bytes when possible
     """
     offset_i = 0
@@ -1035,7 +1029,7 @@ def assemble_block(mnemo, block, loc_db, conservative=False):
                 # Fix special AsmRaw
                 data = b""
                 for expr in instr.raw:
-                    expr_int = fix_expr_val(expr, loc_db)
+                    expr_int = fix_expr_val(expr, block.loc_db)
                     data += pck[expr_int.size](int(expr_int))
                 instr.data = data
 
@@ -1045,17 +1039,17 @@ def assemble_block(mnemo, block, loc_db, conservative=False):
 
         # Assemble an instruction
         saved_args = list(instr.args)
-        instr.offset = loc_db.get_location_offset(block.loc_key) + offset_i
+        instr.offset = block.loc_db.get_location_offset(block.loc_key) + offset_i
 
         # Replace instruction's arguments by resolved ones
-        instr.args = instr.resolve_args_with_symbols(loc_db)
+        instr.args = instr.resolve_args_with_symbols(block.loc_db)
 
         if instr.dstflow():
             instr.fixDstOffset()
 
         old_l = instr.l
         cached_candidate, _ = conservative_asm(
-            mnemo, instr, loc_db,
+            mnemo, instr, block.loc_db,
             conservative
         )
         if len(cached_candidate) != instr.l:
@@ -1063,11 +1057,11 @@ def assemble_block(mnemo, block, loc_db, conservative=False):
             # Retry assembly with updated length
             instr.l = len(cached_candidate)
             instr.args = saved_args
-            instr.args = instr.resolve_args_with_symbols(loc_db)
+            instr.args = instr.resolve_args_with_symbols(block.loc_db)
             if instr.dstflow():
                 instr.fixDstOffset()
             cached_candidate, _ = conservative_asm(
-                mnemo, instr, loc_db,
+                mnemo, instr, block.loc_db,
                 conservative
             )
             assert len(cached_candidate) == instr.l
@@ -1083,8 +1077,8 @@ def assemble_block(mnemo, block, loc_db, conservative=False):
         offset_i += instr.l
 
 
-def asmblock_final(mnemo, asmcfg, blockChains, loc_db, conservative=False):
-    """Resolve and assemble @blockChains using @loc_db until fixed point is
+def asmblock_final(mnemo, asmcfg, blockChains, conservative=False):
+    """Resolve and assemble @blockChains until fixed point is
     reached"""
 
     log_asmblock.debug("asmbloc_final")
@@ -1131,29 +1125,24 @@ def asmblock_final(mnemo, asmcfg, blockChains, loc_db, conservative=False):
 
         while blocks_to_rework:
             block = blocks_to_rework.pop()
-            assemble_block(mnemo, block, loc_db, conservative)
+            assemble_block(mnemo, block, conservative)
 
 
-def asm_resolve_final(mnemo, asmcfg, loc_db, dst_interval=None):
-    """Resolve and assemble @asmcfg using @loc_db into interval
+def asm_resolve_final(mnemo, asmcfg, dst_interval=None):
+    """Resolve and assemble @asmcfg into interval
     @dst_interval"""
 
     asmcfg.sanity_check()
 
     asmcfg.guess_blocks_size(mnemo)
-    blockChains = group_constrained_blocks(loc_db, asmcfg)
-    resolved_blockChains = resolve_symbol(
-        blockChains,
-        loc_db,
-        dst_interval
-    )
-
-    asmblock_final(mnemo, asmcfg, resolved_blockChains, loc_db)
+    blockChains = group_constrained_blocks(asmcfg)
+    resolved_blockChains = resolve_symbol(blockChains, asmcfg.loc_db, dst_interval)
+    asmblock_final(mnemo, asmcfg, resolved_blockChains)
     patches = {}
     output_interval = interval()
 
     for block in asmcfg.blocks:
-        offset = loc_db.get_location_offset(block.loc_key)
+        offset = asmcfg.loc_db.get_location_offset(block.loc_key)
         for instr in block.lines:
             if not instr.data:
                 # Empty line
@@ -1429,7 +1418,7 @@ class disasmEngine(object):
 
                 # `cur_block` must be split at offset `off`from miasm.core.locationdb import LocationDB
 
-                new_b = cur_block.split(self.loc_db, off)
+                new_b = cur_block.split(off)
                 log_asmblock.debug("Split block %x", off)
                 if new_b is None:
                     log_asmblock.error("Cannot split %x!!", off)

--- a/miasm/core/parse_asm.py
+++ b/miasm/core/parse_asm.py
@@ -88,20 +88,15 @@ def asm_ast_to_expr_with_size(arg, loc_db, size):
         return ExprInt(arg.value, size)
     return None
 
-def parse_txt(mnemo, attrib, txt, loc_db=None):
-    """Parse an assembly listing. Returns a couple (asmcfg, loc_db), where
-    asmcfg is an AsmCfg instance and loc_db the associated LocationDB
+def parse_txt(mnemo, attrib, txt, loc_db):
+    """Parse an assembly listing. Returns an AsmCfg instance
 
     @mnemo: architecture used
     @attrib: architecture attribute
     @txt: assembly listing
-    @loc_db: (optional) the LocationDB instance used to handle labels
-    of the listing
+    @loc_db: the LocationDB instance used to handle labels of the listing
 
     """
-
-    if loc_db is None:
-        loc_db = asmblock.LocationDB()
 
     C_NEXT = asmblock.AsmConstraint.c_next
     C_TO = asmblock.AsmConstraint.c_to
@@ -233,9 +228,9 @@ def parse_txt(mnemo, attrib, txt, loc_db=None):
                 # First line must be a label. If it's not the case, generate
                 # it.
                 loc = guess_next_new_label(loc_db)
-                cur_block = asmblock.AsmBlock(loc, alignment=mnemo.alignment)
+                cur_block = asmblock.AsmBlock(loc_db, loc, alignment=mnemo.alignment)
             else:
-                cur_block = asmblock.AsmBlock(line, alignment=mnemo.alignment)
+                cur_block = asmblock.AsmBlock(loc_db, line, alignment=mnemo.alignment)
                 i += 1
             # Generate the current block
             asmcfg.add_block(cur_block)
@@ -302,4 +297,4 @@ def parse_txt(mnemo, attrib, txt, loc_db=None):
 
         # Log block
         asmblock.log_asmblock.info(block)
-    return asmcfg, loc_db
+    return asmcfg

--- a/miasm/core/sembuilder.py
+++ b/miasm/core/sembuilder.py
@@ -242,6 +242,9 @@ class SemBuilder(object):
                 IRDst = ast.Attribute(value=ast.Name(id='ir',
                                                      ctx=ast.Load()),
                                       attr='IRDst', ctx=ast.Load())
+                loc_db = ast.Attribute(value=ast.Name(id='ir',
+                                                     ctx=ast.Load()),
+                                      attr='loc_db', ctx=ast.Load())
                 blocks[-1][-1].append(ast.Call(func=ast.Name(id='ExprAssign',
                                                              ctx=ast.Load()),
                                                args=[IRDst, dst],
@@ -288,8 +291,11 @@ class SemBuilder(object):
 
                     sub_blocks[-1] = ast.Call(func=ast.Name(id='IRBlock',
                                                             ctx=ast.Load()),
-                                              args=[loc_if_name,
-                                                    assignblks],
+                                              args=[
+                                                  loc_db,
+                                                  loc_if_name,
+                                                  assignblks
+                                              ],
                                               keywords=[],
                                               starargs=None,
                                               kwargs=None)

--- a/miasm/ir/ir.py
+++ b/miasm/ir/ir.py
@@ -773,7 +773,7 @@ class IntermediateRepresentation(object):
         if loc_key is None:
             offset = getattr(instr, "offset", None)
             loc_key = self.loc_db.get_or_create_offset_location(offset)
-        block = AsmBlock(loc_key)
+        block = AsmBlock(self.loc_db, loc_key)
         block.lines = [instr]
         self.add_asmblock_to_ircfg(block, ircfg, gen_pc_updt)
         return loc_key

--- a/miasm/jitter/codegen.py
+++ b/miasm/jitter/codegen.py
@@ -156,7 +156,7 @@ class CGen(object):
             dst = ExprLoc(loc_key, self.ir_arch.IRDst.size)
             new_assignblk[self.ir_arch.IRDst] = dst
         irs = [AssignBlock(new_assignblk, instr)]
-        return IRBlock(self.ir_arch.get_loc_key_for_instr(instr), irs)
+        return IRBlock(self.ir_arch.loc_db, self.ir_arch.get_loc_key_for_instr(instr), irs)
 
     def block2assignblks(self, block):
         """

--- a/miasm/jitter/jitcore.py
+++ b/miasm/jitter/jitcore.py
@@ -144,7 +144,7 @@ class JitCore(object):
             return cur_block
         # Logging
         if self.log_newbloc:
-            print(cur_block.to_string(self.mdis.loc_db))
+            print(cur_block)
 
         # Update label -> block
         self.loc_key_to_block[cur_block.loc_key] = cur_block

--- a/miasm/loader/pe_init.py
+++ b/miasm/loader/pe_init.py
@@ -189,7 +189,8 @@ class PE(object):
                  parse_resources=True,
                  parse_delay=True,
                  parse_reloc=True,
-                 wsize=32):
+                 wsize=32,
+                 **kwargs):
         self._rva = ContectRva(self)
         self._virt = ContentVirtual(self)
         self.img_rva = StrPatchwork()

--- a/test/analysis/data_flow.py
+++ b/test/analysis/data_flow.py
@@ -72,7 +72,7 @@ class IRATest(ira):
 
     """Fake IRA class for tests"""
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         arch = Arch()
         super(IRATest, self).__init__(arch, 32, loc_db)
         self.IRDst = IRDst

--- a/test/analysis/data_flow.py
+++ b/test/analysis/data_flow.py
@@ -51,7 +51,7 @@ def gen_irblock(label, exprs_list):
             irs.append(AssignBlock(exprs))
 
     irs.append(AssignBlock({IRDst:dummy}))
-    irbl = IRBlock(label, irs)
+    irbl = IRBlock(loc_db, label, irs)
     return irbl
 
 

--- a/test/analysis/depgraph.py
+++ b/test/analysis/depgraph.py
@@ -95,7 +95,7 @@ class IRATest(ira):
 
     """Fake IRA class for tests"""
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         arch = Arch()
         super(IRATest, self).__init__(arch, 32, loc_db)
         self.IRDst = ExprId("IRDst", 32)

--- a/test/analysis/depgraph.py
+++ b/test/analysis/depgraph.py
@@ -68,7 +68,7 @@ def gen_irblock(label, exprs_list):
         else:
             irs.append(AssignBlock(exprs))
 
-    irbl = IRBlock(label, irs)
+    irbl = IRBlock(loc_db, label, irs)
     return irbl
 
 

--- a/test/analysis/dse.py
+++ b/test/analysis/dse.py
@@ -10,6 +10,7 @@ from miasm.core.asmblock import asm_resolve_final
 from miasm.analysis.machine import Machine
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
 from miasm.analysis.dse import DSEEngine
+from miasm.core.locationdb import LocationDB
 
 
 class DSETest(object):
@@ -31,9 +32,10 @@ class DSETest(object):
     run_addr = 0x0
 
     def __init__(self, jitter_engine):
+        self.loc_db = LocationDB()
         self.machine = Machine(self.arch_name)
         jitter = self.machine.jitter
-        self.myjit = jitter(jitter_engine)
+        self.myjit = jitter(self.loc_db, jitter_engine)
         self.myjit.init_stack()
 
         self.myjit.set_trace_log()
@@ -52,7 +54,7 @@ class DSETest(object):
         self.myjit.cpu.ECX = 4
         self.myjit.cpu.EDX = 5
 
-        self.dse = DSEEngine(self.machine)
+        self.dse = DSEEngine(self.machine, self.loc_db)
         self.dse.attach(self.myjit)
 
     def __call__(self):
@@ -71,17 +73,17 @@ class DSETest(object):
 
     def asm(self):
         mn_x86 = self.machine.mn
-        blocks, loc_db = parse_asm.parse_txt(
+        blocks = parse_asm.parse_txt(
             mn_x86,
             self.arch_attrib,
             self.TXT,
-            loc_db=self.myjit.ir_arch.loc_db
+            self.loc_db
         )
 
         # fix shellcode addr
-        loc_db.set_location_offset(loc_db.get_name_location("main"), 0x0)
+        self.loc_db.set_location_offset(self.loc_db.get_name_location("main"), 0x0)
         output = StrPatchwork()
-        patches = asm_resolve_final(mn_x86, blocks, loc_db)
+        patches = asm_resolve_final(mn_x86, blocks, self.loc_db)
         for offset, raw in viewitems(patches):
             output[offset] = raw
 
@@ -120,7 +122,7 @@ class DSEAttachInBreakpoint(DSETest):
 
     def bp_attach(self, jitter):
         """Attach a DSE in the current jitter"""
-        self.dse = DSEEngine(self.machine)
+        self.dse = DSEEngine(self.machine, self.loc_db)
         self.dse.attach(self.myjit)
         self.dse.update_state_from_concrete()
         self.dse.update_state({

--- a/test/analysis/dse.py
+++ b/test/analysis/dse.py
@@ -73,7 +73,7 @@ class DSETest(object):
 
     def asm(self):
         mn_x86 = self.machine.mn
-        blocks = parse_asm.parse_txt(
+        asmcfg = parse_asm.parse_txt(
             mn_x86,
             self.arch_attrib,
             self.TXT,
@@ -83,7 +83,7 @@ class DSETest(object):
         # fix shellcode addr
         self.loc_db.set_location_offset(self.loc_db.get_name_location("main"), 0x0)
         output = StrPatchwork()
-        patches = asm_resolve_final(mn_x86, blocks, self.loc_db)
+        patches = asm_resolve_final(mn_x86, asmcfg)
         for offset, raw in viewitems(patches):
             output[offset] = raw
 
@@ -117,7 +117,7 @@ class DSEAttachInBreakpoint(DSETest):
         super(DSEAttachInBreakpoint, self).__init__(*args, **kwargs)
         self._dse = None
         ircls = self.machine.ir
-        self._regs = ircls().arch.regs
+        self._regs = ircls(self.loc_db).arch.regs
         self._testid = ExprId("TEST", self._regs.EBX.size)
 
     def bp_attach(self, jitter):

--- a/test/analysis/unssa.py
+++ b/test/analysis/unssa.py
@@ -56,7 +56,7 @@ def gen_irblock(label, exprs_list):
         else:
             irs.append(AssignBlock(exprs))
 
-    irbl = IRBlock(label, irs)
+    irbl = IRBlock(loc_db, label, irs)
     return irbl
 
 
@@ -587,7 +587,7 @@ def add_out_reg_end(ir_arch_a, ircfg_a):
         assignblks = list(irblock)
         new_assiblk = AssignBlock(regs, assignblks[-1].instr)
         assignblks.append(new_assiblk)
-        new_irblock = IRBlock(irblock.loc_key, assignblks)
+        new_irblock = IRBlock(loc_db, irblock.loc_key, assignblks)
         ircfg_a.blocks[loc] = new_irblock
 
 

--- a/test/arch/aarch64/unit/asm_test.py
+++ b/test/arch/aarch64/unit/asm_test.py
@@ -26,11 +26,11 @@ class Asm_Test(object):
         self.check()
 
     def asm(self):
-        blocks = parse_asm.parse_txt(mn_aarch64, 'l', self.TXT, self.loc_db)
+        asmcfg = parse_asm.parse_txt(mn_aarch64, 'l', self.TXT, self.loc_db)
         # fix shellcode addr
         self.loc_db.set_location_offset(self.loc_db.get_name_location("main"), 0x0)
         s = StrPatchwork()
-        patches = asmblock.asm_resolve_final(mn_aarch64, blocks, self.loc_db)
+        patches = asmblock.asm_resolve_final(mn_aarch64, asmcfg)
         for offset, raw in viewitems(patches):
             s[offset] = raw
 

--- a/test/arch/aarch64/unit/asm_test.py
+++ b/test/arch/aarch64/unit/asm_test.py
@@ -10,12 +10,14 @@ from miasm.core import asmblock
 from miasm.loader.strpatchwork import StrPatchwork
 from miasm.analysis.machine import Machine
 from miasm.jitter.csts import *
+from miasm.core.locationdb import LocationDB
 
 reg_and_id = dict(mn_aarch64.regs.all_regs_ids_byname)
 
 class Asm_Test(object):
     def __init__(self, jitter):
-        self.myjit = Machine("aarch64l").jitter(jitter)
+        self.loc_db = LocationDB()
+        self.myjit = Machine("aarch64l").jitter(self.loc_db, jitter)
         self.myjit.init_stack()
 
     def __call__(self):
@@ -24,12 +26,11 @@ class Asm_Test(object):
         self.check()
 
     def asm(self):
-        blocks, loc_db = parse_asm.parse_txt(mn_aarch64, 'l', self.TXT,
-                                                  loc_db = self.myjit.ir_arch.loc_db)
+        blocks = parse_asm.parse_txt(mn_aarch64, 'l', self.TXT, self.loc_db)
         # fix shellcode addr
-        loc_db.set_location_offset(loc_db.get_name_location("main"), 0x0)
+        self.loc_db.set_location_offset(self.loc_db.get_name_location("main"), 0x0)
         s = StrPatchwork()
-        patches = asmblock.asm_resolve_final(mn_aarch64, blocks, loc_db)
+        patches = asmblock.asm_resolve_final(mn_aarch64, blocks, self.loc_db)
         for offset, raw in viewitems(patches):
             s[offset] = raw
 

--- a/test/arch/arm/sem.py
+++ b/test/arch/arm/sem.py
@@ -16,7 +16,8 @@ from miasm.core.locationdb import LocationDB
 from pdb import pm
 
 logging.getLogger('cpuhelper').setLevel(logging.ERROR)
-EXCLUDE_REGS = set([ir_arch().IRDst])
+loc_db = LocationDB()
+EXCLUDE_REGS = set([ir_arch(loc_db).IRDst])
 
 
 def M(addr):

--- a/test/arch/mep/ir/test_ir.py
+++ b/test/arch/mep/ir/test_ir.py
@@ -27,13 +27,14 @@ class TestMisc(object):
             mn = mn_mep.dis(decode_hex(hex_asm), "b")
             print("Dis:", mn)
 
+            loc_db = LocationDB()
+
             # Get the IR
-            im = ir_mepb()
+            im = ir_mepb(loc_db)
             iir, eiir, = im.get_ir(mn)
             print("\nInternal representation:", iir)
 
             # Symbolic execution
-            loc_db = LocationDB()
             sb = SymbolicExecutionEngine(ir_a_mepb(loc_db), regs_init)
 
             # Assign register values before symbolic evaluation

--- a/test/arch/mep/jit/ut_helpers_jit.py
+++ b/test/arch/mep/jit/ut_helpers_jit.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 from miasm.analysis.machine import Machine
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
+from miasm.core.locationdb import LocationDB
 
 
 def jit_instructions(mn_str):
@@ -13,6 +14,7 @@ def jit_instructions(mn_str):
     # Get the miasm Machine
     machine = Machine("mepb")
     mn_mep = machine.mn()
+    loc_db = LocationDB()
 
     # Assemble the instructions
     asm = b""
@@ -22,7 +24,7 @@ def jit_instructions(mn_str):
         asm += mn_mep.asm(instr)[0]
 
     # Init the jitter and add the assembled instructions to memory
-    jitter = machine.jitter(jit_type="gcc")
+    jitter = machine.jitter(loc_db, jit_type="gcc")
     jitter.vm.add_memory_page(0, PAGE_READ | PAGE_WRITE, asm)
 
     # Set the breakpoint

--- a/test/arch/mips32/unit/asm_test.py
+++ b/test/arch/mips32/unit/asm_test.py
@@ -10,6 +10,7 @@ from miasm.core import asmblock
 from miasm.loader.strpatchwork import StrPatchwork
 from miasm.analysis.machine import Machine
 from miasm.jitter.csts import *
+from miasm.core.locationdb import LocationDB
 
 
 reg_and_id = dict(mn_mips32.regs.all_regs_ids_byname)
@@ -17,7 +18,8 @@ reg_and_id = dict(mn_mips32.regs.all_regs_ids_byname)
 class Asm_Test(object):
 
     def __init__(self, jitter):
-        self.myjit = Machine("mips32l").jitter(jitter)
+        self.loc_db = LocationDB()
+        self.myjit = Machine("mips32l").jitter(self.loc_db, jitter)
         self.myjit.init_stack()
 
     def __call__(self):
@@ -26,12 +28,11 @@ class Asm_Test(object):
         self.check()
 
     def asm(self):
-        blocks, loc_db = parse_asm.parse_txt(mn_mips32, 'l', self.TXT,
-                                                  loc_db=self.myjit.ir_arch.loc_db)
+        blocks = parse_asm.parse_txt(mn_mips32, 'l', self.TXT, self.loc_db)
         # fix shellcode addr
-        loc_db.set_location_offset(loc_db.get_name_location("main"), 0x0)
+        self.loc_db.set_location_offset(self.loc_db.get_name_location("main"), 0x0)
         s = StrPatchwork()
-        patches = asmblock.asm_resolve_final(mn_mips32, blocks, loc_db)
+        patches = asmblock.asm_resolve_final(mn_mips32, blocks, self.loc_db)
         for offset, raw in viewitems(patches):
             s[offset] = raw
 

--- a/test/arch/mips32/unit/asm_test.py
+++ b/test/arch/mips32/unit/asm_test.py
@@ -28,11 +28,11 @@ class Asm_Test(object):
         self.check()
 
     def asm(self):
-        blocks = parse_asm.parse_txt(mn_mips32, 'l', self.TXT, self.loc_db)
+        asmcfg = parse_asm.parse_txt(mn_mips32, 'l', self.TXT, self.loc_db)
         # fix shellcode addr
         self.loc_db.set_location_offset(self.loc_db.get_name_location("main"), 0x0)
         s = StrPatchwork()
-        patches = asmblock.asm_resolve_final(mn_mips32, blocks, self.loc_db)
+        patches = asmblock.asm_resolve_final(mn_mips32, asmcfg)
         for offset, raw in viewitems(patches):
             s[offset] = raw
 

--- a/test/arch/msp430/sem.py
+++ b/test/arch/msp430/sem.py
@@ -15,7 +15,8 @@ from miasm.expression.expression import *
 from miasm.core.locationdb import LocationDB
 
 logging.getLogger('cpuhelper').setLevel(logging.ERROR)
-EXCLUDE_REGS = set([res, ir_arch().IRDst])
+loc_db = LocationDB()
+EXCLUDE_REGS = set([res, ir_arch(loc_db).IRDst])
 
 
 def M(addr):

--- a/test/arch/ppc32/sem.py
+++ b/test/arch/ppc32/sem.py
@@ -16,7 +16,8 @@ from miasm.core.locationdb import LocationDB
 from pdb import pm
 
 logging.getLogger('cpuhelper').setLevel(logging.ERROR)
-EXCLUDE_REGS = set([ir_arch().IRDst])
+loc_db = LocationDB()
+EXCLUDE_REGS = set([ir_arch(loc_db).IRDst])
 
 
 def M(addr):

--- a/test/arch/x86/qemu/testqemu.py
+++ b/test/arch/x86/qemu/testqemu.py
@@ -13,6 +13,7 @@ except AttributeError:
 from miasm.analysis.sandbox import Sandbox_Linux_x86_32
 from miasm.jitter.jitload import log_func
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
+from miasm.core.locationdb import LocationDB
 
 # Utils
 def parse_fmt(s):
@@ -122,7 +123,8 @@ options = parser.parse_args()
 expected = open(options.expected)
 
 # Create sandbox
-sb = Sandbox_Linux_x86_32(options.filename, options, globals())
+loc_db = LocationDB()
+sb = Sandbox_Linux_x86_32(loc_db, options.filename, options, globals())
 try:
     addr = sb.elf.getsectionbyname(".symtab")[options.funcname].value
 except AttributeError:

--- a/test/arch/x86/qemu/testqemu64.py
+++ b/test/arch/x86/qemu/testqemu64.py
@@ -13,6 +13,7 @@ except AttributeError:
 from miasm.analysis.sandbox import Sandbox_Linux_x86_64
 from miasm.jitter.jitload import log_func
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
+from miasm.core.locationdb import LocationDB
 
 # Utils
 def parse_fmt(s):
@@ -118,7 +119,8 @@ options = parser.parse_args()
 expected = open(options.expected)
 
 # Create sandbox
-sb = Sandbox_Linux_x86_64(options.filename, options, globals())
+loc_db = LocationDB()
+sb = Sandbox_Linux_x86_64(loc_db, options.filename, options, globals())
 try:
     addr = sb.elf.getsectionbyname(".symtab")[options.funcname].value
 except AttributeError:

--- a/test/arch/x86/sem.py
+++ b/test/arch/x86/sem.py
@@ -21,9 +21,9 @@ from miasm.expression.simplifications import expr_simp
 from miasm.core import parse_asm, asmblock
 from miasm.core.locationdb import LocationDB
 
-
 logging.getLogger('cpuhelper').setLevel(logging.ERROR)
-EXCLUDE_REGS = set([ir_32().IRDst, ir_64().IRDst])
+loc_db = LocationDB()
+EXCLUDE_REGS = set([ir_32(loc_db).IRDst, ir_64(loc_db).IRDst])
 
 
 m32 = 32
@@ -59,7 +59,7 @@ def compute_txt(ir, mode, txt, inputstate={}, debug=False):
     loc_db = LocationDB()
     asmcfg = parse_asm.parse_txt(mn, mode, txt, loc_db)
     loc_db.set_location_offset(loc_db.get_name_location("main"), 0x0)
-    patches = asmblock.asm_resolve_final(mn, asmcfg, loc_db)
+    patches = asmblock.asm_resolve_final(mn, asmcfg)
     ir_arch = ir(loc_db)
     lbl = loc_db.get_name_location("main")
     ircfg = ir_arch.new_ircfg_from_asmcfg(asmcfg)

--- a/test/arch/x86/sem.py
+++ b/test/arch/x86/sem.py
@@ -56,7 +56,8 @@ def compute(ir, mode, asm, inputstate={}, debug=False):
 
 
 def compute_txt(ir, mode, txt, inputstate={}, debug=False):
-    asmcfg, loc_db = parse_asm.parse_txt(mn, mode, txt)
+    loc_db = LocationDB()
+    asmcfg = parse_asm.parse_txt(mn, mode, txt, loc_db)
     loc_db.set_location_offset(loc_db.get_name_location("main"), 0x0)
     patches = asmblock.asm_resolve_final(mn, asmcfg, loc_db)
     ir_arch = ir(loc_db)

--- a/test/arch/x86/unit/access_xmm.py
+++ b/test/arch/x86/unit/access_xmm.py
@@ -2,9 +2,11 @@
 """Test getter and setter for XMM registers (128 bits)"""
 
 from miasm.analysis.machine import Machine
+from miasm.core.locationdb import LocationDB
 
 # Jitter engine doesn't matter, use the always available 'python' one
-myjit = Machine("x86_32").jitter("python")
+loc_db = LocationDB()
+myjit = Machine("x86_32").jitter(loc_db, "python")
 
 # Test basic access (get)
 assert myjit.cpu.XMM0 == 0

--- a/test/arch/x86/unit/asm_test.py
+++ b/test/arch/x86/unit/asm_test.py
@@ -45,11 +45,11 @@ class Asm_Test(object):
         assert(self.myjit.pc == self.ret_addr)
 
     def asm(self):
-        blocks = parse_asm.parse_txt(mn_x86, self.arch_attrib, self.TXT, self.loc_db)
+        asmcfg = parse_asm.parse_txt(mn_x86, self.arch_attrib, self.TXT, self.loc_db)
         # fix shellcode addr
         self.loc_db.set_location_offset(self.loc_db.get_name_location("main"), 0x0)
         s = StrPatchwork()
-        patches = asmblock.asm_resolve_final(mn_x86, blocks, self.loc_db)
+        patches = asmblock.asm_resolve_final(mn_x86, asmcfg)
         for offset, raw in viewitems(patches):
             s[offset] = raw
 

--- a/test/arch/x86/unit/asm_test.py
+++ b/test/arch/x86/unit/asm_test.py
@@ -11,15 +11,16 @@ from miasm.expression.expression import *
 from miasm.core import asmblock
 from miasm.loader.strpatchwork import StrPatchwork
 from miasm.analysis.machine import Machine
+from miasm.core.locationdb import LocationDB
 from miasm.jitter.csts import *
 
 reg_and_id = dict(mn_x86.regs.all_regs_ids_byname)
-
 class Asm_Test(object):
     run_addr = 0x0
 
     def __init__(self, jitter_engine):
-        self.myjit = Machine(self.arch_name).jitter(jitter_engine)
+        self.loc_db = LocationDB()
+        self.myjit = Machine(self.arch_name).jitter(self.loc_db, jitter_engine)
         self.myjit.init_stack()
 
     def test_init(self):
@@ -44,12 +45,11 @@ class Asm_Test(object):
         assert(self.myjit.pc == self.ret_addr)
 
     def asm(self):
-        blocks, loc_db = parse_asm.parse_txt(mn_x86, self.arch_attrib, self.TXT,
-                                                  loc_db = self.myjit.ir_arch.loc_db)
+        blocks = parse_asm.parse_txt(mn_x86, self.arch_attrib, self.TXT, self.loc_db)
         # fix shellcode addr
-        loc_db.set_location_offset(loc_db.get_name_location("main"), 0x0)
+        self.loc_db.set_location_offset(self.loc_db.get_name_location("main"), 0x0)
         s = StrPatchwork()
-        patches = asmblock.asm_resolve_final(mn_x86, blocks, loc_db)
+        patches = asmblock.asm_resolve_final(mn_x86, blocks, self.loc_db)
         for offset, raw in viewitems(patches):
             s[offset] = raw
 
@@ -77,7 +77,8 @@ class Asm_Test_16(Asm_Test):
     ret_addr = 0x1337
 
     def __init__(self, jitter_engine):
-        self.myjit = Machine(self.arch_name).jitter(jitter_engine)
+        self.loc_db = LocationDB()
+        self.myjit = Machine(self.arch_name).jitter(self.loc_db, jitter_engine)
         self.myjit.stack_base = 0x1000
         self.myjit.stack_size = 0x1000
         self.myjit.init_stack()

--- a/test/arch/x86/unit/mn_pushpop.py
+++ b/test/arch/x86/unit/mn_pushpop.py
@@ -21,7 +21,7 @@ class Test_PUSHAD_32(Asm_Test_32):
     MYSTRING = "test pushad 32"
 
     def prepare(self):
-        self.myjit.ir_arch.loc_db.add_location("lbl_ret", self.ret_addr)
+        self.loc_db.add_location("lbl_ret", self.ret_addr)
 
     def test_init(self):
         init_regs(self)
@@ -48,7 +48,7 @@ class Test_PUSHA_32(Asm_Test_32):
     MYSTRING = "test pusha 32"
 
     def prepare(self):
-        self.myjit.ir_arch.loc_db.add_location("lbl_ret", self.ret_addr)
+        self.loc_db.add_location("lbl_ret", self.ret_addr)
 
     def test_init(self):
         init_regs(self)
@@ -75,7 +75,7 @@ class Test_PUSHA_16(Asm_Test_16):
     MYSTRING = "test pusha 16"
 
     def prepare(self):
-        self.myjit.ir_arch.loc_db.add_location("lbl_ret", self.ret_addr)
+        self.loc_db.add_location("lbl_ret", self.ret_addr)
 
     def test_init(self):
         init_regs(self)
@@ -102,7 +102,7 @@ class Test_PUSHAD_16(Asm_Test_16):
     MYSTRING = "test pushad 16"
 
     def prepare(self):
-        self.myjit.ir_arch.loc_db.add_location("lbl_ret", self.ret_addr)
+        self.loc_db.add_location("lbl_ret", self.ret_addr)
 
     def test_init(self):
         init_regs(self)
@@ -129,7 +129,7 @@ class Test_PUSH_mode32_32(Asm_Test_32):
     MYSTRING = "test push mode32 32"
 
     def prepare(self):
-        self.myjit.ir_arch.loc_db.add_location("lbl_ret", self.ret_addr)
+        self.loc_db.add_location("lbl_ret", self.ret_addr)
 
     def test_init(self):
         init_regs(self)
@@ -152,7 +152,7 @@ class Test_PUSH_mode32_16(Asm_Test_32):
     MYSTRING = "test push mode32 16"
 
     def prepare(self):
-        self.myjit.ir_arch.loc_db.add_location("lbl_ret", self.ret_addr)
+        self.loc_db.add_location("lbl_ret", self.ret_addr)
 
     def test_init(self):
         init_regs(self)
@@ -175,7 +175,7 @@ class Test_PUSH_mode16_16(Asm_Test_16):
     MYSTRING = "test push mode16 16"
 
     def prepare(self):
-        self.myjit.ir_arch.loc_db.add_location("lbl_ret", self.ret_addr)
+        self.loc_db.add_location("lbl_ret", self.ret_addr)
 
     def test_init(self):
         init_regs(self)
@@ -198,7 +198,7 @@ class Test_PUSH_mode16_32(Asm_Test_16):
     MYSTRING = "test push mode16 32"
 
     def prepare(self):
-        self.myjit.ir_arch.loc_db.add_location("lbl_ret", self.ret_addr)
+        self.loc_db.add_location("lbl_ret", self.ret_addr)
 
     def test_init(self):
         init_regs(self)
@@ -221,7 +221,7 @@ class Test_POP_mode32_32(Asm_Test_32):
     MYSTRING = "test pop mode32 32"
 
     def prepare(self):
-        self.myjit.ir_arch.loc_db.add_location("lbl_ret", self.ret_addr)
+        self.loc_db.add_location("lbl_ret", self.ret_addr)
 
     def test_init(self):
         self.value = 0x11223344
@@ -243,7 +243,7 @@ class Test_POP_mode32_16(Asm_Test_32):
     MYSTRING = "test pop mode32 16"
 
     def prepare(self):
-        self.myjit.ir_arch.loc_db.add_location("lbl_ret", self.ret_addr)
+        self.loc_db.add_location("lbl_ret", self.ret_addr)
 
     def test_init(self):
         self.value = 0x1122
@@ -265,7 +265,7 @@ class Test_POP_mode16_16(Asm_Test_16):
     MYSTRING = "test pop mode16 16"
 
     def prepare(self):
-        self.myjit.ir_arch.loc_db.add_location("lbl_ret", self.ret_addr)
+        self.loc_db.add_location("lbl_ret", self.ret_addr)
 
     def test_init(self):
         self.value = 0x1122
@@ -287,7 +287,7 @@ class Test_POP_mode16_32(Asm_Test_16):
     MYSTRING = "test pop mode16 32"
 
     def prepare(self):
-        self.myjit.ir_arch.loc_db.add_location("lbl_ret", self.ret_addr)
+        self.loc_db.add_location("lbl_ret", self.ret_addr)
 
     def test_init(self):
         self.value = 0x11223344

--- a/test/arch/x86/unit/test_asm_x86_64.py
+++ b/test/arch/x86/unit/test_asm_x86_64.py
@@ -2,11 +2,13 @@ from miasm.core import asmblock
 from miasm.arch.x86  import arch
 from miasm.core import parse_asm
 from miasm.core.interval import interval
+from miasm.core.locationdb import LocationDB
 
 my_mn = arch.mn_x86
+loc_db = LocationDB()
 
-
-asmcfg, loc_db = parse_asm.parse_txt(my_mn, 64, r'''
+asmcfg = parse_asm.parse_txt(
+    my_mn, 64, r'''
 main:
   PUSH   RBP
   MOV    RBP, RSP
@@ -18,7 +20,9 @@ end:
   POP    RBP
   RET
 
-''')
+''',
+    loc_db
+)
 
 loc_db.set_location_offset(loc_db.get_name_location("main"), 0x100001000)
 dst_interval = interval([(0x100001000, 0x100002000)])

--- a/test/arch/x86/unit/test_asm_x86_64.py
+++ b/test/arch/x86/unit/test_asm_x86_64.py
@@ -29,6 +29,5 @@ dst_interval = interval([(0x100001000, 0x100002000)])
 patches = asmblock.asm_resolve_final(
     my_mn,
     asmcfg,
-    loc_db,
     dst_interval
 )

--- a/test/core/parse_asm.py
+++ b/test/core/parse_asm.py
@@ -3,6 +3,7 @@
 
 from builtins import range
 import unittest
+from miasm.core.locationdb import LocationDB
 
 
 class TestParseAsm(unittest.TestCase):
@@ -10,6 +11,7 @@ class TestParseAsm(unittest.TestCase):
     def test_ParseTxt(self):
         from miasm.arch.x86.arch import mn_x86
         from miasm.core.parse_asm import parse_txt
+        loc_db = LocationDB()
 
         ASM0 = '''
         ;
@@ -33,13 +35,14 @@ class TestParseAsm(unittest.TestCase):
         ASM1 = '''
         .XXX
         '''
-        self.assertTrue(parse_txt(mn_x86, 32, ASM0))
-        self.assertRaises(ValueError, parse_txt, mn_x86, 32, ASM1)
+        self.assertTrue(parse_txt(mn_x86, 32, ASM0, loc_db))
+        self.assertRaises(ValueError, parse_txt, mn_x86, 32, ASM1, loc_db)
 
     def test_DirectiveDontSplit(self):
         from miasm.arch.x86.arch import mn_x86
         from miasm.core.parse_asm import parse_txt
         from miasm.core.asmblock import asm_resolve_final
+        loc_db = LocationDB()
 
         ASM0 = '''
         lbl0:
@@ -65,10 +68,8 @@ class TestParseAsm(unittest.TestCase):
         .string "toto"
         '''
 
-        asmcfg, loc_db = parse_txt(mn_x86, 32, ASM0)
-        patches = asm_resolve_final(mn_x86,
-                                    asmcfg,
-                                    loc_db)
+        asmcfg = parse_txt(mn_x86, 32, ASM0, loc_db)
+        patches = asm_resolve_final(mn_x86, asmcfg, loc_db)
         lbls = []
         for i in range(6):
             lbls.append(loc_db.get_name_location('lbl%d' % i))
@@ -87,6 +88,7 @@ class TestParseAsm(unittest.TestCase):
     def test_DirectiveSplit(self):
         from miasm.arch.x86.arch import mn_x86
         from miasm.core.parse_asm import parse_txt
+        loc_db = LocationDB()
 
         ASM0 = '''
         lbl0:
@@ -96,7 +98,7 @@ class TestParseAsm(unittest.TestCase):
             RET
         '''
 
-        asmcfg, loc_db = parse_txt(mn_x86, 32, ASM0)
+        asmcfg = parse_txt(mn_x86, 32, ASM0, loc_db)
         lbls = []
         for i in range(2):
             lbls.append(loc_db.get_name_location('lbl%d' % i))

--- a/test/core/parse_asm.py
+++ b/test/core/parse_asm.py
@@ -69,7 +69,7 @@ class TestParseAsm(unittest.TestCase):
         '''
 
         asmcfg = parse_txt(mn_x86, 32, ASM0, loc_db)
-        patches = asm_resolve_final(mn_x86, asmcfg, loc_db)
+        patches = asm_resolve_final(mn_x86, asmcfg)
         lbls = []
         for i in range(6):
             lbls.append(loc_db.get_name_location('lbl%d' % i))

--- a/test/core/test_types.py
+++ b/test/core/test_types.py
@@ -14,6 +14,7 @@ from miasm.core.types import MemStruct, Num, Ptr, Str, \
                               set_allocator, MemUnion, Struct
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
 from miasm.os_dep.common import heap
+from miasm.core.locationdb import LocationDB
 
 # Two structures with some fields
 class OtherStruct(MemStruct):
@@ -35,7 +36,8 @@ class MyStruct(MemStruct):
         ("i", Ptr("I", Num("I"))),
     ]
 
-jitter = Machine("x86_32").jitter("python")
+loc_db = LocationDB()
+jitter = Machine("x86_32").jitter(loc_db, "python")
 jitter.init_stack()
 addr = 0x1000
 size = 0x1000

--- a/test/ir/reduce_graph.py
+++ b/test/ir/reduce_graph.py
@@ -95,7 +95,7 @@ def gen_irblock(label, exprs_list):
         else:
             irs.append(AssignBlock(exprs))
 
-    irbl = IRBlock(label, irs)
+    irbl = IRBlock(loc_db, label, irs)
     return irbl
 
 

--- a/test/ir/reduce_graph.py
+++ b/test/ir/reduce_graph.py
@@ -74,7 +74,7 @@ class IRATest(ira):
 
     """Fake IRA class for tests"""
 
-    def __init__(self, loc_db=None):
+    def __init__(self, loc_db):
         arch = Arch()
         super(IRATest, self).__init__(arch, 32, loc_db)
         self.IRDst = IRDst

--- a/test/jitter/bad_block.py
+++ b/test/jitter/bad_block.py
@@ -2,6 +2,7 @@ import sys
 from miasm.core.utils import decode_hex
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE, EXCEPT_UNK_MNEMO
 from miasm.analysis.machine import Machine
+from miasm.core.locationdb import LocationDB
 
 def code_sentinelle(jitter):
     jitter.run = False
@@ -9,7 +10,8 @@ def code_sentinelle(jitter):
     return True
 
 machine = Machine("x86_32")
-jitter = machine.jitter(sys.argv[1])
+loc_db = LocationDB()
+jitter = machine.jitter(loc_db, sys.argv[1])
 
 jitter.init_stack()
 

--- a/test/jitter/jit_options.py
+++ b/test/jitter/jit_options.py
@@ -5,6 +5,7 @@ import sys
 from miasm.core.utils import decode_hex
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
 from miasm.analysis.machine import Machine
+from miasm.core.locationdb import LocationDB
 from pdb import pm
 
 # Shellcode
@@ -21,16 +22,17 @@ from pdb import pm
 
 data = decode_hex("b810000000bb0100000083e8010f44cb75f8c3")
 run_addr = 0x40000000
+loc_db = LocationDB()
 
 def code_sentinelle(jitter):
     jitter.run = False
     jitter.pc = 0
     return True
 
-def init_jitter():
+def init_jitter(loc_db):
     global data, run_addr
     # Create jitter
-    myjit = Machine("x86_32").jitter(sys.argv[1])
+    myjit = Machine("x86_32").jitter(loc_db, sys.argv[1])
 
     myjit.vm.add_memory_page(run_addr, PAGE_READ | PAGE_WRITE, data)
 
@@ -44,7 +46,7 @@ def init_jitter():
 
 # Test 'max_exec_per_call'
 print("[+] First run, to jit blocks")
-myjit = init_jitter()
+myjit = init_jitter(loc_db)
 myjit.init_run(run_addr)
 myjit.continue_run()
 
@@ -78,7 +80,7 @@ assert myjit.cpu.EAX >= 0xA
 
 # Test 'jit_maxline'
 print("[+] Run instr one by one")
-myjit = init_jitter()
+myjit = init_jitter(loc_db)
 myjit.jit.options["jit_maxline"] = 1
 myjit.jit.options["max_exec_per_call"] = 1
 

--- a/test/jitter/jitcore.py
+++ b/test/jitter/jitcore.py
@@ -1,8 +1,10 @@
 import sys
+from miasm.core.locationdb import LocationDB
 
 from miasm.analysis.machine import Machine
 machine = Machine("x86_64")
-jitter = machine.jitter(sys.argv[1])
+loc_db = LocationDB()
+jitter = machine.jitter(loc_db, sys.argv[1])
 
 jitter.cpu.RAX = 16565615892967251934
 assert jitter.cpu.RAX == 16565615892967251934

--- a/test/jitter/jitload.py
+++ b/test/jitter/jitload.py
@@ -5,12 +5,15 @@ from miasm.core.utils import decode_hex, encode_hex
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
 from miasm.analysis.machine import Machine
 from miasm.expression.expression import ExprId, ExprAssign, ExprInt, ExprMem
+from miasm.core.locationdb import LocationDB
+
 
 # Initial data: from 'example/samples/x86_32_sc.bin'
 data = decode_hex("8d49048d5b0180f90174058d5bffeb038d5b0189d8c3")
+loc_db = LocationDB()
 
 # Init jitter
-myjit = Machine("x86_32").jitter(sys.argv[1])
+myjit = Machine("x86_32").jitter(loc_db, sys.argv[1])
 myjit.init_stack()
 
 run_addr = 0x40000000

--- a/test/jitter/jmp_out_mem.py
+++ b/test/jitter/jmp_out_mem.py
@@ -2,6 +2,8 @@ import sys
 from miasm.core.utils import decode_hex
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE, EXCEPT_ACCESS_VIOL
 from miasm.analysis.machine import Machine
+from miasm.core.locationdb import LocationDB
+
 
 def code_sentinelle(jitter):
     jitter.run = False
@@ -10,7 +12,8 @@ def code_sentinelle(jitter):
 
 
 machine = Machine("x86_32")
-jitter = machine.jitter(sys.argv[1])
+loc_db = LocationDB()
+jitter = machine.jitter(loc_db, sys.argv[1])
 
 jitter.init_stack()
 

--- a/test/jitter/mem_breakpoint.py
+++ b/test/jitter/mem_breakpoint.py
@@ -5,6 +5,7 @@ from miasm.core.utils import decode_hex
 from miasm.analysis.machine import Machine
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE, \
     EXCEPT_BREAKPOINT_MEMORY, EXCEPT_ACCESS_VIOL
+from miasm.core.locationdb import LocationDB
 
 def mem_breakpoint_handler(jitter):
     print("======")
@@ -35,7 +36,8 @@ def mem_breakpoint_handler(jitter):
     return True
 
 machine = Machine("aarch64l")
-jitter = machine.jitter(sys.argv[1])
+loc_db = LocationDB()
+jitter = machine.jitter(loc_db, sys.argv[1])
 
 start_addr = 0xFFFFFF8008080000
 end_addr = start_addr + 0x8000000

--- a/test/jitter/test_post_instr.py
+++ b/test/jitter/test_post_instr.py
@@ -5,9 +5,11 @@ from miasm.core.utils import decode_hex
 from miasm.analysis.machine import Machine
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE, \
     EXCEPT_BREAKPOINT_MEMORY, EXCEPT_ACCESS_VIOL
+from miasm.core.locationdb import LocationDB
 
 machine = Machine("x86_32")
-jitter = machine.jitter(sys.argv[1])
+loc_db = LocationDB()
+jitter = machine.jitter(loc_db, sys.argv[1])
 
 # Prepare stack and reset memory accesses to avoid an exception
 jitter.vm.add_memory_page(0x10000, PAGE_READ|PAGE_WRITE, b"\x00"*0x1000, "stack")

--- a/test/jitter/vm_mngr.py
+++ b/test/jitter/vm_mngr.py
@@ -1,8 +1,10 @@
 import sys
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
 from miasm.analysis.machine import Machine
+from miasm.core.locationdb import LocationDB
 
-myjit = Machine("x86_32").jitter(sys.argv[1])
+loc_db = LocationDB()
+myjit = Machine("x86_32").jitter(loc_db, sys.argv[1])
 
 base_addr = 0x13371337
 page_size = 0x1000

--- a/test/os_dep/common.py
+++ b/test/os_dep/common.py
@@ -8,10 +8,12 @@ from miasm.analysis.machine import Machine
 import miasm.os_dep.common as commonapi
 from miasm.core.utils import pck32
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
+from miasm.core.locationdb import LocationDB
 
 machine = Machine("x86_32")
 
-jit = machine.jitter()
+loc_db = LocationDB()
+jit = machine.jitter(loc_db)
 jit.init_stack()
 
 class TestCommonAPI(unittest.TestCase):

--- a/test/os_dep/linux/stdlib.py
+++ b/test/os_dep/linux/stdlib.py
@@ -7,10 +7,12 @@ from miasm.analysis.machine import Machine
 import miasm.os_dep.linux_stdlib as stdlib
 from miasm.core.utils import pck32
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
+from miasm.core.locationdb import LocationDB
 
 machine = Machine("x86_32")
 
-jit = machine.jitter()
+loc_db = LocationDB()
+jit = machine.jitter(loc_db)
 jit.init_stack()
 
 heap = stdlib.linobjs.heap

--- a/test/os_dep/linux/test_env.py
+++ b/test/os_dep/linux/test_env.py
@@ -5,6 +5,7 @@ from pdb import pm
 from miasm.analysis.binary import Container
 from miasm.analysis.sandbox import Sandbox_Linux_x86_32, Sandbox_Linux_x86_64,\
     Sandbox_Linux_arml, Sandbox_Linux_aarch64l
+from miasm.core.locationdb import LocationDB
 
 if len(sys.argv) < 2:
     print("Usage: %s <arch> ..." % sys.argv[0])
@@ -29,7 +30,8 @@ parser.add_argument("filename", help="ELF Filename")
 options = parser.parse_args(sys.argv[2:])
 
 # Create sandbox
-sb = sandbox(options.filename, options, globals())
+loc_db = LocationDB()
+sb = sandbox(loc_db, options.filename, options, globals())
 
 # Run
 sb.run()

--- a/test/os_dep/win_api_x86_32.py
+++ b/test/os_dep/win_api_x86_32.py
@@ -9,10 +9,12 @@ import miasm.os_dep.win_api_x86_32 as winapi
 from miasm.os_dep.win_api_x86_32 import get_win_str_a, get_win_str_w
 from miasm.core.utils import pck32
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
+from miasm.core.locationdb import LocationDB
 
 machine = Machine("x86_32")
 
-jit = machine.jitter()
+loc_db = LocationDB()
+jit = machine.jitter(loc_db)
 jit.init_stack()
 
 heap = winapi.winobjs.heap


### PR DESCRIPTION
The `LocationDB` in Miasm everywhere: IR, loader, sandbox, ...
If some code share locations (`loc_key`), for example between the `IRCFG` and the `AsmCFG`, those locations *must absolutely* be part of the *same* `LocationDB`. If not, this may fail in a terrible and undetectable way. I mean, in a ghostbusters style, like "don't cross the streams" (https://www.youtube.com/watch?v=wyKQe_i9yyo)

The problem was that in Miasm, some objects take a `LocationDB` in their constructors, and some take an *optional* `LocationDB`. In the last case, the object was creating a new `locationDB` which must be used later.

This behavior is bad, as the user never really know when he has to create a `LocationDB` or where he has to find a default created one.

This PR fixes this behavior. No more object in Miasm will create a default `LocationDB`. If the `LocationDB` is needed, it will be explicit in the  object's constructor.

This will avoid #1268 #1129 #873 
Fixes #1268 