### PR TITLE
Example: add a basic symbol_exec example

### DIFF
--- a/example/symbol_exec/symbol_exec.py
+++ b/example/symbol_exec/symbol_exec.py
@@ -1,0 +1,49 @@
+from __future__ import print_function
+from argparse import ArgumentParser
+
+from future.utils import viewvalues
+from miasm.analysis.binary import Container
+from miasm.analysis.machine import Machine
+from miasm.core.locationdb import LocationDB
+from miasm.ir.symbexec import SymbolicExecutionEngine
+
+parser = ArgumentParser("Simple SymbolicExecution demonstrator")
+parser.add_argument("target_binary", help="Target binary path")
+parser.add_argument("--address", help="Starting address for emulation. If not set, use the entrypoint")
+parser.add_argument("--steps", help="Log emulation state after each instruction", action="store_true")
+options = parser.parse_args()
+
+###################################################################
+# Common section from example/disam/dis_binary_lift_model_call.py #
+###################################################################
+
+fdesc = open(options.target_binary, 'rb')
+loc_db = LocationDB()
+
+cont = Container.from_stream(fdesc, loc_db)
+
+machine = Machine(cont.arch)
+
+mdis = machine.dis_engine(cont.bin_stream, loc_db=cont.loc_db)
+
+addr = cont.entry_point if options.address is None else int(options.address, 0)
+asmcfg = mdis.dis_multiblock(addr)
+
+lifter = machine.lifter_model_call(mdis.loc_db)
+ircfg = lifter.new_ircfg_from_asmcfg(asmcfg)
+
+#####################################
+#    End common section             #
+#####################################
+
+# Instantiate a Symbolic Execution engine with default value for registers
+symb = SymbolicExecutionEngine(lifter)
+
+# Emulate until the next address cannot be resolved (`ret`, unresolved condition, etc.)
+cur_addr = symb.run_at(ircfg, addr, step=options.steps)
+
+# Modified elements
+print('Modified registers:')
+symb.dump(mems=False)
+print('Modified memory (should be empty):')
+symb.dump(ids=False)

--- a/example/symbol_exec/symbol_exec.py
+++ b/example/symbol_exec/symbol_exec.py
@@ -26,7 +26,16 @@ machine = Machine(cont.arch)
 
 mdis = machine.dis_engine(cont.bin_stream, loc_db=cont.loc_db)
 
-addr = cont.entry_point if options.address is None else int(options.address, 0)
+# no address -> entry point
+# 0xXXXXXX -> use this address
+# symbol -> resolve then use
+if options.address is None:
+    addr = cont.entry_point
+else:
+    try:
+        addr = int(options.address, 0)
+    except ValueError:
+        addr = loc_db.get_name_offset(options.address)
 asmcfg = mdis.dis_multiblock(addr)
 
 lifter = machine.lifter_model_call(mdis.loc_db)

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -739,6 +739,7 @@ class ExampleSymbolExec(Example):
 
 
 testset += ExampleSymbolExec(["single_instr.py"])
+testset += ExampleSymbolExec(["symbol_exec.py", "--steps", Example.get_sample("box_upx.exe")])
 for options, nb_sol, tag in [([], 8, []),
                              (["-i", "--rename-args"], 12, [TAGS["z3"]])]:
     testset += ExampleSymbolExec(["depgraph.py",


### PR DESCRIPTION
Following the series of `dis_binary.py` and `dis_binary_lift*.py`, this PR adds a simple example to demonstrate `SymbolicExecution`:

```
$ python symbol_exec.py mystere_sub --address mystere1
Modified registers:
zf                 = ESP == 0x4
nf                 = (ESP + 0xFFFFFFFC)[31:32]
pf                 = parity((ESP + 0xFFFFFFFC) & 0xFF)
cf                 = ((((ESP + 0xFFFFFFF4) ^ (ESP + 0xFFFFFFFC)) & ((ESP + 0xFFFFFFF4) ^ 0xFFFFFFF7)) ^ (ESP + 0xFFFFFFF4) ^ (ESP + 0xFFFFFFFC) ^ 0x8)[31:32]
of                 = (((ESP + 0xFFFFFFF4) ^ (ESP + 0xFFFFFFFC)) & ((ESP + 0xFFFFFFF4) ^ 0xFFFFFFF7))[31:32]
af                 = ((ESP + 0xFFFFFFF4) ^ (ESP + 0xFFFFFFFC) ^ 0x8)[4:5]
EAX                = @32[ESP + 0x4] + @32[ESP + 0x8] + 0x1337
ECX                = -@32[ESP + 0x4] + -@32[ESP + 0x8] + 0xFFFFECD0
EDX                = @32[ESP + 0x4] + @32[ESP + 0x8] + 0x1337
ESP                = ESP + 0x4
EIP                = @32[ESP]
IRDst              = @32[ESP]
Modified memory (should be empty):
@32[ESP + 0xFFFFFFF4] = @32[ESP + 0x8]
@32[ESP + 0xFFFFFFF8] = @32[ESP + 0x4]
@32[ESP + 0xFFFFFFFC] = EBP
```

It provides a ready-to-fire script to emulate a sample at a given address, without proposing too much options.
This is done on purpose to avoid the boilerplate code handling every possible options, which decrease readability and "copy / pasting" possibilities.

The `single_instr.py` example does not follow the same API path: it first assemble, then manually translate only one `AsmBlock` instead of the general approach `Machine -> Container -> Disassembler -> Lifter`