### PR TITLE
Generic import recovery (cheap ImpRec style)

### DIFF
--- a/example/jitter/unpack_generic.py
+++ b/example/jitter/unpack_generic.py
@@ -1,0 +1,53 @@
+from __future__ import print_function
+import os
+import logging
+from miasm.analysis.sandbox import Sandbox_Win_x86_32
+from miasm.jitter.loader.pe import vm2pe, ImpRecStrategy
+from miasm.core.locationdb import LocationDB
+from miasm.jitter.jitload import JitterException
+
+parser = Sandbox_Win_x86_32.parser(description="Generic & dummy unpacker")
+parser.add_argument("filename", help="PE Filename")
+parser.add_argument("--oep", help="Stop and dump if this address is reached")
+parser.add_argument('-v', "--verbose",
+                    help="verbose mode", action="store_true")
+options = parser.parse_args()
+
+loc_db = LocationDB()
+sb = Sandbox_Win_x86_32(
+    loc_db, options.filename, options, globals(),
+    parse_reloc=False
+)
+
+if options.verbose is True:
+    logging.basicConfig(level=logging.INFO)
+else:
+    logging.basicConfig(level=logging.WARNING)
+
+if options.verbose is True:
+    print(sb.jitter.vm)
+
+def stop(jitter):
+    logging.info('User provided OEP reached')
+    # Stop execution
+    return False
+
+if options.oep:
+    # Set callbacks
+    sb.jitter.add_breakpoint(int(options.oep, 0), stop)
+    
+# Run until an error is encountered - IT IS UNLIKELY THE ORIGINAL ENTRY POINT
+try:
+    sb.run()
+except (JitterException, ValueError) as e:
+    logging.exception(e)
+
+out_fname = "%s.dump" % (options.filename)
+
+# Try a generic approach to rebuild the Import Table
+imprec = ImpRecStrategy(sb.jitter, sb.libs, 32)
+imprec.recover_import()
+
+# Rebuild the PE and dump it
+print("Dump to %s" % out_fname)
+vm2pe(sb.jitter, out_fname, libs=sb.libs, e_orig=sb.pe)

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -799,6 +799,12 @@ for jitter in ExampleJitter.jitter_engines:
                              products=[Example.get_sample("box_upx_exe_unupx.bin")],
                              tags=tags.get(jitter, []))
 
+    testset += ExampleJitter(["unpack_generic.py",
+                              Example.get_sample("box_upx.exe")] +
+                             ["--jitter", jitter, "-o"],
+                             products=[Example.get_sample("box_upx.exe.dump")],
+                             tags=tags.get(jitter, []))
+
     testset += ExampleJitter(["memory_breakpoint.py",
                               Example.get_sample("box_upx.exe")] +
                              ["--jitter", jitter] +


### PR DESCRIPTION
This PR adds:

- a `ImpRecStrategy` object using a FSM to recover import table in memory using a naive strategy (null-byte terminated continuation of same module export addresses)
- an example, `unpack_generic.py` using this strategy before dumping with `vm2pe`

This example is running the sandbox until it can't no more (exception, unknown API, etc.). It is very likely the OEP is not the address where it stopped, but it could be either a wave or close to the OEP. That way, dumping the binary at this state could a good way to obtain a binary which can be analyzed.

If the user is using a trace, such as `-b` and found a candidate OEP, it can stop the execution using the `--oep` argument.

For instance:
```bash
# First run
$ python unpack_generic.py ../samples/box_upx.exe -b -o
...
POPAD      
LEA        EAX, DWORD PTR [ESP + 0xFFFFFF80]
PUSH       0x0
CMP        ESP, EAX
JNZ        loc_4076f2
->	c_next:loc_4076f8 	c_to:loc_4076f2 
loc_4076f2
PUSH       0x0
CMP        ESP, EAX
JNZ        loc_4076f2
->	c_next:loc_4076f8 	c_to:loc_4076f2 
loc_4076f8
SUB        ESP, 0xFFFFFF80
JMP        loc_401130
->	c_to:loc_401130 
loc_401130
PUSH       EBP                            <----------- THIS IS LIKELY THE OEP
MOV        EBP, ESP
SUB        ESP, 0x14

# Second run
$ python unpack_generic.py ../samples/box_upx.exe -b -o --oep 0x401130
...
Dump to ../samples/box_upx.exe.dump
```

`box_upx.exe.dump` can be RE, with working import.


This basic strategy has only been tested on UPX and Aspack.

In the future, this example could be used to generically implement in Miasm few common strategies, such as:

- stopped when a previously written byte is executed
- stopped when the code jump from a section to another
- stopped when a `POPA` is reached
- stopped if the entropy of memory section is lower
- etc.

The goal is not to replace the analyst work, but rather to gain some time on common and dummy samples.
Obviously, in the future the strategy used by [Scylla](https://github.com/NtQuery/Scylla) would also been interesting to implement (using the jitter possibilities, faking import, etc.)