### PR TITLE
Fix: `bin_stream::get_u8` method returning bytes

### DIFF
--- a/miasm/core/bin_stream.py
+++ b/miasm/core/bin_stream.py
@@ -124,7 +124,10 @@ class bin_stream(object):
         if endianness is None:
             endianness = self.endianness
         data = self.getbytes(addr, 1)
-        return data
+        if endianness == LITTLE_ENDIAN:
+            return upck8le(data)
+        else:
+            return upck8be(data)
 
     def get_u16(self, addr, endianness=None):
         """


### PR DESCRIPTION
`bin_stream::get_u8` supposed to be returning an int.
but instead it returns a bytes object

> Not sure how the dependent callers are expecting!