### PR TITLE
Fix Dockerfile (UnicodeEncodeError)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,20 +18,33 @@ FROM debian:buster
 LABEL maintainer="Camille Mougey <commial@gmail.com>"
 
 # Download needed packages
-RUN apt-get -qq update && \
-    apt-get -qqy install python python3 libpython-dev libpython3-dev python-pyparsing python3-pyparsing python-pip python3-pip && \
-    apt-get -qqy install gcc g++ && \
-    apt-get -qq clean
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gcc \
+        g++ \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /root/.cache
 
-# Get miasm
-ADD . /opt/miasm
-RUN cd /opt/miasm && \
-    pip install -r requirements.txt && \
-    pip install -r optional_requirements.txt && \
-    pip install . && \
-    pip3 install -r requirements.txt && \
-    pip3 install -r optional_requirements.txt && \
-    pip3 install .
+WORKDIR /opt/miasm
+
+# Install Requirements
+COPY requirements.txt /opt/miasm/requirements.txt
+RUN pip3 install -r requirements.txt
+COPY optional_requirements.txt /opt/miasm/optional_requirements.txt
+RUN pip3 install -r optional_requirements.txt
+
+# Install miasm
+COPY README.md /opt/miasm/README.md
+COPY setup.py /opt/miasm/setup.py
+COPY miasm /opt/miasm/miasm
+RUN pip3 install .
+
+# Get everything else
+COPY . /opt/miasm
 
 # Set user
 RUN useradd miasm && \
@@ -40,4 +53,4 @@ USER miasm
 
 # Default cmd
 WORKDIR /opt/miasm/test
-CMD ["/bin/bash", "-c", "for v in 2 3; do /usr/bin/python$v test_all.py -m; done"]
+CMD ["/bin/bash", "-c", "/usr/bin/python3 test_all.py -m"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # along with Miasm-Docker. If not, see <http://www.gnu.org/licenses/>.
 
 FROM debian:buster
-MAINTAINER Camille Mougey <commial@gmail.com>
+LABEL maintainer="Camille Mougey <commial@gmail.com>"
 
 # Download needed packages
 RUN apt-get -qq update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Miasm-Docker. If not, see <http://www.gnu.org/licenses/>.
 
-FROM debian:stretch
+FROM debian:buster
 MAINTAINER Camille Mougey <commial@gmail.com>
 
 # Download needed packages


### PR DESCRIPTION
The python3 version that comes with stretch does not like accented characters, `docker build .` results in:
``` pytb
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/pip-oosab_wh-build/setup.py", line 344, in <module>
    buil_all()
  File "/tmp/pip-oosab_wh-build/setup.py", line 269, in buil_all
    url = "http://miasm.re",
  File "/usr/lib/python3.5/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.5/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.5/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/usr/lib/python3/dist-packages/setuptools/command/egg_info.py", line 272, in run
    writer(self, ep.name, os.path.join(self.egg_info, ep.name))
  File "/usr/lib/python3/dist-packages/setuptools/command/egg_info.py", line 600, in write_pkg_info
    metadata.write_pkg_info(cmd.egg_info)
  File "/usr/lib/python3.5/distutils/dist.py", line 1107, in write_pkg_info
    self.write_pkg_file(pkg_info)
  File "/tmp/pip-oosab_wh-build/setup.py", line 328, in _write_pkg_file
    _write_pkg_file_orig(self, tmpfd)
  File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 56, in write_pkg_file
    file.write('Description: %s\n' % long_desc)
UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in position 24661: ordinal not in range(128)
```
`long_desc` is read from `README.md` in `setup.py`.

Updating the Dockerfile to use buster instead fixed the issue, but then I got carried away...
Feel free to cherry pick whatever you deem suitable.


