### PR TITLE
ci: pin pyparsing dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.6']
+        python-version: ['2.7', '3.6', '3.8']
 
     steps:
 
@@ -18,6 +18,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Update pip
+      run: pip install pip --upgrade
 
     - name: Install requirements
       run: pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyparsing
+pyparsing~=2.0
 future

--- a/setup.py
+++ b/setup.py
@@ -242,7 +242,7 @@ def buil_all():
                         "VERSION"
                     ]
                 },
-                install_requires=['future', 'pyparsing'],
+                install_requires=['future', 'pyparsing~=2.0'],
                 cmdclass={"install_data": smart_install_data},
                 ext_modules = ext_modules,
                 # Metadata


### PR DESCRIPTION
While testing with Python 3.9, tests were failing because of breaking changes in version 3 of pyparsing. Therefore the dependency on pyparsing should be pinned to ~=2.0 for now.