### PR TITLE
fix expression division

### DIFF
--- a/miasm/expression/expression.py
+++ b/miasm/expression/expression.py
@@ -568,11 +568,11 @@ class Expr(object):
     def __sub__(self, other):
         return ExprOp('+', self, ExprOp('-', other))
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         return ExprOp('/', self, other)
 
     def __floordiv__(self, other):
-        return self.__div__(other)
+        return self.__truediv__(other)
 
     def __mod__(self, other):
         return ExprOp('%', self, other)

--- a/test/expression/expression.py
+++ b/test/expression/expression.py
@@ -80,16 +80,22 @@ assert mem.get_r(mem_read=True) == set([mem, A])
 
 C = A+B
 D = C + A
+E = A / B
+F = A // B
+assert E is F
 
 assert A in A
 assert A in C
 assert B in C
 assert C in C
+assert E in E
 
 assert A in D
 assert B in D
 assert C in D
 assert D in D
+assert A in E
+assert B in E
 
 assert C not in A
 assert C not in B


### PR DESCRIPTION
`__div__` is not bound to the division operator in Python3. This leads to an error when trying to divide expressions.