### PR TITLE
[ARM] compute cf for shift/rotate

### DIFF
--- a/miasm/arch/arm/arch.py
+++ b/miasm/arch/arm/arch.py
@@ -1148,8 +1148,12 @@ class arm_op2(arm_arg):
             shift_op = ExprInt(amount, 32)
         a = regs_expr[rm]
         if shift_op == ExprInt(0, 32):
+            #rrx
             if shift_type == 3:
                 self.expr = ExprOp(allshifts[4], a)
+            #asr, lsr
+            elif shift_type == 1 or shift_type == 2:
+                self.expr = ExprOp(allshifts[shift_type], a, ExprInt(32, 32))
             else:
                 self.expr = a
         else:

--- a/miasm/arch/arm/sem.py
+++ b/miasm/arch/arm/sem.py
@@ -405,6 +405,8 @@ def adc(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     arg1, arg2 = b, c
     r = b + c + cf.zeroExtend(32)
     if instr.name == 'ADCS' and a != PC:
@@ -421,6 +423,8 @@ def add(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     arg1, arg2 = b, c
     r = b + c
     if instr.name == 'ADDS' and a != PC:
@@ -459,6 +463,8 @@ def sub(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     r = b - c
     e.append(ExprAssign(a, r))
     dst = get_dst(a)
@@ -471,6 +477,8 @@ def subs(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     arg1, arg2 = b, c
     r = b - c
     e += update_flag_arith_sub_zn(arg1, arg2)
@@ -486,6 +494,8 @@ def eor(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     r = b ^ c
     e.append(ExprAssign(a, r))
     dst = get_dst(a)
@@ -522,6 +532,8 @@ def rsb(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     arg1, arg2 = c, b
     r = arg1 - arg2
     e.append(ExprAssign(a, r))
@@ -535,6 +547,8 @@ def rsbs(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     arg1, arg2 = c, b
     r = arg1 - arg2
     e += update_flag_arith_sub_zn(arg1, arg2)
@@ -550,6 +564,8 @@ def sbc(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     arg1, arg2 = b, c
     r = arg1 - (arg2 + (~cf).zeroExtend(32))
     e.append(ExprAssign(a, r))
@@ -563,6 +579,8 @@ def sbcs(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     arg1, arg2 = b, c
     r = arg1 - (arg2 + (~cf).zeroExtend(32))
 
@@ -580,6 +598,8 @@ def rsc(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     arg1, arg2 = c, b
     r = arg1 - (arg2 + (~cf).zeroExtend(32))
     e.append(ExprAssign(a, r))
@@ -593,6 +613,8 @@ def rscs(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     arg1, arg2 = c, b
     r = arg1 - (arg2 + (~cf).zeroExtend(32))
 
@@ -659,6 +681,8 @@ def cmn(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     arg1, arg2 = b, c
     e += update_flag_arith_add_zn(arg1, arg2)
     e += update_flag_arith_add_co(arg1, arg2)
@@ -669,6 +693,8 @@ def orr(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     r = b | c
     e.append(ExprAssign(a, r))
     dst = get_dst(a)
@@ -681,6 +707,8 @@ def orn(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     r = ~(b | c)
     e.append(ExprAssign(a, r))
     dst = get_dst(a)
@@ -885,6 +913,8 @@ def bic(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     r = b & (c ^ ExprInt(-1, 32))
     e.append(ExprAssign(a, r))
     dst = get_dst(a)
@@ -921,6 +951,8 @@ def sdiv(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
 
     loc_div = ExprLoc(ir.loc_db.add_location(), ir.IRDst.size)
     loc_except = ExprId(ir.loc_db.add_location(), ir.IRDst.size)
@@ -952,6 +984,8 @@ def udiv(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
 
 
 
@@ -1015,6 +1049,8 @@ def mul(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     r = b * c
     e.append(ExprAssign(a, r))
     dst = get_dst(a)
@@ -1027,6 +1063,8 @@ def muls(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     r = b * c
     e += update_flag_zn(r)
     e.append(ExprAssign(a, r))
@@ -1300,6 +1338,8 @@ def lsr(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     return _shift_rotate_tpl(ir, instr, a, b >> c, setflags=False)
 
 
@@ -1307,12 +1347,16 @@ def lsrs(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     return _shift_rotate_tpl(ir, instr, a, b >> c, setflags= a != PC)
 
 def asr(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     r = ExprOp("a>>", b, c)
     return _shift_rotate_tpl(ir, instr, a, r, setflags=False)
 
@@ -1320,6 +1364,8 @@ def asrs(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     r = ExprOp("a>>", b, c)
     return _shift_rotate_tpl(ir, instr, a, r, setflags= a != PC)
 
@@ -1327,6 +1373,8 @@ def lsl(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     return _shift_rotate_tpl(ir, instr, a, b << c, setflags=False)
 
 
@@ -1335,6 +1383,8 @@ def lsls(ir, instr, a, b, c=None):
     e = []
     if c is None:
         b, c = a, b
+    if c.is_op('rrx'):
+        c, _ = compute_rrx_carry(c)
     return _shift_rotate_tpl(ir, instr, a, b << c, setflags= a != PC)
 
 

--- a/miasm/arch/arm/sem.py
+++ b/miasm/arch/arm/sem.py
@@ -391,6 +391,9 @@ def update_flag_arith_subwc_co(arg1, arg2, arg3):
     e += update_flag_subwc_of(arg1, arg2, arg3)
     return e
 
+# Utility function for flag computation when it depends on the mode
+def isThumb(lifter):
+    return isinstance(lifter, (Lifter_Armtl, Lifter_Armtb))
 
 
 def get_dst(a):

--- a/test/arch/arm/arch.py
+++ b/test/arch/arm/arch.py
@@ -241,7 +241,12 @@ reg_tests_arm = [
      '110f111e'),
     ('XXXXXXXX    MCRCC      p15, 0x0, R8, c2, c0, 0x1',
      '308f023e'),
-
+    ('XXXXXXXX    MOV        R4, R4 ASR 0x20',
+     '4440a0e1'),
+    ('XXXXXXXX    MOV        R2, R5 LSR 0x20',
+     '2520a0e1'),
+    ('XXXXXXXX    MOVS       R2, R5 LSR 0x20',
+     '2520b0e1'),
 
 ]
 ts = time.time()

--- a/test/arch/arm/sem.py
+++ b/test/arch/arm/sem.py
@@ -81,7 +81,7 @@ class TestARMSemantic(unittest.TestCase):
         self.assertEqual(
             compute('MOV R4, R4 LSR 31', {R4: 0xDEADBEEF, }), {R4: 0x00000001, })
         self.assertEqual(
-            compute('MOV R4, R4 LSR 32', {R4: 0xDEADBEEF, }), {R4: 0xDEADBEEF, })
+            compute('MOV R4, R4 LSR 32', {R4: 0xDEADBEEF, }), {R4: 0x0, })
         self.assertRaises(ValueError, compute, 'MOV R4, R4 LSR 33')
         self.assertEqual(
             compute('MOV R4, R4 LSR R5', {R4: 0xDEADBEEF, R5: 0xBADBAD01, }), {R4: 0x6F56DF77, R5: 0xBADBAD01, })
@@ -93,7 +93,7 @@ class TestARMSemantic(unittest.TestCase):
         self.assertEqual(
             compute('MOV R4, R4 ASR 31', {R4: 0xDEADBEEF, }), {R4: 0xFFFFFFFF, })
         self.assertEqual(
-            compute('MOV R4, R4 ASR 32', {R4: 0xDEADBEEF, }), {R4: 0xDEADBEEF, })
+            compute('MOV R4, R4 ASR 32', {R4: 0xDEADBEEF, }), {R4: 0xFFFFFFFF, })
         self.assertRaises(ValueError, compute, 'MOV R4, R4 ASR 33')
         self.assertEqual(
             compute('MOV R4, R4 ASR R5', {R4: 0xDEADBEEF, R5: 0xBADBAD01, }), {R4: 0xEF56DF77, R5: 0xBADBAD01, })

--- a/test/arch/arm/sem.py
+++ b/test/arch/arm/sem.py
@@ -111,6 +111,57 @@ class TestARMSemantic(unittest.TestCase):
                          cf: 0, R4: 0x6F56DF77, })
         self.assertEqual(compute('MOV R4, R4 RRX   ', {cf: 1, R4: 0xDEADBEEF, }), {
                          cf: 1, R4: 0xEF56DF77, })
+        # S
+        self.assertEqual(
+            compute('MOVS R4, R4       ', {R4: 0xDEADBEEF, }), {R4: 0xDEADBEEF, nf: 1, zf: 0,})
+        self.assertRaises(ValueError, compute, 'MOVS R4, R4 LSL  0')
+        self.assertEqual(
+            compute('MOVS R4, R4 LSL  1', {R4: 0xDEADBEEF, }), {R4: 0xBD5B7DDE, nf: 1, zf: 0, cf: 1,})
+        self.assertEqual(
+            compute('MOVS R4, R4 LSL 16', {R4: 0xDEADBEEF, }), {R4: 0xBEEF0000, nf: 1, zf: 0, cf: 1,})
+        self.assertEqual(
+            compute('MOVS R4, R4 LSL 31', {R4: 0xDEADBEEF, }), {R4: 0x80000000, nf: 1, zf: 0, cf: 1,})
+        self.assertRaises(ValueError, compute, 'MOVS R4, R4 LSL 32')
+        self.assertEqual(
+            compute('MOVS R4, R4 LSL R5', {R4: 0xDEADBEEF, R5: 0xBADBAD01, }), {R4: 0xBD5B7DDE, R5: 0xBADBAD01, nf: 1, zf: 0, cf: 1,})
+        self.assertRaises(ValueError, compute, 'MOVS R4, R4 LSR  0')
+        self.assertEqual(
+            compute('MOVS R4, R4 LSR  1', {R4: 0xDEADBEEF, }), {R4: 0x6F56DF77, nf: 0, zf: 0, cf: 1,})
+        self.assertEqual(
+            compute('MOVS R4, R4 LSR 16', {R4: 0xDEADBEEF, }), {R4: 0x0000DEAD, nf: 0, zf: 0, cf: 1,})
+        self.assertEqual(
+            compute('MOVS R4, R4 LSR 31', {R4: 0xDEADBEEF, }), {R4: 0x00000001, nf: 0, zf: 0, cf: 1,})
+        self.assertEqual(
+            compute('MOVS R4, R4 LSR 32', {R4: 0xDEADBEEF, }), {R4: 0x0, nf: 0, zf: 1, cf: 1,})
+        self.assertRaises(ValueError, compute, 'MOVS R4, R4 LSR 33')
+        self.assertEqual(
+            compute('MOVS R4, R4 LSR R5', {R4: 0xDEADBEEF, R5: 0xBADBAD01, }), {R4: 0x6F56DF77, R5: 0xBADBAD01, nf: 0, zf: 0, cf: 1,})
+        self.assertRaises(ValueError, compute, 'MOVS R4, R4 ASR  0')
+        self.assertEqual(
+            compute('MOVS R4, R4 ASR  1', {R4: 0xDEADBEEF, }), {R4: 0xEF56DF77, nf: 1, zf: 0, cf: 1,})
+        self.assertEqual(
+            compute('MOVS R4, R4 ASR 16', {R4: 0xDEADBEEF, }), {R4: 0xFFFFDEAD, nf: 1, zf: 0, cf: 1,})
+        self.assertEqual(
+            compute('MOVS R4, R4 ASR 31', {R4: 0xDEADBEEF, }), {R4: 0xFFFFFFFF, nf: 1, zf: 0, cf: 1,})
+        self.assertEqual(
+            compute('MOVS R4, R4 ASR 32', {R4: 0xDEADBEEF, }), {R4: 0xFFFFFFFF, nf: 1, zf: 0, cf: 1,})
+        self.assertRaises(ValueError, compute, 'MOVS R4, R4 ASR 33')
+        self.assertEqual(
+            compute('MOVS R4, R4 ASR R5', {R4: 0xDEADBEEF, R5: 0xBADBAD01, }), {R4: 0xEF56DF77, R5: 0xBADBAD01, nf: 1, zf: 0, cf: 1,})
+        self.assertRaises(ValueError, compute, 'MOVS R4, R4 ROR  0')
+        self.assertEqual(
+            compute('MOVS R4, R4 ROR  1', {R4: 0xDEADBEEF, }), {R4: 0xEF56DF77, nf: 1, zf: 0, cf: 1,})
+        self.assertEqual(
+            compute('MOVS R4, R4 ROR 16', {R4: 0xDEADBEEF, }), {R4: 0xBEEFDEAD, nf: 1, zf: 0, cf: 1,})
+        self.assertEqual(
+            compute('MOVS R4, R4 ROR 31', {R4: 0xDEADBEEF, }), {R4: 0xBD5B7DDF, nf: 1, zf: 0, cf: 1,})
+        self.assertRaises(ValueError, compute, 'MOVS R4, R4 ROR 32')
+        self.assertEqual(
+            compute('MOVS R4, R4 ROR R5', {R4: 0xDEADBEEF, R5: 0xBADBAD01, }), {R4: 0xEF56DF77, R5: 0xBADBAD01, nf: 1, zf: 0, cf: 1,})
+        self.assertEqual(compute('MOVS R4, R4 RRX   ', {cf: 0, R4: 0xDEADBEEF, }), {
+                        cf: 1, R4: 0x6F56DF77, zf: 0, nf: 0})
+        self.assertEqual(compute('MOVS R4, R4 RRX   ', {cf: 1, R4: 0xDEADBEEF, }), {
+                        cf: 1, R4: 0xEF56DF77, zf: 0, nf: 1})
 
     def test_ADC(self):
         # §A8.8.1:                 ADC{S}{<c>}{<q>} {<Rd>,} <Rn>, #<const>


### PR DESCRIPTION
This partially addresses #1456

- Moves rrx computation inside the functions, this allows to do the carry flag computation related to RRX
- Adds a shifter/rotate template for the carry flag similar to the one in x86

It is still (at least) left to:
- compute the carry flag of some instructions with immediates.
Here is an example A32ExpandImm_C (https://developer.arm.com/documentation/ddi0597/2023-06/Shared-Pseudocode/aarch32-functions-common?lang=en#impl-aarch32.A32ExpandImm_C.2). Used by ANDS, BICS, EORS, MOVS, MVNS, ORRS, TEQ, TST with immediates.
The equation is something like `cf= ROR(zExt32(imm[0:8], imm[8:12] << 1).MSB()` (if `2*imm[8:12] != 0`). This is tricky because the semantics don't know the rotate amount that was used. Maybe the additional_info object on instructions could store useful data like rotate amount and maybe the encoding category (A1, A2, T1, T2...)?

- ~~Update the semantic tests to include the carry flag.~~

Related additional work:
- Maybe we could also clean up a bit the code (use flag functions more often, replace isinstance for Expr* by is_XXX...)
- Maybe handle the exception when setflags AND dst=PC?