### PR TITLE
docs: fix simple typo, corresponoding -> corresponding

### DIFF
--- a/miasm/expression/parser.py
+++ b/miasm/expression/parser.py
@@ -73,7 +73,7 @@ expr_aff.setParseAction(lambda t: ExprAssign(*t))
 
 
 def str_to_expr(str_in):
-    """Parse the @str_in and return the corresponoding Expression
+    """Parse the @str_in and return the corresponding Expression
     @str_in: repr string of an Expression"""
 
     try:


### PR DESCRIPTION
There is a small typo in miasm/expression/parser.py.

Should read `corresponding` rather than `corresponoding`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md