### PR TITLE
Create the build directory to fix `pip install` build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -296,6 +296,8 @@ def build_all():
         ext_modules_all = []
 
     print("building")
+    if not os.path.exists("build"):
+        os.mkdir("build")
     build_ok = False
     for name, ext_modules in [("all", ext_modules_all)]:
         print("build with", repr(name))


### PR DESCRIPTION
When using a `requirements.txt` like this:

```
graphviz~=0.20.1
z3-solver~=4.11.2.0
git+https://github.com/cea-sec/miasm@2b6c894aee49218bf8809531263a50b71a145405#egg=miasm
```

Running `pip install -r requirements.txt` will error because the `build` directory doesn't exist. This fixes that by creating the build directory if it doesn't exist yet.