### PR TITLE
Fix compilation for FreeBSD OS

### DIFF
--- a/miasm/jitter/vm_mngr.h
+++ b/miasm/jitter/vm_mngr.h
@@ -39,7 +39,7 @@
 #define __BYTE_ORDER __BYTE_ORDER__
 #define __BIG_ENDIAN BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN
-#elif defined(__NetBSD__) || defined(__OpenBSD__)
+#elif defined(__NetBSD__) || defined(__OpenBSD__) || defined(__FreeBSD__)
 #define __BYTE_ORDER _BYTE_ORDER
 #define __BIG_ENDIAN _BIG_ENDIAN
 #define __LITTLE_ENDIAN _LITTLE_ENDIAN


### PR DESCRIPTION
Fixes https://github.com/cea-sec/miasm/issues/1469

test run:
```
[alex@bsd14 ~/miasm]$ pip install .
Defaulting to user installation because normal site-packages is not writeable
Processing /home/alex/miasm
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting future (from miasm==0.1.5.dev49)
  Using cached future-1.0.0-py3-none-any.whl.metadata (4.0 kB)
Collecting pyparsing>=2.4.1 (from miasm==0.1.5.dev49)
  Using cached pyparsing-3.1.2-py3-none-any.whl.metadata (5.1 kB)
Using cached pyparsing-3.1.2-py3-none-any.whl (103 kB)
Using cached future-1.0.0-py3-none-any.whl (491 kB)
Building wheels for collected packages: miasm
  Building wheel for miasm (pyproject.toml) ... done
  Created wheel for miasm: filename=miasm-0.1.5.dev49-cp311-cp311-freebsd_14_1_release_amd64.whl size=1114299 sha256=03e731629a3ecbaedbcf05e05acff018e97c4f9778615321a7bb32a94ddbc8b2
  Stored in directory: /tmp/pip-ephem-wheel-cache-hwth3s58/wheels/d5/02/5a/b736a9b67ae1fadef0e961c5f67f81a8594645f49098e3828d
Successfully built miasm
Installing collected packages: pyparsing, future, miasm
  WARNING: The scripts futurize and pasteurize are installed in '/home/alex/.local/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
Successfully installed future-1.0.0 miasm-0.1.5.dev49 pyparsing-3.1.2
[alex@bsd14 ~/miasm]$ pip freeze | grep miasm
miasm @ file:///home/alex/miasm
[alex@bsd14 ~/miasm]$ uname -a
FreeBSD bsd14 14.1-RELEASE FreeBSD 14.1-RELEASE releng/14.1-n267679-10e31f0946d8 GENERIC amd64
[alex@bsd14 ~/miasm]$
```