### PR TITLE
Minor Generic Dominator Calculation Algorithm Optimization

### DIFF
--- a/miasm/core/graph.py
+++ b/miasm/core/graph.py
@@ -416,14 +416,10 @@ class DiGraph(object):
             dominators[node] = set(nodes)
 
         dominators[head] = set([head])
-        todo = set(nodes)
+        todo = set([succ for succ in next_cb(head)])
 
         while todo:
             node = todo.pop()
-
-            # Heads state must not be changed
-            if node == head:
-                continue
 
             # Compute intersection of all predecessors'dominators
             new_dom = None
@@ -446,6 +442,7 @@ class DiGraph(object):
             dominators[node] = new_dom
             for succ in next_cb(node):
                 todo.add(succ)
+
         return dominators
 
     def compute_dominators(self, head):


### PR DESCRIPTION
The generic dominator calculation algorithm used to set the initial `todo` set to be just all the nodes. This leads to redundant calculations since:
1. The head node will always be ignored by the loop, and will not be added to the `todo` otherwise - the algorithm adds to the `todo` set only successors, and by definition, the head can never be a successor of any node in the graph. Thus, by removing it from the initial `todo` set, we can get rid of this specific case handling.
2. The loop tries to see if the dominators of the current node have changed by intersecting the dominators of every preceding node. Since the initial dominator set of all nodes is always the entire node set, except for the head node, whose dominator set is `set([head])`, this intersection calculation will always return the entire node set for all nodes except the successors of the head node. Therefore, we can prevent this waste of cycles by setting the initial `todo` set to contain only them.