### PR TITLE
Add cntleadzeroes, cnttrailzeroes call operators

### DIFF
--- a/miasm/ir/translators/python.py
+++ b/miasm/ir/translators/python.py
@@ -85,6 +85,9 @@ class TranslatorPython(Translator):
 
             return "((%s | %s) &0x%x)" % (part1, part2, int(expr.mask))
 
+        elif expr.op in ['cntleadzeros', 'cnttrailzeros']:
+            return "%s(0x%x, %s)" % (expr.op, expr.args[0].size, self.from_expr(arg))
+
         raise NotImplementedError("Unknown operator: %s" % expr.op)
 
     def from_ExprAssign(self, expr):


### PR DESCRIPTION
With this patch the python IR translator when reaches a 'cntleadzeros' or a 'cnttrailzeros' converts them in a call to a function with tha same name as the operator

cntleadzeors -> cntleadzeros(size, arg)
cnttrailzeros -> cnttrailzeros(size, arg) 