### PR TITLE
Fixing error with installation on windows with cp1251

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -416,7 +416,7 @@ _write_pkg_file_orig = DistributionMetadata.write_pkg_file
 
 
 def _write_pkg_file(self, file):
-    with TemporaryFile(mode="w+") as tmpfd:
+    with TemporaryFile(mode="w+", encoding="utf-8") as tmpfd:
         _write_pkg_file_orig(self, tmpfd)
         tmpfd.seek(0)
         for line in tmpfd:


### PR DESCRIPTION
Faced with installation error on Windows, last lines in exception log:

`File "C:\Users\...\AppData\Local\Temp\tmp87tpzffd\.venv\lib\site-packages\setuptools\_core_metadata.py", line 136, in write_pkg_info
  self.write_pkg_file(f)
File "<string>", line 420, in _write_pkg_file
File "C:\Users\...\AppData\Local\Temp\tmp87tpzffd\.venv\lib\site-packages\setuptools\_core_metadata.py", line 210, in write_pkg_file
  file.write("\n%s" % long_description)
File "C:\Python310\lib\tempfile.py", line 483, in func_wrapper
  return func(*args, **kwargs)
File "C:\Python310\lib\encodings\cp1251.py", line 19, in encode
  return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\xe9' in position 20918: character maps to <undefined>`

I realized that problem was in setup.py: long_description was read with utf-8, but written with local encoding which doesn't support diacritics from readme.md