### PR TITLE
Updated IDA API call for IDA 7.x

### DIFF
--- a/example/ida/utils.py
+++ b/example/ida/utils.py
@@ -46,7 +46,7 @@ def guess_machine(addr=None):
         # Default is arm
         is_armt = False
         if addr is not None:
-            t_reg = GetReg(addr, "T")
+            t_reg = get_sreg(addr, "T")
             is_armt = t_reg == 1
 
         is_bigendian = info.is_be()


### PR DESCRIPTION
`idc.GetReg` API call is changed to `idc.get_sreg` in IDA 7.x

https://hex-rays.com/products/ida/support/ida74_idapython_no_bc695_porting_guide.shtml