### PR TITLE
Add future to install_requires in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -242,6 +242,7 @@ def buil_all():
                         "VERSION"
                     ]
                 },
+                install_requires=['future', 'pyparsing'],
                 cmdclass={"install_data": smart_install_data},
                 ext_modules = ext_modules,
                 # Metadata


### PR DESCRIPTION
The future library is used in `miasm/core/bin_stream.py`: `from future.utils import PY3`

When running miasm (with Python 3.9.1) without future installed, I get the following error:
`ModuleNotFoundError: No module named 'future'`

I assume that future needs to be installed to run miasm (and consequently needs to be added to the dependencies). Or am I doing something wrong?