### PR TITLE
Incorrect usage in shellcode.py --help

### DIFF
--- a/example/asm/shellcode.py
+++ b/example/asm/shellcode.py
@@ -13,7 +13,7 @@ from miasm.core.interval import interval
 from miasm.core.locationdb import LocationDB
 from miasm.core.utils import iterbytes, int_to_byte
 
-parser = ArgumentParser("Multi-arch (32 bits) assembler")
+parser = ArgumentParser(description="Multi-arch (32 bits) assembler")
 parser.add_argument('architecture', help="architecture: " +
                     ",".join(Machine.available_machine()))
 parser.add_argument("source", help="Source file to assemble")


### PR DESCRIPTION
The first argument to ArgumentParser is the program name, not the description. The previous version displayed invalid usage in the help command:
```
usage: Multi-arch (32 bits) assembler [-h] [--PE] [-e ENCRYPT ENCRYPT] architecture source output
```

The new version displays the correct usage:
```
usage: shellcode.py [-h] [--PE] [-e ENCRYPT ENCRYPT] architecture source output

Multi-arch (32 bits) assembler
```