### PR TITLE
x86_64 Fix multiple REX prefix instruction disasm

### DIFF
--- a/miasm/arch/x86/arch.py
+++ b/miasm/arch/x86/arch.py
@@ -751,14 +751,18 @@ class mn_x86(cls_mn):
                 break
             pre_dis_info['prefix'] += c
             offset += 1
-        if mode == 64 and c in b'@ABCDEFGHIJKLMNO':
-            x = ord(c)
+        rex_prefixes = b'@ABCDEFGHIJKLMNO'
+        if mode == 64 and c in rex_prefixes:
+            while c in rex_prefixes:
+                # multiple REX prefixes case - use last REX prefix
+                x = ord(c)
+                offset += 1
+                c = v.getbytes(offset)
             pre_dis_info['rex_p'] = 1
             pre_dis_info['rex_w'] = (x >> 3) & 1
             pre_dis_info['rex_r'] = (x >> 2) & 1
             pre_dis_info['rex_x'] = (x >> 1) & 1
             pre_dis_info['rex_b'] = (x >> 0) & 1
-            offset += 1
         elif pre_dis_info.get('g1', None) == 12 and c in [b'\xa6', b'\xa7', b'\xae', b'\xaf']:
             pre_dis_info['g1'] = 4
         return pre_dis_info, v, mode, offset, offset - offset_o

--- a/setup.py
+++ b/setup.py
@@ -324,7 +324,7 @@ _write_pkg_file_orig = DistributionMetadata.write_pkg_file
 
 
 def _write_pkg_file(self, file):
-    with TemporaryFile(mode="w+", encoding="utf-8") as tmpfd:
+    with TemporaryFile(mode="w+") as tmpfd:
         _write_pkg_file_orig(self, tmpfd)
         tmpfd.seek(0)
         for line in tmpfd:

--- a/setup.py
+++ b/setup.py
@@ -324,7 +324,7 @@ _write_pkg_file_orig = DistributionMetadata.write_pkg_file
 
 
 def _write_pkg_file(self, file):
-    with TemporaryFile(mode="w+") as tmpfd:
+    with TemporaryFile(mode="w+", encoding="utf-8") as tmpfd:
         _write_pkg_file_orig(self, tmpfd)
         tmpfd.seek(0)
         for line in tmpfd:

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -3125,6 +3125,8 @@ reg_tests = [
      "f30f1efa"),
     (m32, "00000000    ENDBR32",
      "f30f1efb"),
+    (m64, "00000000    MOV        QWORD PTR ES:[RAX], RDX",
+     "26488910"),
 ]
 
 
@@ -3201,3 +3203,8 @@ cProfile.run('profile_dis(o)')
 instr_bytes = b'\x65\xc7\x00\x09\x00\x00\x00'
 inst = mn_x86.dis(instr_bytes, 32, 0)
 assert(inst.b == instr_bytes)
+
+# Test multiple REX prefixes
+for i in range(1, 3):
+    mn = mn_x86.dis(b'\x26' + b'\x48' * i + b'\x89\x10', 64)
+    assert (str(mn).strip() == 'MOV        QWORD PTR ES:[RAX], RDX')

--- a/test/arch/x86/arch.py
+++ b/test/arch/x86/arch.py
@@ -3205,6 +3205,6 @@ inst = mn_x86.dis(instr_bytes, 32, 0)
 assert(inst.b == instr_bytes)
 
 # Test multiple REX prefixes
-for i in range(1, 3):
+for i in range(1, 4):
     mn = mn_x86.dis(b'\x26' + b'\x48' * i + b'\x89\x10', 64)
     assert (str(mn).strip() == 'MOV        QWORD PTR ES:[RAX], RDX')


### PR DESCRIPTION
Example of problem instruction `mov qword ptr es:[rax], rdx` (`26 48 48 89 10` in hex where `48` is REX prefix)
Issue: https://github.com/cea-sec/miasm/issues/1375