### PR TITLE
Fix lift AsmBadBlock

### DIFF
--- a/miasm/ir/ir.py
+++ b/miasm/ir/ir.py
@@ -539,7 +539,7 @@ class IRCFG(DiGraph):
             }
         )
         if node not in self._blocks:
-            yield [self.DotCellDescription(text="NOT PRESENT", attr={})]
+            yield [self.DotCellDescription(text="NOT PRESENT", attr={'bgcolor': 'red'})]
             return
         for i, assignblk in enumerate(self._blocks[node]):
             for dst, src in viewitems(assignblk):

--- a/miasm/ir/ir.py
+++ b/miasm/ir/ir.py
@@ -25,7 +25,7 @@ from future.utils import viewvalues, viewitems
 
 import miasm.expression.expression as m2_expr
 from miasm.expression.expression_helper import get_missing_interval
-from miasm.core.asmblock import AsmBlock, AsmConstraint
+from miasm.core.asmblock import AsmBlock, AsmBlockBad, AsmConstraint
 from miasm.core.graph import DiGraph
 from functools import reduce
 
@@ -806,6 +806,9 @@ class IntermediateRepresentation(object):
 
         loc_key = block.loc_key
         ir_blocks_all = []
+
+        if isinstance(block, AsmBlockBad):
+            return ir_blocks_all
 
         assignments = []
         for instr in block.lines:


### PR DESCRIPTION
When adding an AsmBlockBad in an IRCFG, the result was:
![ir_bug](https://user-images.githubusercontent.com/9433661/95480689-7badef00-098c-11eb-9210-c539f2793818.png)
This was due to the add of a dummy block ir in, which was linked to an unknown `loc_key` created for the case.
The fix gives:
![ir_fixed](https://user-images.githubusercontent.com/9433661/95480791-997b5400-098c-11eb-8d01-d36cec284769.png)
