### PR TITLE
Remove Python 2.7 from CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,18 +10,6 @@ environment:
     - platform: Win32
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PLATFORM_TOOLSET: v141
-      PYTHON: c:\Python27
-      PYTHON_VERSION: "2.7.x"
-
-    - platform: x64
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      PLATFORM_TOOLSET: v141
-      PYTHON: c:\Python27-x64
-      PYTHON_VERSION: "2.7.x"
-
-    - platform: Win32
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      PLATFORM_TOOLSET: v141
       PYTHON: c:\Python38
       PYTHON_VERSION: "3.8.x"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.6', '3.8', '3.10']
+        python-version: ['3.6', '3.8', '3.10']
 
     steps:
 
     - name: Git checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Use Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
It would be nice if Miasm could slowly migrate to more modern python (f-strings, type annotations). According to earlier discussions 2.7 isn't supported anymore so I took the liberty to remove it from CI.

Also a discussion about the minimal Python 3 version would be good. There's nice updates to typing in more recent versions.