### PR TITLE
[x86] add missing Expression EIP when using address-size prefix for RIP-relative addressing

### DIFF
--- a/miasm/arch/x86/regs.py
+++ b/miasm/arch/x86/regs.py
@@ -26,7 +26,7 @@ regs16_str = ["AX", "CX", "DX", "BX", "SP", "BP", "SI", "DI"] + \
 regs16_expr = [ExprId(x, 16) for x in regs16_str]
 
 regs32_str = ["EAX", "ECX", "EDX", "EBX", "ESP", "EBP", "ESI", "EDI"] + \
-    ["R%dD" % (i + 8) for i in range(8)]
+    ["R%dD" % (i + 8) for i in range(8)] + ["EIP"]
 regs32_expr = [ExprId(x, 32) for x in regs32_str]
 
 regs64_str = ["RAX", "RCX", "RDX", "RBX", "RSP", "RBP", "RSI", "RDI",


### PR DESCRIPTION
Hello,

I encountered the following exception:

```
[...]
  File "XXX\miasm\core\cpu.py", line 1257, in dis
    ret = f.decode(todo[i])
  File "XXX\miasm\arch\x86\arch.py", line 2265, in decode
    expr = modrm2expr(xx, p, 1)
  File "XXX\miasm\arch\x86\arch.py", line 1977, in modrm2expr
    expr = size2gpregs[admode].expr[modrm_k]
IndexError: list index out of range
```

While trying to disassemble the following bytecodes : ``67 83 05 90 00 00 00 42`` (note the usage of the prefix ``0x67`` -> Address-size override prefix).

Script example to reproduce the issue:

```python
from __future__ import print_function
from miasm.analysis.binary import Container
from miasm.analysis.machine import Machine
from miasm.core.locationdb import LocationDB

instrs = b"\x67\x83\x05\x90\x00\x00\x00\x42"
instrs += b"\xC3"

loc_db = LocationDB()
cont = Container.from_string(instrs, loc_db)
machine = Machine("x86_64")
mdis = machine.dis_engine(cont.bin_stream, loc_db=loc_db)
asm_block = mdis.dis_block(0)
print(asm_block)
```

Chapter ``2.2.1.6 RIP-Relative Addressing`` of Intel manual 2 when using `` Address-size override prefix``:

```
The use of the address-size prefix does not disable RIP-relative addressing.
The effect of the address-size prefix is to truncate and zero-extend the computed effective address to 32 bits.
```

The following PR fix the issue by adding the missing "EIP" register to the table ``regs32_str`` in ``x86/regs.py``.

Output after the fix:

```
loc_0
ADD        DWORD PTR [EIP + 0x90], 0x42
RET
```

Let me know what you think.

Thx,