### PR TITLE
simp_compose_and_mask improvements

### DIFF
--- a/miasm/expression/simplifications_common.py
+++ b/miasm/expression/simplifications_common.py
@@ -1753,19 +1753,38 @@ def simp_compose_and_mask(_, expr):
     if not arg2.is_int():
         return expr
     int2 = int(arg2)
-    if (int2 + 1) & int2 != 0:
-        return expr
-    mask_size = int2.bit_length() + 7 // 8
+    mask_size = (int2.bit_length() + 7) // 8 * 8
+    if int2 == int(arg1.mask):
+        return arg1
     out = []
+    mask_needed = False
     for offset, arg in arg1.iter_args():
         if offset == mask_size:
-            return ExprCompose(*out).zeroExtend(expr.size)
-        elif mask_size > offset and mask_size < offset+arg.size and arg.is_int():
-            out.append(ExprSlice(arg, 0, mask_size-offset))
-            return ExprCompose(*out).zeroExtend(expr.size)
+            break
         else:
-            out.append(arg)
-    return expr
+            if offset < mask_size < offset+arg.size:
+                arg = ExprSlice(arg, 0, mask_size-offset)
+
+            arg_mask = (int(arg.mask) << offset)
+            if int2 & arg_mask != 0:
+                out.append(arg)
+                if int2 & arg_mask != arg_mask:
+                    mask_needed = True
+            elif mask_size > offset + arg.size:
+                out.append(ExprInt(0, arg.size))
+
+            if mask_size <= offset + arg.size:
+                break
+
+    if len(out) == 0:
+        return ExprInt(0, expr.size)
+    else:
+        result = out[0] if len(out) == 1 else ExprCompose(*out)
+        if result.size != expr.size:
+            result = result.zeroExtend(expr.size)
+        if mask_needed:
+            result = result & arg2
+        return result
 
 def simp_bcdadd_cf(_, expr):
     """bcdadd(const, const) => decimal"""

--- a/miasm/expression/simplifications_common.py
+++ b/miasm/expression/simplifications_common.py
@@ -1779,15 +1779,10 @@ def simp_compose_and_mask(_, expr):
     if len(out) == 0:
         return ExprInt(0, expr.size)
     else:
-        if len(out) == 1:
-            result = out[0]
-            if result.size != expr.size:
-                result = result.zeroExtend(expr.size)
-        else:
-            size = sum(arg.size for arg in out)
-            if size != expr.size:
-                out.append(ExprInt(0, expr.size - size))
-            result = ExprCompose(*out)
+        size = sum(arg.size for arg in out)
+        if size != expr.size:
+            out.append(ExprInt(0, expr.size - size))
+        result = ExprCompose(*out)
         if mask_needed:
             result = result & arg2
         return result

--- a/miasm/expression/simplifications_common.py
+++ b/miasm/expression/simplifications_common.py
@@ -1741,19 +1741,38 @@ def simp_compose_and_mask(_, expr):
     if not arg2.is_int():
         return expr
     int2 = int(arg2)
-    if (int2 + 1) & int2 != 0:
-        return expr
-    mask_size = int2.bit_length() + 7 // 8
+    mask_size = (int2.bit_length() + 7) // 8 * 8
+    if int2 == int(arg1.mask):
+        return arg1
     out = []
+    mask_needed = False
     for offset, arg in arg1.iter_args():
         if offset == mask_size:
-            return ExprCompose(*out).zeroExtend(expr.size)
-        elif mask_size > offset and mask_size < offset+arg.size and arg.is_int():
-            out.append(ExprSlice(arg, 0, mask_size-offset))
-            return ExprCompose(*out).zeroExtend(expr.size)
+            break
         else:
-            out.append(arg)
-    return expr
+            if offset < mask_size < offset+arg.size:
+                arg = ExprSlice(arg, 0, mask_size-offset)
+
+            arg_mask = (int(arg.mask) << offset)
+            if int2 & arg_mask != 0:
+                out.append(arg)
+                if int2 & arg_mask != arg_mask:
+                    mask_needed = True
+            elif mask_size > offset + arg.size:
+                out.append(ExprInt(0, arg.size))
+
+            if mask_size <= offset + arg.size:
+                break
+
+    if len(out) == 0:
+        return ExprInt(0, expr.size)
+    else:
+        result = out[0] if len(out) == 1 else ExprCompose(*out)
+        if result.size != expr.size:
+            result = result.zeroExtend(expr.size)
+        if mask_needed:
+            result = result & arg2
+        return result
 
 def simp_bcdadd_cf(_, expr):
     """bcdadd(const, const) => decimal"""

--- a/test/expression/simplifications.py
+++ b/test/expression/simplifications.py
@@ -368,6 +368,19 @@ to_test = [(ExprInt(1, 32) - ExprInt(1, 32), ExprInt(0, 32)),
                  ExprInt(0x1, 32),
                  ExprInt(0x0, 32))
        ),
+   (ExprCompose(a[:8],b[:8],c[:8],d[:8])
+                &
+                ExprInt(0xA000B000, 32),
+    ExprCompose(ExprInt(0,8), b[:8], ExprInt(0,8), d[:8]) &
+        ExprInt(0xA000B000, 32)
+      ),
+
+    (ExprCompose(a[:8],b[:8],c[:8],d[:8])
+            &
+            ExprInt(0xFF00FF00, 32),
+     ExprCompose(ExprInt(0,8), b[:8], ExprInt(0,8), d[:8])
+       ),
+
     (ExprCompose(a[:16], b[:16])[8:32],
      ExprCompose(a[8:16], b[:16])),
     ((a >> ExprInt(16, 32))[:16],


### PR DESCRIPTION
this PR simplifies masked `ExprCompose` objects by removing parts of the expression that are always zero in the result. It also removes the mask if the mask is not needed. I found some cases where this is desirable:

```
X = {@16[...] 0 16, X[16:32] 16 32} & 0x1000 
--> 
X = {@16[...] 0 16, 0x0 16 32} & 0x1000
```

```
IRDst = ({fcom_c0(...) 0 1, fcom_c1(...) 1 2, fcom_c2(...) 2 3, float_stack_ptr 3 6, fcom_c3(...) 6 7, 0x0 7 8} & 0x41)?(loc_1ec5,loc_1ece)
--> 
IRDst = {fcom_c0(...) 0 1, fcom_c3(...) 1 2}?(loc_1ec5,loc_1ece)
```