### PR TITLE
Fix outofssa algorithm: lost update in insert_parallel_copy and insructions after conditional jmp

### DIFF
--- a/miasm/analysis/outofssa.py
+++ b/miasm/analysis/outofssa.py
@@ -5,7 +5,6 @@ from miasm.ir.ir import IRBlock, AssignBlock
 from miasm.analysis.ssa import get_phi_sources_parent_block, \
     irblock_has_phi
 
-import logging
 
 class Varinfo(object):
     """Store liveness information for a variable"""
@@ -89,13 +88,7 @@ class UnSSADiGraph(object):
             for parent, parallel_copies in viewitems(parent_to_parallel_copies):
                 parent = ircfg.blocks[parent]
                 assignblks = list(parent)
-                # insert before IRDst, TODO: might need to check for interference as mentioned in the paper
-                # sanity checks for now:
-                jmp_block = parent[-1]
-                for jmp_src in jmp_block.values():
-                    jmp_read_values = set(filter(lambda expr: expr.is_id(), jmp_src.get_r(mem_read=True)))
-                    assert len(jmp_read_values & set(parallel_copies.keys())) == 0, "Interference between jmp instruction read set and parallel copy write set"
-                assignblks.insert(-1, AssignBlock(parallel_copies, jmp_block.instr))
+                assignblks.append(AssignBlock(parallel_copies, parent[-1].instr))
                 new_irblock = IRBlock(parent.loc_db, parent.loc_key, assignblks)
                 ircfg.blocks[parent.loc_key] = new_irblock
 

--- a/miasm/analysis/outofssa.py
+++ b/miasm/analysis/outofssa.py
@@ -5,6 +5,7 @@ from miasm.ir.ir import IRBlock, AssignBlock
 from miasm.analysis.ssa import get_phi_sources_parent_block, \
     irblock_has_phi
 
+import logging
 
 class Varinfo(object):
     """Store liveness information for a variable"""
@@ -61,7 +62,8 @@ class UnSSADiGraph(object):
         """
         ircfg = self.ssa.graph
 
-        for irblock in list(viewvalues(ircfg.blocks)):
+        for block_loc in list(ircfg.blocks.keys()):
+            irblock = ircfg.get_block(block_loc)
             if not irblock_has_phi(irblock):
                 continue
 
@@ -87,7 +89,13 @@ class UnSSADiGraph(object):
             for parent, parallel_copies in viewitems(parent_to_parallel_copies):
                 parent = ircfg.blocks[parent]
                 assignblks = list(parent)
-                assignblks.append(AssignBlock(parallel_copies, parent[-1].instr))
+                # insert before IRDst, TODO: might need to check for interference as mentioned in the paper
+                # sanity checks for now:
+                jmp_block = parent[-1]
+                for jmp_src in jmp_block.values():
+                    jmp_read_values = set(filter(lambda expr: expr.is_id(), jmp_src.get_r(mem_read=True)))
+                    assert len(jmp_read_values & set(parallel_copies.keys())) == 0, "Interference between jmp instruction read set and parallel copy write set"
+                assignblks.insert(-1, AssignBlock(parallel_copies, jmp_block.instr))
                 new_irblock = IRBlock(parent.loc_db, parent.loc_key, assignblks)
                 ircfg.blocks[parent.loc_key] = new_irblock
 


### PR DESCRIPTION
I have noticed that for certain larger IRCFGs the `UnSSADiGraph` produced an invalid output. This is caused by `insert_parallel_copy` in certain constellations as it would add parallel copies to the end of a `IRBlock` in one loop iteration and then in a later one add parallel copies to the start of the same `IRBlock`. But as the iteration is over the `IRBlock`s itself, the first update was lost.

Secondly, I noticed that the code produces the following sequence of instructions at the end of a basic block:
```
IRDst = A?(loc_1, loc_2)
C = D
```
As i would interpret the IRDst assignment as a jump, this seems not correct. Please correct me there if the semantics of the `IRDst` assignments differ from my assumptions.
As mentioned in the paper this algorithm stems from, if we need to insert parallel copies before the conditional jump instructions, we need to check for interference with the condition computation. As for a quick fix, this is currently done with an `assert`, which is less than ideal. But I don't know how to implement that interference check into the given algorithm.