### PR TITLE
Implement syscall handler for mips32b + minimal Linux environment

### DIFF
--- a/miasm/arch/mips32/jit.py
+++ b/miasm/arch/mips32/jit.py
@@ -135,6 +135,17 @@ class jitter_mips32l(Jitter):
             arg = self.get_stack_arg(index-4)
         return arg
 
+    def syscall_args_systemv(self, n_args):
+        # Documentation: http://man7.org/linux/man-pages/man2/syscall.2.html
+        # mips/o32      a0    a1    a2    a3    stack
+        args = [self.get_arg_n_stdcall(i) for i in range(n_args)]
+        return args
+
+    def syscall_ret_systemv(self, value1, value2, error):
+        # Documentation: http://man7.org/linux/man-pages/man2/syscall.2.html
+        self.cpu.V0 = value1
+        self.cpu.V1 = value2
+        self.cpu.A3 = error  # 0 -> no error, -1 -> error
 
     func_args_systemv = func_args_stdcall
     func_ret_systemv = func_ret_stdcall

--- a/miasm/arch/mips32/sem.py
+++ b/miasm/arch/mips32/sem.py
@@ -3,7 +3,7 @@ from miasm.ir.ir import Lifter, IRBlock, AssignBlock
 from miasm.arch.mips32.arch import mn_mips32
 from miasm.arch.mips32.regs import R_LO, R_HI, PC, RA, ZERO, exception_flags
 from miasm.core.sembuilder import SemBuilder
-from miasm.jitter.csts import EXCEPT_DIV_BY_ZERO, EXCEPT_SOFT_BP
+from miasm.jitter.csts import EXCEPT_DIV_BY_ZERO, EXCEPT_SOFT_BP, EXCEPT_SYSCALL
 
 
 # SemBuilder context
@@ -400,6 +400,11 @@ def break_(ir, instr):
     e.append(m2_expr.ExprAssign(exception_flags, m2_expr.ExprInt(EXCEPT_SOFT_BP, 32)))
     return e, []
 
+def syscall(ir, instr, code):
+    e = []
+    e.append(m2_expr.ExprAssign(exception_flags, m2_expr.ExprInt(EXCEPT_SYSCALL, 32)))
+    return e, []
+
 def ins(ir, instr, a, b, c, d):
     e = []
     pos = int(c)
@@ -611,6 +616,7 @@ mnemo_func.update(
         'break': break_,
         'sb': sb,
         'sh': sh,
+        'syscall': syscall,
     }
 )
 

--- a/miasm/os_dep/linux/environment.py
+++ b/miasm/os_dep/linux/environment.py
@@ -710,6 +710,11 @@ class LinuxEnvironment_arml(LinuxEnvironment):
     kuser_helper_version = 3
 
 
+class LinuxEnvironment_mips32b(LinuxEnvironment):
+    platform_arch = b"mips32b"
+    sys_machine = b"mips32b"
+
+
 class AuxVec(object):
     """Auxiliary vector abstraction, filled with default values
     (mainly based on https://lwn.net/Articles/519085)


### PR DESCRIPTION
Hello,

As mentioned in the title, this PR aims to implement a minimalist Linux environment for the mips32b architecture in order to handle syscalls.

There is also an implementation of the `socket` syscall (to give an example). 