### PR TITLE
[AARCH64] fix 'ldp' disas ; remove duplicate 'umsubh'

### DIFF
--- a/miasm/arch/aarch64/arch.py
+++ b/miasm/arch/aarch64/arch.py
@@ -2028,8 +2028,8 @@ bs_ldstp_name = bs_name(l=1, name=ldstp_name)
 aarch64op("ldstp", [sf, bs('0'), bs('101'), bs('0'), bs('0'), post_pre, bs('1'), bs_ldstp_name, simm7, rt2, rn64_deref_sf, rt], [rt, rt2, rn64_deref_sf])
 aarch64op("ldstp", [sf, bs('0'), bs('101'), bs('0'), bs('0'), bs('1'), bs('0'), bs_ldstp_name, simm7, rt2, rn64_deref_sf, rt], [rt, rt2, rn64_deref_sf])
 
-aarch64op("ldstp", [sdsize, bs('101'), bs('1'), bs('0'), post_pre, bs('1'), bs_ldstp_name, uimm7, sd2, rn64_deref_sd, sd1], [sd1, sd2, rn64_deref_sd])
-aarch64op("ldstp", [sdsize, bs('101'), bs('1'), bs('0'), bs('1'), bs('0'), bs_ldstp_name, uimm7, sd2, rn64_deref_sd, sd1], [sd1, sd2, rn64_deref_sd])
+aarch64op("ldstp", [sdsize, bs('101'), bs('1'), bs('0'), post_pre, bs('1'), bs_ldstp_name, simm7, sd2, rn64_deref_sd, sd1], [sd1, sd2, rn64_deref_sd])
+aarch64op("ldstp", [sdsize, bs('101'), bs('1'), bs('0'), bs('1'), bs('0'), bs_ldstp_name, simm7, sd2, rn64_deref_sd, sd1], [sd1, sd2, rn64_deref_sd])
 
 
 # data process p.207
@@ -2123,8 +2123,6 @@ aarch64op("msub",  [sf, bs('00'), bs('11011'), bs('000'), rm, bs('1'), ra, rn, r
 
 aarch64op("umulh", [bs('1'), bs('00'), bs('11011'), bs('110'), rm64, bs('0'), bs('11111'), rn64, rd64], [rd64, rn64, rm64])
 aarch64op("smulh", [bs('1'), bs('00'), bs('11011'), bs('010'), rm64, bs('0'), bs('11111'), rn64, rd64], [rd64, rn64, rm64])
-aarch64op("umsubh",[bs('1'), bs('00'), bs('11011'), bs('101'), rm32, bs('1'), ra64, rn32, rd64], [rd64, rn32, rm32, ra64])
-
 
 aarch64op("smaddl",[bs('1'), bs('00'), bs('11011'), bs('001'), rm32, bs('0'), ra64, rn32, rd64], [rd64, rn32, rm32, ra64])
 aarch64op("umaddl",[bs('1'), bs('00'), bs('11011'), bs('101'), rm32, bs('0'), ra64, rn32, rd64], [rd64, rn32, rm32, ra64])


### PR DESCRIPTION
Hello,

I noticed that some disassembly of ldp/stp was wrong, as the imm7 parameter is sometimes treated as unsigned as it should be always treated as signed for 'PRE' / 'POST' / 'SIGNED' classes.

Normally the 'signed' class will sign extend on the data read from mem : I didn't fix the semantic, as the 'opc' parameter seems not available when 'ldp' is called inside 'sem.py', or did I miss something?

Here is the fix at least for the disassembly, 'imm7' is always treated as signed.

Example for 'ldp', that was outputing a wrong disassembly:

```python
from __future__ import print_function
from miasm.analysis.binary import Container
from miasm.analysis.machine import Machine
from miasm.core.locationdb import LocationDB

instrs = b"\xA1\x83\x7C\xAD"        # LDP             Q1, Q0, [X29,#-0x70]
instrs += b"\xC0\x03\x5F\xD6"       # RET

loc_db = LocationDB()
cont = Container.from_string(instrs, loc_db)
machine = Machine("aarch64l")
mdis = machine.dis_engine(cont.bin_stream, loc_db=loc_db)
asm_block = mdis.dis_block(0)
print(asm_block)
```

And also I notice that there a duplicate aarch64op for 'umsubl' and 'umsubh', but 'umsubh' doesn't even exist.

Example for 'umsubl', that throw the duplicate operation:

```python
instrs = b"\xa3\xa4\xa2\x9b"        # UMSUBL          X3, W5, W2, X9
instrs += b"\xC0\x03\x5F\xD6"       # RET

loc_db = LocationDB()
cont = Container.from_string(instrs, loc_db)
machine = Machine("aarch64l")
mdis = machine.dis_engine(cont.bin_stream, loc_db=loc_db)
asm_block = mdis.dis_block(0)
print(asm_block)
```
Thx,