### PR TITLE
Add offset() to miasm.core.asmblock.AsmBlock

### DIFF
--- a/miasm/core/asmblock.py
+++ b/miasm/core/asmblock.py
@@ -117,6 +117,15 @@ class AsmBlock(object):
     def addline(self, l):
         self.lines.append(l)
 
+    def offset(self):
+        """
+        returns the offset (as int) of the first line in the block
+        """
+        try:
+            return min(line.offset for line in block.lines)
+        except ValueError:
+            return None
+
     def addto(self, c):
         assert isinstance(self.bto, set)
         self.bto.add(c)


### PR DESCRIPTION
I find myself calculating the offset of a block often with a code like `block.lines[0].offset`, which doesn't look really nice. I can write an `offset()` method in my code, but I think this function belongs to miasm. Can `miasm.core.asmblock.AsmBlock` have an `offset()` method/attribute? 🙏 

![please](https://media.giphy.com/media/Q94xQWspTUkShljj8P/giphy.gif)

I have implemented the function with `min([line.offset for line in block.lines])` instead of `block.lines[0].offset`, because I think new lines could be added at the front with `addline()` and the lines wouldn't be ordered in that case.