### PR TITLE
fix compilation on cygwin

### DIFF
--- a/miasm/runtime/int_lib.h
+++ b/miasm/runtime/int_lib.h
@@ -48,7 +48,7 @@
 #define XSTR(a) STR(a)
 #define SYMBOL_NAME(name) XSTR(__USER_LABEL_PREFIX__) #name
 
-#if defined(__ELF__) || defined(__MINGW32__) || defined(__wasm__)
+#if defined(__ELF__) || defined(__MINGW32__) || defined(__CYGWIN__) || defined(__wasm__)
 #define COMPILER_RT_ALIAS(name, aliasname) \
   COMPILER_RT_ABI __typeof(name) aliasname __attribute__((__alias__(#name)));
 #elif defined(__APPLE__)


### PR DESCRIPTION
Hello! I am unsure if it was intentional not to target Cygwin, but based on what the modified line was targeting, it appears the line is attempting to detect compilation environments. Cygwin is a Windows-based Unix-like POSIX environment. So while it compiles on Windows (i.e.. `defined(_WIN32)`, for MSVC), it ultimately gets compiled with Unix tools like GCC or Clang on a Windows environment, and can be detected with the `__CYGWIN__` preprocessor define.

Compilation of the C Python bindings for miasm fails because it does not detect the Cygwin environment on compilation. The fix is pretty simple. Miasm is working great on my system now.

Let me know if it was intentional not to target Cygwin, I can see why you might not want to have so many platforms to support on your plate, but if you're targetting MinGW32, I don't see why you couldn't also support Cygwin.