### PR TITLE
CI: add support for Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,11 +25,14 @@ jobs:
     - name: Install requirements
       run: pip install -r requirements.txt
 
+    - name: Install llvm 8 (llvmlite compatible)
+      run: sudo apt-get install llvm-8
+
+    - name: Use llvm 8
+      run: sudo update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-8 1
+
     - name: Install optional requirements
       run: pip install -r optional_requirements.txt
-
-    - name: Install llvm
-      run: sudo apt-get install llvm
 
     - name: Install Miasm
       uses: ./.github/actions/install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.6', '3.8']
+        python-version: ['2.7', '3.6', '3.8', '3.10']
 
     steps:
 


### PR DESCRIPTION
This PR adds, in CI:
* Matrix test for Python 3.10
* use of LLVM 8 as expected by the currently used `llvmlite` version 