### PR TITLE
Fix propagate undef

### DIFF
--- a/miasm/analysis/data_flow.py
+++ b/miasm/analysis/data_flow.py
@@ -1971,10 +1971,6 @@ class State(object):
             if not self.propagation_allowed(src):
                 continue
 
-            ## Dont create equivalence if dependence on undef
-            if dst.is_mem() and self.may_interfer(self.undefined, dst.ptr):
-                continue
-
             self.undefined.discard(dst)
             if dst in self.equivalence_classes.nodes():
                 self.equivalence_classes.del_element(dst)


### PR DESCRIPTION
Let A and B undef.
If we have:
X = [A]
X and [A] can be set in the same equivalence class (even if A and B are
undef)