### PR TITLE
Python 3.12 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,18 @@
 # Build directory
 /build/*
+dist/
+sdists/
 # Emacs files
 *~
 # Compiled python files
+__pycache__/
 *.py[cod]
 # Generated files
 *.egg*
 **.dot
 **.so
 VERSION
+# Virtual environments
+venv*/
+.env/
+.venv*/

--- a/example/jitter/unpack_generic.py
+++ b/example/jitter/unpack_generic.py
@@ -35,7 +35,7 @@ def stop(jitter):
 if options.oep:
     # Set callbacks
     sb.jitter.add_breakpoint(int(options.oep, 0), stop)
-    
+
 # Run until an error is encountered - IT IS UNLIKELY THE ORIGINAL ENTRY POINT
 try:
     sb.run()

--- a/miasm/__init__.py
+++ b/miasm/__init__.py
@@ -40,13 +40,13 @@ def _version_from_git_describe():
 
     if process.returncode == 0:
         tag = out.decode().strip()
-        match = re.match('^v?(.+?)-(\\d+)-g[a-f0-9]+$', tag)
+        match = re.match(r'^v?(.+?)-(\d+)-g[a-f0-9]+$', tag)
         if match:
             # remove the 'v' prefix and add a '.devN' suffix
             return '%s.dev%s' % (match.group(1), match.group(2))
         else:
             # just remove the 'v' prefix
-            return re.sub('^v', '', tag)
+            return re.sub(r'^v', '', tag)
     else:
         raise subprocess.CalledProcessError(process.returncode, err)
 
@@ -71,7 +71,7 @@ def _version():
             # See 'man gitattributes' for more details.
             git_archive_id = '$Format:%h %d$'
             sha1 = git_archive_id.strip().split()[0]
-            match = re.search('tag:(\\S+)', git_archive_id)
+            match = re.search(r'tag:(\S+)', git_archive_id)
             if match:
                 return "git-archive.dev" + match.group(1)
             elif sha1:

--- a/miasm/analysis/debugging.py
+++ b/miasm/analysis/debugging.py
@@ -377,7 +377,7 @@ class DebugCmd(cmd.Cmd, object):
 
         args = arg.split(" ")
         if args[-1].lower() not in ["on", "off"]:
-            self.print_warning("/!\ %s not in 'on' / 'off'" % args[-1])
+            self.print_warning("[!] %s not in 'on' / 'off'" % args[-1])
             return
         mode = args[-1].lower() == "on"
         d = {}

--- a/miasm/analysis/dse.py
+++ b/miasm/analysis/dse.py
@@ -234,7 +234,7 @@ class DSEEngine(object):
     def handle(self, cur_addr):
         r"""Handle destination
         @cur_addr: Expr of the next address in concrete execution
-        /!\ cur_addr may be a loc_key
+        [!] cur_addr may be a loc_key
 
         In this method, self.symb is in the "just before branching" state
         """
@@ -475,7 +475,7 @@ class DSEEngine(object):
         @cpu: (optional) if set, update registers' value
         @mem: (optional) if set, update memory value
 
-        /!\ all current states will be loss.
+        [!] all current states will be loss.
         This function is usually called when states are no more synchronized
         (at the beginning, returning from an unstubbed syscall, ...)
         """

--- a/miasm/arch/aarch64/sem.py
+++ b/miasm/arch/aarch64/sem.py
@@ -179,7 +179,7 @@ system_regs = {
 
     (3, 0, 2, 3, 0): APGAKeyLo_EL1,
     (3, 0, 2, 3, 1): APGAKeyHi_EL1,
-    
+
     (3, 0, 4, 1, 0): SP_EL0,
     (3, 0, 4, 6, 0): ICC_PMR_EL1, # Alias ICV_PMR_EL1
 
@@ -285,7 +285,7 @@ system_regs = {
     (3, 0, 0, 0, 1): CTR_EL0,
 
     (3, 3, 0, 0, 7): DCZID_EL0,
-    
+
     (3, 3, 4, 4, 0): FPCR,
     (3, 3, 4, 4, 1): FPSR,
 
@@ -1578,13 +1578,13 @@ def msr(ir, instr, arg1, arg2, arg3, arg4, arg5, arg6):
         e.append(ExprAssign(zf, arg6[30:31]))
         e.append(ExprAssign(cf, arg6[29:30]))
         e.append(ExprAssign(of, arg6[28:29]))
-    
+
     elif arg1.is_int(3) and arg2.is_int(3) and arg3.is_id("c4") and arg4.is_id("c2") and arg5.is_int(7):
         e.append(ExprAssign(tco, arg6[25:26]))
 
     elif arg1.is_int(3) and arg2.is_int(3) and arg3.is_id("c4") and arg4.is_id("c2") and arg5.is_int(0):
         e.append(ExprAssign(dit, arg6[24:25]))
-    
+
     elif arg1.is_int(3) and arg2.is_int(0) and arg3.is_id("c4") and arg4.is_id("c2") and arg5.is_int(4):
         e.append(ExprAssign(uao, arg6[23:24]))
 
@@ -1599,7 +1599,7 @@ def msr(ir, instr, arg1, arg2, arg3, arg4, arg5, arg6):
         e.append(ExprAssign(af, arg6[8:9]))
         e.append(ExprAssign(iff, arg6[7:8]))
         e.append(ExprAssign(ff, arg6[6:7]))
-    
+
     elif arg1.is_int(3) and arg2.is_int(0) and arg3.is_id("c4") and arg4.is_id("c2") and arg5.is_int(2):
         e.append(ExprAssign(cur_el, arg6[2:4]))
 

--- a/miasm/arch/x86/arch.py
+++ b/miasm/arch/x86/arch.py
@@ -428,7 +428,7 @@ def offsize(p):
 
 
 def get_prefix(s):
-    g = re.search('(\S+)(\s+)', s)
+    g = re.search(r'(\S+)(\s+)', s)
     if not g:
         return None, s
     prefix, b = g.groups()

--- a/miasm/core/cpu.py
+++ b/miasm/core/cpu.py
@@ -408,7 +408,7 @@ default_prio = 0x1337
 
 
 def isbin(s):
-    return re.match('[0-1]+$', s)
+    return re.match(r'[0-1]+$', s)
 
 
 def int2bin(i, l):
@@ -1301,7 +1301,7 @@ class cls_mn(with_metaclass(metamn, object)):
     @classmethod
     def fromstring(cls, text, loc_db, mode = None):
         global total_scans
-        name = re.search('(\S+)', text).groups()
+        name = re.search(r'(\S+)', text).groups()
         if not name:
             raise ValueError('cannot find name', text)
         name = name[0]

--- a/miasm/core/graph.py
+++ b/miasm/core/graph.py
@@ -20,7 +20,7 @@ class DiGraph(object):
         # N -> Nodes N2 with a edge (N2 -> N)
         self._nodes_pred = {}
 
-        self.escape_chars = re.compile('[' + re.escape('{}') + '&|<>' + ']')
+        self.escape_chars = re.compile(r'[\{\}&|<>]')
 
 
     def __repr__(self):

--- a/miasm/core/sembuilder.py
+++ b/miasm/core/sembuilder.py
@@ -22,8 +22,8 @@ class MiasmTransformer(ast.NodeTransformer):
     """
 
     # Parsers
-    parse_integer = re.compile("^i([0-9]+)$")
-    parse_mem = re.compile("^mem([0-9]+)$")
+    parse_integer = re.compile(r"^i([0-9]+)$")
+    parse_mem = re.compile(r"^mem([0-9]+)$")
 
     # Visitors
     def visit_Call(self, node):

--- a/miasm/core/utils.py
+++ b/miasm/core/utils.py
@@ -26,7 +26,7 @@ COLOR_OP = "black"
 
 COLOR_MNEMO = "blue1"
 
-ESCAPE_CHARS = re.compile('[' + re.escape('{}') + '&|<>' + ']')
+ESCAPE_CHARS = re.compile(r'[\{\}&|<>]')
 
 def set_html_text_color(text, color):
     return '<font color="%s">%s</font>' % (color, text)

--- a/miasm/expression/expression.py
+++ b/miasm/expression/expression.py
@@ -2146,7 +2146,7 @@ def expr_is_sNaN(expr):
 
 def expr_is_float_lower(op1, op2):
     """Return 1 on 1 bit if @op1 < @op2, 0 otherwise.
-    /!\ Assume @op1 and @op2 are not NaN
+    [!] Assume @op1 and @op2 are not NaN
     Comparison is the floating point one, defined in IEEE754
     """
     sign1, sign2 = op1.msb(), op2.msb()
@@ -2160,7 +2160,7 @@ def expr_is_float_lower(op1, op2):
 
 def expr_is_float_equal(op1, op2):
     """Return 1 on 1 bit if @op1 == @op2, 0 otherwise.
-    /!\ Assume @op1 and @op2 are not NaN
+    [!] Assume @op1 and @op2 are not NaN
     Comparison is the floating point one, defined in IEEE754
     """
     sign1, sign2 = op1.msb(), op2.msb()

--- a/miasm/expression/expression_helper.py
+++ b/miasm/expression/expression_helper.py
@@ -89,7 +89,7 @@ op_propag_cst = ['+', '*', '^', '&', '|', '>>',
 def is_pure_int(e):
     """
     return True if expr is only composed with integers
-    /!\ ExprCond returns True is src1 and src2 are integers
+    [!] ExprCond returns True is src1 and src2 are integers
     """
     def modify_cond(e):
         if isinstance(e, m2_expr.ExprCond):
@@ -444,7 +444,7 @@ class ExprRandom(object):
         """Internal function for generating sub-expression according to options
         @size: (optional) Operation size
         @depth: (optional) Expression depth
-        /!\ @generated_elements is left modified
+        [!] @generated_elements is left modified
         """
         # Perfect tree handling
         if not cls.perfect_tree:

--- a/miasm/expression/simplifications_common.py
+++ b/miasm/expression/simplifications_common.py
@@ -1275,7 +1275,7 @@ def simp_cond_eq_zero(_, expr):
 
 def simp_sign_inf_zeroext(expr_s, expr):
     """
-    /!\ Ensure before: X.zeroExt(X.size) => X
+    [!] Ensure before: X.zeroExt(X.size) => X
 
     X.zeroExt() <s 0 => 0
     X.zeroExt() <=s 0 => X == 0

--- a/miasm/expression/simplifications_common.py
+++ b/miasm/expression/simplifications_common.py
@@ -1146,7 +1146,7 @@ def simp_cmp_bijective_op(expr_simp, expr):
     # a + b + c == a + b
     if not args_b:
         return ExprOp(TOK_EQUAL, ExprOp(op, *args_a), ExprInt(0, args_a[0].size))
-    
+
     arg_a = ExprOp(op, *args_a)
     arg_b = ExprOp(op, *args_b)
     return ExprOp(TOK_EQUAL, arg_a, arg_b)
@@ -1782,7 +1782,7 @@ def simp_bcdadd_cf(_, expr):
     for i in range(0,16,4):
         nib_1 = (arg1.arg >> i) & (0xF)
         nib_2 = (arg2.arg >> i) & (0xF)
-        
+
         j = (carry + nib_1 + nib_2)
         if (j >= 10):
             carry = 1
@@ -1807,7 +1807,7 @@ def simp_bcdadd(_, expr):
     for i in range(0,16,4):
         nib_1 = (arg1.arg >> i) & (0xF)
         nib_2 = (arg2.arg >> i) & (0xF)
-        
+
         j = (carry + nib_1 + nib_2)
         if (j >= 10):
             carry = 1

--- a/miasm/ir/ir.py
+++ b/miasm/ir/ir.py
@@ -48,7 +48,7 @@ def _expr_loc_to_symb(expr, loc_db):
     return m2_expr.ExprId(name, expr.size)
 
 
-ESCAPE_CHARS = re.compile('[' + re.escape('{}') + '&|<>' + ']')
+ESCAPE_CHARS = re.compile(r'[\{\}&|<>]')
 
 class TranslatorHtml(Translator):
     __LANG__ = "custom_expr_color"

--- a/miasm/ir/translators/z3_ir.py
+++ b/miasm/ir/translators/z3_ir.py
@@ -1,10 +1,11 @@
 from builtins import map
 from builtins import range
-import imp
+import importlib.util
 import logging
 
 # Raise an ImportError if z3 is not available WITHOUT actually importing it
-imp.find_module("z3")
+if importlib.util.find_spec("z3") is None:
+    raise ImportError("No module named 'z3'")
 
 from miasm.ir.translators.translator import Translator
 

--- a/miasm/jitter/loader/pe.py
+++ b/miasm/jitter/loader/pe.py
@@ -23,12 +23,12 @@ log.setLevel(logging.INFO)
 
 def get_pe_dependencies(pe_obj):
     """Collect the shared libraries upon which this PE depends.
-    
+
     @pe_obj: pe object
     Returns a set of strings of DLL names.
-    
+
     Example:
-    
+
         pe = miasm.analysis.binary.Container.from_string(buf)
         deps = miasm.jitter.loader.pe.get_pe_dependencies(pe.executable)
         assert sorted(deps)[0] == 'api-ms-win-core-appcompat-l1-1-0.dll'
@@ -63,12 +63,12 @@ def get_import_address_pe(e):
     """Compute the addresses of imported symbols.
     @e: pe object
     Returns a dict mapping from tuple (dll name string, symbol name string) to set of virtual addresses.
-    
+
     Example:
-    
+
         pe = miasm.analysis.binary.Container.from_string(buf)
         imports = miasm.jitter.loader.pe.get_import_address_pe(pe.executable)
-        assert imports[('api-ms-win-core-rtlsupport-l1-1-0.dll', 'RtlCaptureStackBackTrace')] == {0x6b88a6d0}    
+        assert imports[('api-ms-win-core-rtlsupport-l1-1-0.dll', 'RtlCaptureStackBackTrace')] == {0x6b88a6d0}
     """
     import2addr = defaultdict(set)
     if e.DirImport.impdesc is None:
@@ -732,7 +732,7 @@ class ImpRecStateMachine(object):
             "entry_module_addr": func_addr,
             "entry_memory_addr": self.cur_address,
         }
-        
+
     def transition(self, data):
         if self.state == self.STATE_SEARCH:
             if data in self.func_addrs:
@@ -760,7 +760,7 @@ class ImpRecStateMachine(object):
             self.transition(data)
         else:
             raise ValueError()
-        
+
     def run(self):
         while True:
             data, address = yield
@@ -804,7 +804,7 @@ class ImpRecStrategy(object):
         @update_libs: if set (default), update `libs` object with founded addresses
         @align_hypothesis: if not set (default), do not consider import
             addresses are written on aligned addresses
-        
+
         Return the list of candidates
         """
         candidates = []

--- a/miasm/jitter/loader/utils.py
+++ b/miasm/jitter/loader/utils.py
@@ -65,7 +65,7 @@ class libimp(object):
         #    imp_ord_or_name = vm_get_str(imp_ord_or_name, 0x100)
         #    imp_ord_or_name = imp_ord_or_name[:imp_ord_or_name.find('\x00')]
 
-        #/!\ can have multiple dst ad
+        #[!] can have multiple dst ad
         if not imp_ord_or_name in self.lib_imp2dstad[libad]:
             self.lib_imp2dstad[libad][imp_ord_or_name] = set()
         if dst_ad is not None:

--- a/miasm/loader/minidump.py
+++ b/miasm/loader/minidump.py
@@ -388,7 +388,7 @@ class Context_AMD64(CStruct):
         ("MxCsr", "u32"),
 
         # Segment & processor
-        # /!\ activation depends on multiple flags
+        # [!] activation depends on multiple flags
         ("SegCs", "u16", is_activated("CONTEXT_CONTROL")),
         ("SegDs", "u16", is_activated("CONTEXT_SEGMENTS")),
         ("SegEs", "u16", is_activated("CONTEXT_SEGMENTS")),
@@ -406,7 +406,7 @@ class Context_AMD64(CStruct):
         ("Dr7", "u64", is_activated("CONTEXT_DEBUG_REGISTERS")),
 
         # Integer registers
-        # /!\ activation depends on multiple flags
+        # [!] activation depends on multiple flags
         ("Rax", "u64", is_activated("CONTEXT_INTEGER")),
         ("Rcx", "u64", is_activated("CONTEXT_INTEGER")),
         ("Rdx", "u64", is_activated("CONTEXT_INTEGER")),

--- a/miasm/os_dep/linux/environment.py
+++ b/miasm/os_dep/linux/environment.py
@@ -13,7 +13,7 @@ from miasm.core.interval import interval
 from miasm.jitter.csts import PAGE_READ, PAGE_WRITE
 
 
-REGEXP_T = type(re.compile(''))
+REGEXP_T = type(re.compile(r''))
 
 StatInfo = namedtuple("StatInfo", [
     "st_dev", "st_ino", "st_nlink", "st_mode", "st_uid", "st_gid", "st_rdev",
@@ -262,7 +262,7 @@ class FileSystem(object):
                             expr.flags,
                             exc_info=True,
                         )
-                        return re.compile('$X')
+                        return re.compile(r'$X')
                 return expr
 
         # Remove '../', etc.

--- a/miasm/os_dep/win_api_x86_32.py
+++ b/miasm/os_dep/win_api_x86_32.py
@@ -2452,7 +2452,7 @@ def user32_GetKeyboardType(jitter):
 
     jitter.func_ret_stdcall(ret_ad, ret)
 
-    
+
 class startupinfo(object):
     """
         typedef struct _STARTUPINFOA {
@@ -2528,7 +2528,7 @@ def kernel32_GetStartupInfo(jitter, funcname, set_str):
 
         Retrieves the contents of the STARTUPINFO structure that was specified
         when the calling process was created.
-        
+
         https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getstartupinfow
 
     """

--- a/test/analysis/depgraph.py
+++ b/test/analysis/depgraph.py
@@ -108,7 +108,7 @@ class IRATest(LifterModelCall):
 def bloc2graph(irgraph, label=False, lines=True):
     """Render dot graph of @blocks"""
 
-    escape_chars = re.compile('[' + re.escape('{}') + ']')
+    escape_chars = re.compile(r'[\{\}]')
     label_attr = 'colspan="2" align="center" bgcolor="grey"'
     edge_attr = 'label = "%s" color="%s" style="bold"'
     td_attr = 'align="left"'
@@ -179,7 +179,7 @@ def bloc2graph(irgraph, label=False, lines=True):
 def dg2graph(graph, label=False, lines=True):
     """Render dot graph of @blocks"""
 
-    escape_chars = re.compile('[' + re.escape('{}') + ']')
+    escape_chars = re.compile(r'[\{\}]')
     label_attr = 'colspan="2" align="center" bgcolor="grey"'
     edge_attr = 'label = "%s" color="%s" style="bold"'
     td_attr = 'align="left"'

--- a/test/arch/mep/asm/ut_helpers_asm.py
+++ b/test/arch/mep/asm/ut_helpers_asm.py
@@ -27,7 +27,7 @@ def check_instruction(mn_str, mn_hex, multi=None, offset=0):
     """Try to disassemble and assemble this instruction"""
 
     # Rename objdump registers names
-    mn_str = re.sub("\$([0-9]+)", lambda m: "R"+m.group(1), mn_str)
+    mn_str = re.sub(r"\$([0-9]+)", lambda m: "R"+m.group(1), mn_str)
     mn_str = mn_str.replace("$", "")
 
     # Disassemble


### PR DESCRIPTION
The main issue is the removal of the deprecated `imp` module (I replaced it with `importlib.util` and matched the existing behavior).

Other than that I made a few minor fixes of warnings, most notably fixing some broken regular expressions by switching to regex literals.
