### PR TITLE
X86 fix and instr add

### DIFF
--- a/miasm/arch/x86/arch.py
+++ b/miasm/arch/x86/arch.py
@@ -4461,6 +4461,9 @@ addop("pmaxuw", [bs8(0x0f), bs8(0x38), bs8(0x3e), pref_66] +
 addop("pmaxud", [bs8(0x0f), bs8(0x38), bs8(0x3f), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm))
 
+addop("pmaxsd", [bs8(0x0f), bs8(0x38), bs8(0x3d), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm))
+
 addop("pmaxsw", [bs8(0x0f), bs8(0xee), no_xmm_pref] +
       rmmod(mm_reg, rm_arg_mm_m64))
 addop("pmaxsw", [bs8(0x0f), bs8(0xee), pref_66] +

--- a/miasm/arch/x86/arch.py
+++ b/miasm/arch/x86/arch.py
@@ -4641,6 +4641,8 @@ addop("pmulhw", [bs8(0x0f), bs8(0xe5), no_xmm_pref] +
       rmmod(mm_reg, rm_arg_mm_m64))
 addop("pmulhw", [bs8(0x0f), bs8(0xe5), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128))
+addop("pmuldq", [bs8(0x0f), bs8(0x38), bs8(0x28), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
 addop("pmuludq", [bs8(0x0f), bs8(0xf4), no_xmm_pref] +
       rmmod(mm_reg, rm_arg_mm_m64))
 addop("pmuludq", [bs8(0x0f), bs8(0xf4), pref_66] +

--- a/miasm/arch/x86/arch.py
+++ b/miasm/arch/x86/arch.py
@@ -4285,7 +4285,8 @@ addop("pshuflw", [bs8(0x0f), bs8(0x70), pref_f2] +
       rmmod(xmm_reg, rm_arg_xmm_m128) + [u08])
 addop("pshufhw", [bs8(0x0f), bs8(0x70), pref_f3] +
       rmmod(xmm_reg, rm_arg_xmm_m128) + [u08])
-
+addop("ptest", [bs8(0x0f), bs8(0x38), bs8(0x17), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
 
 ### Convert
 ### SS = single precision

--- a/miasm/arch/x86/arch.py
+++ b/miasm/arch/x86/arch.py
@@ -4345,6 +4345,19 @@ addop("palignr", [bs8(0x0f), bs8(0x73), bs8(0x0f), no_xmm_pref] +
 addop("palignr", [bs8(0x0f), bs8(0x3a), bs8(0x0f), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128) + [u08], [xmm_reg, rm_arg_xmm_m128, u08])
 
+addop("psignb", [bs8(0x0f), bs8(0x38), bs8(0x08), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("psignb", [bs8(0x0f), bs8(0x38), bs8(0x08), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+addop("psignw", [bs8(0x0f), bs8(0x38), bs8(0x09), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("psignw", [bs8(0x0f), bs8(0x38), bs8(0x09), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+addop("psignd", [bs8(0x0f), bs8(0x38), bs8(0x0a), no_xmm_pref] +
+      rmmod(mm_reg, rm_arg_mm_m64))
+addop("psignd", [bs8(0x0f), bs8(0x38), bs8(0x0a), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+
 addop("psrlq", [bs8(0x0f), bs8(0x73), no_xmm_pref] +
       rmmod(d2, rm_arg_mm) + [u08], [rm_arg_mm, u08])
 addop("psrlq", [bs8(0x0f), bs8(0x73), pref_66] +

--- a/miasm/arch/x86/arch.py
+++ b/miasm/arch/x86/arch.py
@@ -4346,6 +4346,10 @@ addop("palignr", [bs8(0x0f), bs8(0x73), bs8(0x0f), no_xmm_pref] +
 addop("palignr", [bs8(0x0f), bs8(0x3a), bs8(0x0f), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128) + [u08], [xmm_reg, rm_arg_xmm_m128, u08])
 
+addop("pclmulqdq", [bs8(0x0f), bs8(0x3a), bs8(0x44), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128) + [u08],
+      [xmm_reg, rm_arg_xmm_m128, u08])
+
 addop("psignb", [bs8(0x0f), bs8(0x38), bs8(0x08), no_xmm_pref] +
       rmmod(mm_reg, rm_arg_mm_m64))
 addop("psignb", [bs8(0x0f), bs8(0x38), bs8(0x08), pref_66] +
@@ -4483,6 +4487,8 @@ addop("phminposuw", [bs8(0x0f), bs8(0x38), bs8(0x41), pref_66] +
 addop("pminud", [bs8(0x0f), bs8(0x38), bs8(0x3b), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm))
 
+addop("pminsd", [bs8(0x0f), bs8(0x38), bs8(0x39), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm))
 
 addop("pcmpeqb", [bs8(0x0f), bs8(0x74), no_xmm_pref] +
       rmmod(mm_reg, rm_arg_mm))

--- a/miasm/arch/x86/arch.py
+++ b/miasm/arch/x86/arch.py
@@ -4611,6 +4611,18 @@ addop("pmovmskb", [bs8(0x0f), bs8(0xd7), no_xmm_pref] +
 addop("pmovmskb", [bs8(0x0f), bs8(0xd7), pref_66] +
       rmmod(reg_modrm, rm_arg_xmm_reg))
 
+addop("pmovsxwd", [bs8(0x0f), bs8(0x38), bs8(0x23), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m64))
+
+addop("pmovsxwq", [bs8(0x0f), bs8(0x38), bs8(0x24), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m32))
+
+addop("pmovsxbd", [bs8(0x0f), bs8(0x38), bs8(0x21), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m32))
+
+addop("pmovsxdq", [bs8(0x0f), bs8(0x38), bs8(0x25), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m64))
+
 addop("shufps", [bs8(0x0f), bs8(0xc6), no_xmm_pref] +
       rmmod(xmm_reg, rm_arg_xmm) + [u08])
 addop("shufpd", [bs8(0x0f), bs8(0xc6), pref_66] +

--- a/miasm/arch/x86/arch.py
+++ b/miasm/arch/x86/arch.py
@@ -4566,9 +4566,8 @@ addop("pextrb", [bs8(0x0f), bs8(0x3a), bs8(0x14), pref_66] +
       rmmod(xmm_reg, rm_arg_reg_m08) + [u08], [rm_arg_reg_m08, xmm_reg, u08])
 addop("pextrd", [bs8(0x0f), bs8(0x3a), bs8(0x16), pref_66, bs_opmode32] +
       rmmod(xmm_reg, rm_arg) + [u08], [rm_arg, xmm_reg, u08])
-addop("pextrq", [bs8(0x0f), bs8(0x3a), bs8(0x16), pref_66] +
-      rmmod(xmm_reg, rm_arg_m64) + [bs_opmode64] + [u08], [rm_arg_m64, xmm_reg, u08])
-
+addop("pextrq", [bs8(0x0F), bs8(0x3A), bs8(0x16), pref_66, bs_opmode64] +
+      rmmod(xmm_reg, rm_arg) + [u08], [rm_arg, xmm_reg, u08])
 
 addop("pextrw", [bs8(0x0f), bs8(0x3a), bs8(0x15), pref_66] +
       rmmod(xmm_reg, rm_arg_reg_m16) + [u08], [rm_arg_reg_m16, xmm_reg, u08])

--- a/miasm/arch/x86/arch.py
+++ b/miasm/arch/x86/arch.py
@@ -4473,6 +4473,9 @@ addop("pminub", [bs8(0x0f), bs8(0xda), pref_66] +
 addop("pminuw", [bs8(0x0f), bs8(0x38), bs8(0x3a), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm))
 
+addop("phminposuw", [bs8(0x0f), bs8(0x38), bs8(0x41), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+
 addop("pminud", [bs8(0x0f), bs8(0x38), bs8(0x3b), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm))
 

--- a/miasm/arch/x86/arch.py
+++ b/miasm/arch/x86/arch.py
@@ -4648,6 +4648,9 @@ addop("packuswb", [bs8(0x0f), bs8(0x67), no_xmm_pref] +
 addop("packuswb", [bs8(0x0f), bs8(0x67), pref_66] +
       rmmod(xmm_reg, rm_arg_xmm_m128))
 
+addop("packusdw", [bs8(0x0f), bs8(0x38), bs8(0x2b), pref_66] +
+      rmmod(xmm_reg, rm_arg_xmm_m128))
+
 addop("pmullw", [bs8(0x0f), bs8(0xd5), no_xmm_pref] +
       rmmod(mm_reg, rm_arg_mm_m64))
 addop("pmullw", [bs8(0x0f), bs8(0xd5), pref_66] +

--- a/miasm/arch/x86/sem.py
+++ b/miasm/arch/x86/sem.py
@@ -4619,7 +4619,6 @@ def punpckldq(ir, instr, dst, src):
 def punpcklqdq(ir, instr, dst, src):
     return punpck(ir, instr, dst, src, 64, 0)
 
-
 def pinsr(_, instr, dst, src, imm, size):
     e = []
 
@@ -4707,6 +4706,52 @@ def unpcklpd(_, instr, dst, src):
     e.append(m2_expr.ExprAssign(dst, src))
     return e, []
 
+def pmovsxwd(ir, instr, dst, src):
+    out = []
+    for i in range(4):
+        lane = src[16 * i:16 * (i + 1)]
+        out.append(lane.signExtend(32))
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out))], []
+
+def pmovsxwq(ir, instr, dst, src):
+    e = []
+    if dst.size != 128:
+        raise RuntimeError("Unsupported size %d" % dst.size)
+
+    out = []
+    for i in range(2):
+        w = src[16 * i:16 * (i + 1)]
+        out.append(w.signExtend(64))
+
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out)))
+    return e, []
+
+def pmovmskb(ir, instr, dst, src):
+    e = []
+    e.append(m2_expr.ExprAssign(dst, src.zeroExtend(dst.size)))
+    return e, []
+
+def pmovsxbd(ir, instr, dst, src):
+    e = []
+    if dst.size != 128:
+        raise RuntimeError("Unsupported size %d" % dst.size)
+    out = []
+    for i in range(4):
+        b = src[8 * i: 8 * (i + 1)]
+        out.append(b.signExtend(32))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out)))
+    return e, []
+
+def pmovsxdq(_, instr, dst, src):
+    e = []
+    if dst.size != 128:
+        raise RuntimeError("Unsupported size %d" % dst.size)
+    out = []
+    for i in range(2):
+        d = src[32 * i: 32 * (i + 1)]
+        out.append(d.signExtend(64))
+    e.append(m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out)))
+    return e, []
 
 def movlpd(_, instr, dst, src):
     e = []
@@ -5783,6 +5828,10 @@ mnemo_func = {'mov': mov,
               "sqrtss": sqrtss,
 
               "pmovmskb": pmovmskb,
+              "pmovsxwd": pmovsxwd,
+              "pmovsxwq": pmovsxwq,
+              "pmovsxbd": pmovsxbd,
+              "pmovsxdq": pmovsxdq,
 
               "phminposuw": phminposuw,
 

--- a/miasm/arch/x86/sem.py
+++ b/miasm/arch/x86/sem.py
@@ -5012,6 +5012,12 @@ def packuswb(ir, instr, dst, src):
             out.append(_signed_to_unsigned_saturation(source[start:start + 16], 8))
     return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out))], []
 
+def packusdw(ir, instr, dst, src):
+    out = []
+    for source in [dst, src]:
+        for start in range(0, dst.size, 32):
+            out.append(_signed_to_unsigned_saturation(source[start:start + 32], 16))
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out))], []
 
 def _saturation_sub_unsigned(expr):
     assert expr.is_op("+") and len(expr.args) == 2 and expr.args[-1].is_op("-")
@@ -5838,6 +5844,7 @@ mnemo_func = {'mov': mov,
               "packsswb": packsswb,
               "packssdw": packssdw,
               "packuswb": packuswb,
+              "packusdw": packusdw,
 
               "psubusb": psubusb,
               "psubusw": psubusw,

--- a/miasm/arch/x86/sem.py
+++ b/miasm/arch/x86/sem.py
@@ -3991,6 +3991,7 @@ pminsw = vec_vertical_instr('min', 16, lambda x: _min_max(x, signed=True))
 pminub = vec_vertical_instr('min', 8, lambda x: _min_max(x, signed=False))
 pminuw = vec_vertical_instr('min', 16, lambda x: _min_max(x, signed=False))
 pminud = vec_vertical_instr('min', 32, lambda x: _min_max(x, signed=False))
+pminsd = vec_vertical_instr('min', 32, lambda x: _min_max(x, signed=True))
 pmaxub = vec_vertical_instr('max', 8, lambda x: _min_max(x, signed=False))
 pmaxuw = vec_vertical_instr('max', 16, lambda x: _min_max(x, signed=False))
 pmaxud = vec_vertical_instr('max', 32, lambda x: _min_max(x, signed=False))
@@ -4442,6 +4443,27 @@ def ptest(_, instr, dst, src):
     e.append(m2_expr.ExprAssign(pf, m2_expr.ExprInt(0, 1)))
     e.append(m2_expr.ExprAssign(nf, m2_expr.ExprInt(0, 1)))
     return e, []
+
+def _clmul64_to_128(a64, b64):
+    assert a64.size == 64
+    assert b64.size == 64
+
+    a128 = a64.zeroExtend(128)
+    res = m2_expr.ExprInt(0, 128)
+
+    for i in range(64):
+        bit = b64[i:i + 1]
+        term = m2_expr.ExprCond(bit, a128 << m2_expr.ExprInt(i, 128), m2_expr.ExprInt(0, 128))
+        res = m2_expr.ExprOp('^', res, term)
+
+    return expr_simp(res)
+
+def pclmulqdq(_, instr, dst, src, imm8):
+    control = int(imm8)
+    a = dst[64:128] if (control & 0x01) else dst[:64]
+    b = src[64:128] if (control & 0x10) else src[:64]
+    res = _clmul64_to_128(a, b)
+    return [m2_expr.ExprAssign(dst, res)], []
 
 def ps_rl_ll(ir, instr, dst, src, op, size):
     mask = {16: 0xF,
@@ -5755,6 +5777,8 @@ mnemo_func = {'mov': mov,
               "pshuflw": pshuflw,
               "pshufhw": pshufhw,
               "ptest": ptest,
+              "ptest": ptest,
+              "pclmulqdq": pclmulqdq,
 
               "psrlw": psrlw,
               "psrld": psrld,
@@ -5782,6 +5806,7 @@ mnemo_func = {'mov': mov,
               "pminub": pminub,
               "pminuw": pminuw,
               "pminud": pminud,
+              "pminsd": pminsd,
 
               "pcmpeqb": pcmpeqb,
               "pcmpeqw": pcmpeqw,

--- a/miasm/arch/x86/sem.py
+++ b/miasm/arch/x86/sem.py
@@ -3994,6 +3994,7 @@ pminud = vec_vertical_instr('min', 32, lambda x: _min_max(x, signed=False))
 pmaxub = vec_vertical_instr('max', 8, lambda x: _min_max(x, signed=False))
 pmaxuw = vec_vertical_instr('max', 16, lambda x: _min_max(x, signed=False))
 pmaxud = vec_vertical_instr('max', 32, lambda x: _min_max(x, signed=False))
+pmaxsd = vec_vertical_instr('max', 32, lambda x: _min_max(x, signed=True))
 pmaxsw = vec_vertical_instr('max', 16, lambda x: _min_max(x, signed=True))
 
 # Floating-point arithmetic
@@ -5724,6 +5725,7 @@ mnemo_func = {'mov': mov,
               "pmaxub": pmaxub,
               "pmaxuw": pmaxuw,
               "pmaxud": pmaxud,
+              "pmaxsd": pmaxsd,
               "pmaxsw": pmaxsw,
 
               "pminub": pminub,

--- a/miasm/arch/x86/sem.py
+++ b/miasm/arch/x86/sem.py
@@ -4432,6 +4432,15 @@ def pshufhw(_, instr, dst, src, imm):
         out.append(src[shift + 64: shift + 16 + 64])
     return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out))], []
 
+def ptest(_, instr, dst, src):
+    e = []
+    e.append(m2_expr.ExprAssign(zf, m2_expr.ExprOp('FLAG_EQ', dst & src)))
+    e.append(m2_expr.ExprAssign(cf, m2_expr.ExprOp('FLAG_EQ', src & ~dst)))
+    e.append(m2_expr.ExprAssign(of, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(af, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(pf, m2_expr.ExprInt(0, 1)))
+    e.append(m2_expr.ExprAssign(nf, m2_expr.ExprInt(0, 1)))
+    return e, []
 
 def ps_rl_ll(ir, instr, dst, src, op, size):
     mask = {16: 0xF,
@@ -4918,7 +4927,21 @@ def _signed_to_unsigned_saturation(expr, dst_size):
         )
     )
 
+def phminposuw(ir, instr, dst, src):
+    if dst.size != 128 or src.size != 128:
+        raise RuntimeError("Unsupported size dst=%d src=%d" % (dst.size, src.size))
 
+    min_val = src[:16]
+    min_idx = m2_expr.ExprInt(0, 16)
+
+    for i in range(1, 8):
+        word = src[i * 16:(i + 1) * 16]
+        cond = m2_expr.expr_is_unsigned_lower(word, min_val)
+        min_val = m2_expr.ExprCond(cond, word, min_val)
+        min_idx = m2_expr.ExprCond(cond, m2_expr.ExprInt(i, 16), min_idx)
+
+    result = m2_expr.ExprCompose(min_val, min_idx, m2_expr.ExprInt(0, 96))
+    return [m2_expr.ExprAssign(dst, result)], []
 
 def packsswb(ir, instr, dst, src):
     out = []
@@ -5757,6 +5780,8 @@ mnemo_func = {'mov': mov,
               "sqrtss": sqrtss,
 
               "pmovmskb": pmovmskb,
+
+              "phminposuw": phminposuw,
 
               "packsswb": packsswb,
               "packssdw": packssdw,

--- a/miasm/arch/x86/sem.py
+++ b/miasm/arch/x86/sem.py
@@ -5702,6 +5702,7 @@ mnemo_func = {'mov': mov,
               "pshufd": pshufd,
               "pshuflw": pshuflw,
               "pshufhw": pshufhw,
+              "ptest": ptest,
 
               "psrlw": psrlw,
               "psrld": psrld,

--- a/miasm/arch/x86/sem.py
+++ b/miasm/arch/x86/sem.py
@@ -3895,6 +3895,21 @@ pmulhw = vec_vertical_instr('*', 16, lambda x: _keep_mul_high(x, signed=True))
 pmulhd = vec_vertical_instr('*', 32, lambda x: _keep_mul_high(x, signed=True))
 pmulhq = vec_vertical_instr('*', 64, lambda x: _keep_mul_high(x, signed=True))
 
+def pmuldq(ir, instr, dst, src):
+    e = []
+    if dst.size != 128:
+        raise RuntimeError("Unsupported size %d" % dst.size)
+
+    e.append(m2_expr.ExprAssign(
+        dst[:64],
+        src[:32].signExtend(64) * dst[:32].signExtend(64)
+    ))
+    e.append(m2_expr.ExprAssign(
+        dst[64:],
+        src[64:96].signExtend(64) * dst[64:96].signExtend(64)
+    ))
+    return e, []
+
 def pmuludq(ir, instr, dst, src):
     e = []
     if dst.size == 64:
@@ -5563,6 +5578,7 @@ mnemo_func = {'mov': mov,
               "pmulhw": pmulhw,
               "pmulhd": pmulhd,
               "pmulhq": pmulhq,
+              "pmuldq": pmuldq,
               "pmuludq": pmuludq,
 
               # Mix

--- a/miasm/arch/x86/sem.py
+++ b/miasm/arch/x86/sem.py
@@ -4805,6 +4805,36 @@ def palignr(ir, instr, dst, src, imm):
 
     return [m2_expr.ExprAssign(dst, result)], []
 
+def psign(ir, instr, dst, src, lane_size):
+    if dst.size not in [64, 128] or src.size != dst.size:
+        raise RuntimeError("Unsupported size dst=%d src=%d" % (dst.size, src.size))
+
+    out = []
+    for i in range(0, dst.size, lane_size):
+        data = dst[i:i + lane_size]
+        control = src[i:i + lane_size]
+        neg_data = (data ^ data.mask) + m2_expr.ExprInt(1, data.size)
+        out.append(
+            m2_expr.ExprCond(
+                control.msb(),
+                neg_data,
+                m2_expr.ExprCond(
+                    control,
+                    data,
+                    m2_expr.ExprInt(0, data.size)
+                )
+            )
+        )
+    return [m2_expr.ExprAssign(dst, m2_expr.ExprCompose(*out))], []
+
+def psignb(ir, instr, dst, src):
+    return psign(ir, instr, dst, src, 8)
+
+def psignw(ir, instr, dst, src):
+    return psign(ir, instr, dst, src, 16)
+
+def psignd(ir, instr, dst, src):
+    return psign(ir, instr, dst, src, 32)
 
 def _signed_to_signed_saturation(expr, dst_size):
     """Saturate the expr @expr for @dst_size bit
@@ -5646,6 +5676,10 @@ mnemo_func = {'mov': mov,
               "psrad": psrad,
 
               "palignr": palignr,
+
+              "psignb": psignb,
+              "psignw": psignw,
+              "psignd": psignd,
 
               "pmaxub": pmaxub,
               "pmaxuw": pmaxuw,


### PR DESCRIPTION
# x86 fix and enhancements

Hello, please find attached a pull request that fix an issue in arch (x86), and add new several instructions (disas and semantics).

## Fix

### PEXTRQ cannot disasm

Currently the instruction 'pextrq' fail to disassembly specific opcodes.

Here is a python script to show the issue :

```python
import miasm
from miasm.analysis.machine import Machine

checks = [
    # pextrq rbp, xmm0, 8
    (b"\x66\x48\x0F\x3A\x16\xC5\x08", "PEXTRQ RBP, XMM0, 0x8"),
    # pextrq r13, xmm0, 8   (REX.W + REX.B)
    (b"\x66\x49\x0F\x3A\x16\xC5\x08", "PEXTRQ R13, XMM0, 0x8"),
    # pextrq rcx, xmm8, 1   (REX.W + REX.R)
    (b"\x66\x4C\x0F\x3A\x16\xC1\x01", "PEXTRQ RCX, XMM8, 0x1"),
    # pextrq qword ptr [r13+10h], xmm0, 1
    (b"\x66\x49\x0F\x3A\x16\x45\x10\x01", "PEXTRQ QWORD PTR [R13 + 0x10], XMM0, 0x1"),
]

machine = Machine("x86_64")

for instr_bytes, expected in checks:
    try:
        instr = machine.mn.dis(instr_bytes, 64)
        got = " ".join(str(instr).split()).upper()
        exp = " ".join(str(expected).split()).upper()
        if got != exp:
            print("\033[91m[-] {:<30} -> expected : {} ; got : {}\033[0m".format(instr_bytes.hex(" "), exp, got))
        else:
            print("\033[92m[+] {:<30} -> {}\033[0m".format(instr_bytes.hex(" "),got))
    except miasm.core.utils.Disasm_Exception:
        print("\033[91m[-] {:<30} cannot be disassembled\033[0m".format(instr_bytes.hex(" ")))
```

And here is the result :

```console
$ python3 /tmp/miasm_test.py 
[-] 66 48 0f 3a 16 c5 08           cannot be disassembled
[-] 66 49 0f 3a 16 c5 08           cannot be disassembled
[-] 66 4c 0f 3a 16 c1 01           cannot be disassembled
[+] 66 49 0f 3a 16 45 10 01        -> PEXTRQ QWORD PTR [R13 + 0X10], XMM0, 0X1
```
https://github.com/cea-sec/miasm/blob/2a15c60712b326b541d42ac48f372f97023547e7/miasm/arch/x86/arch.py#L4570

The issue was that the ``addop`` was adding an uncecessary (second) ``bs_opmode64`` in the opcode stream.

From the previous example ``66 48 0f 3a 16 c5 08`` there is no extry byte between ``c5`` and ``08``.

The second issue is that the definition was using ``rm_arg_m64``, but this instruction can extract value from XMM register into GPR too, so the operand has been changed to ``rm_arg``.

## Enhancements

### PSIGN

This pull request adds the ability to disassemble ``PSIGNB`` / ``PSIGNW`` / ``PSIGND`` instructions and includes their semantics, the following tests were used to verify the disassembly :

```python
checks = [
    # psignb mm0, mm1
    (b"\x0F\x38\x08\xC1", "PSIGNB MM0, MM1"),
    # psignb xmm0, xmm1
    (b"\x66\x0F\x38\x08\xC1", "PSIGNB XMM0, XMM1"),
    # psignb mm0, qword ptr [r13 + 10h]
    (b"\x41\x0F\x38\x08\x45\x10", "PSIGNB MM0, QWORD PTR [R13 + 0x10]"),
    # psignb xmm0, xmmword ptr [r13 + 10h]
    (b"\x66\x41\x0F\x38\x08\x45\x10", "PSIGNB XMM0, XMMWORD PTR [R13 + 0x10]"),

    # psignw mm0, mm1
    (b"\x0F\x38\x09\xC1", "PSIGNW MM0, MM1"),
    # psignw xmm0, xmm1
    (b"\x66\x0F\x38\x09\xC1", "PSIGNW XMM0, XMM1"),
    # psignw xmm8, xmm1
    (b"\x66\x44\x0F\x38\x09\xC1", "PSIGNW XMM8, XMM1"),
    # psignw xmm0, xmm8
    (b"\x66\x41\x0F\x38\x09\xC0", "PSIGNW XMM0, XMM8"),
    # psignw mm0, qword ptr [r13 + 10h]
    (b"\x41\x0F\x38\x09\x45\x10", "PSIGNW MM0, QWORD PTR [R13 + 0x10]"),
    # psignw xmm0, xmmword ptr [r13 + 10h]
    (b"\x66\x41\x0F\x38\x09\x45\x10", "PSIGNW XMM0, XMMWORD PTR [R13 + 0x10]"),

    # psignd mm0, mm1
    (b"\x0F\x38\x0A\xC1", "PSIGND MM0, MM1"),
    # psignd xmm0, xmm1
    (b"\x66\x0F\x38\x0A\xC1", "PSIGND XMM0, XMM1"),
    # psignd xmm8, xmm1
    (b"\x66\x44\x0F\x38\x0A\xC1", "PSIGND XMM8, XMM1"),
    # psignd xmm0, xmm8
    (b"\x66\x41\x0F\x38\x0A\xC0", "PSIGND XMM0, XMM8"),
    # psignd mm0, qword ptr [r13 + 10h]
    (b"\x41\x0F\x38\x0A\x45\x10", "PSIGND MM0, QWORD PTR [R13 + 0x10]"),
    # psignd xmm0, xmmword ptr [r13 + 10h]
    (b"\x66\x41\x0F\x38\x0A\x45\x10", "PSIGND XMM0, XMMWORD PTR [R13 + 0x10]"),
]
```

### PMULDQ

This pull request adds the ability to disassemble ``PMULDQ`` instructions and includes its semantic, the following tests were used to verify the disassembly :


```python

checks = [
    # pmuldq xmm0, xmm1
    (b"\x66\x0F\x38\x28\xC1", "PMULDQ XMM0, XMM1"),
    # pmuldq xmm8, xmm1
    (b"\x66\x44\x0F\x38\x28\xC1", "PMULDQ XMM8, XMM1"),
    # pmuldq xmm0, xmm8
    (b"\x66\x41\x0F\x38\x28\xC0", "PMULDQ XMM0, XMM8"),
    # pmuldq xmm0, xmmword ptr [r13 + 0x10]
    (b"\x66\x41\x0F\x38\x28\x45\x10", "PMULDQ XMM0, XMMWORD PTR [R13 + 0x10]"),
    # pmuldq xmm8, xmmword ptr [r13 + 0x10]
    (b"\x66\x45\x0F\x38\x28\x45\x10", "PMULDQ XMM8, XMMWORD PTR [R13 + 0x10]"),
    # pmuldq xmm1, xmmword ptr [rip + 0x1234]
    (b"\x66\x0F\x38\x28\x0D\x34\x12\x00\x00", "PMULDQ XMM1, XMMWORD PTR [RIP + 0x1234]"),
]
```

### PMOVSX

This pull request adds the ability to disassemble ``PMOVSXWD`` / ``PMOVSXWQ`` / ``PMOVSXBD`` / ``PMOVSXDQ`` instructions and includes their semantics, the following tests were used to verify the disassembly :

```python

checks = [
    # pmovsxwd xmm0, xmm1
    (b"\x66\x0F\x38\x23\xC1", "PMOVSXWD XMM0, XMM1"),
    # pmovsxwd xmm8, xmm1
    (b"\x66\x44\x0F\x38\x23\xC1", "PMOVSXWD XMM8, XMM1"),
    # pmovsxwd xmm0, xmm8
    (b"\x66\x41\x0F\x38\x23\xC0", "PMOVSXWD XMM0, XMM8"), 
    # pmovsxwd xmm0, qword ptr [r13 + 0x10]
    (b"\x66\x41\x0F\x38\x23\x45\x10", "PMOVSXWD XMM0, QWORD PTR [R13 + 0x10]"),
    # pmovsxwd xmm8, qword ptr [r13 + 0x10]
    (b"\x66\x45\x0F\x38\x23\x45\x10", "PMOVSXWD XMM8, QWORD PTR [R13 + 0x10]"), 

    # pmovsxwq xmm0, xmm1
    (b"\x66\x0F\x38\x24\xC1", "PMOVSXWQ XMM0, XMM1"),
    # pmovsxwq xmm8, xmm1
    (b"\x66\x44\x0F\x38\x24\xC1", "PMOVSXWQ XMM8, XMM1"),
    # pmovsxwq xmm0, xmm8
    (b"\x66\x41\x0F\x38\x24\xC0", "PMOVSXWQ XMM0, XMM8"),
    # pmovsxwq xmm0, dword ptr [r13 + 0x10]
    (b"\x66\x41\x0F\x38\x24\x45\x10", "PMOVSXWQ XMM0, DWORD PTR [R13 + 0x10]"),
    # pmovsxwq xmm8, dword ptr [r13 + 0x10]
    (b"\x66\x45\x0F\x38\x24\x45\x10", "PMOVSXWQ XMM8, DWORD PTR [R13 + 0x10]"), 

    # pmovsxbd xmm0, xmm1
    (b"\x66\x0F\x38\x21\xC1", "PMOVSXBD XMM0, XMM1"),
    # pmovsxbd xmm8, xmm1
    (b"\x66\x44\x0F\x38\x21\xC1", "PMOVSXBD XMM8, XMM1"),
    # pmovsxbd xmm0, xmm8
    (b"\x66\x41\x0F\x38\x21\xC0", "PMOVSXBD XMM0, XMM8"), 
    # pmovsxbd xmm0, dword ptr [r13 + 0x10] 
    (b"\x66\x41\x0F\x38\x21\x45\x10", "PMOVSXBD XMM0, DWORD PTR [R13 + 0x10]"),
    # pmovsxbd xmm8, dword ptr [r13 + 0x10]
    (b"\x66\x45\x0F\x38\x21\x45\x10", "PMOVSXBD XMM8, DWORD PTR [R13 + 0x10]"), 

    # pmovsxdq xmm0, xmm1
    (b"\x66\x0F\x38\x25\xC1", "PMOVSXDQ XMM0, XMM1"),
    # pmovsxdq xmm8, xmm1
    (b"\x66\x44\x0F\x38\x25\xC1", "PMOVSXDQ XMM8, XMM1"),
    # pmovsxdq xmm0, xmm8
    (b"\x66\x41\x0F\x38\x25\xC0", "PMOVSXDQ XMM0, XMM8"),
    # pmovsxdq xmm0, qword ptr [r13 + 0x10]
    (b"\x66\x41\x0F\x38\x25\x45\x10", "PMOVSXDQ XMM0, QWORD PTR [R13 + 0x10]"),
    # pmovsxdq xmm8, qword ptr [r13 + 0x10]
    (b"\x66\x45\x0F\x38\x25\x45\x10", "PMOVSXDQ XMM8, QWORD PTR [R13 + 0x10]"),
]
```

### PMAXSD

This pull request adds the ability to disassemble ``PMAXSD`` instruction and includes its semantic, the following tests were used to verify the disassembly :

```python
checks = [
    # pmaxsd xmm0, xmm1
    (b"\x66\x0F\x38\x3D\xC1", "PMAXSD XMM0, XMM1"),
    # pmaxsd xmm8, xmm1
    (b"\x66\x44\x0F\x38\x3D\xC1", "PMAXSD XMM8, XMM1"),
    # pmaxsd xmm0, xmm8
    (b"\x66\x41\x0F\x38\x3D\xC0", "PMAXSD XMM0, XMM8"), 
    # pmaxsd xmm0, xmmword ptr [r13 + 0x10]
    (b"\x66\x41\x0F\x38\x3D\x45\x10", "PMAXSD XMM0, XMMWORD PTR [R13 + 0x10]"), 
    # pmaxsd xmm8, xmmword ptr [r13 + 0x10]
    (b"\x66\x45\x0F\x38\x3D\x45\x10", "PMAXSD XMM8, XMMWORD PTR [R13 + 0x10]"),
]
```

### PTEST

This pull request adds the ability to disassemble ``PTEST`` instruction and includes its semantic, the following tests were used to verify the disassembly :

```python

checks = [
    # ptest xmm0, xmm1
    (b"\x66\x0F\x38\x17\xC1", "PTEST XMM0, XMM1"),
    # ptest xmm8, xmm1
    (b"\x66\x44\x0F\x38\x17\xC1", "PTEST XMM8, XMM1"),
    # ptest xmm0, xmm8
    (b"\x66\x41\x0F\x38\x17\xC0", "PTEST XMM0, XMM8"),
    # ptest xmm0, xmmword ptr [r13 + 0x10]
    (b"\x66\x41\x0F\x38\x17\x45\x10", "PTEST XMM0, XMMWORD PTR [R13 + 0x10]"),
    # ptest xmm8, xmmword ptr [r13 + 0x10]
    (b"\x66\x45\x0F\x38\x17\x45\x10", "PTEST XMM8, XMMWORD PTR [R13 + 0x10]"),
    # ptest xmm1, xmmword ptr [rip + 0x1234]
    (b"\x66\x0F\x38\x17\x0D\x34\x12\x00\x00", "PTEST XMM1, XMMWORD PTR [RIP + 0x1234]"),
]
```

### PHMINPOSUW

This pull request adds the ability to disassemble ``PHMINPOSUW`` instruction and includes its semantic, the following tests were used to verify the disassembly :

```python

checks = [
    # phminposuw xmm0, xmm1
    (b"\x66\x0F\x38\x41\xC1", "PHMINPOSUW XMM0, XMM1"),
    # phminposuw xmm8, xmm1
    (b"\x66\x44\x0F\x38\x41\xC1", "PHMINPOSUW XMM8, XMM1"),
    # phminposuw xmm0, xmm8
    (b"\x66\x41\x0F\x38\x41\xC0", "PHMINPOSUW XMM0, XMM8"),
    # phminposuw xmm0, xmmword ptr [r13 + 0x10]
    (b"\x66\x41\x0F\x38\x41\x45\x10", "PHMINPOSUW XMM0, XMMWORD PTR [R13 + 0x10]"),
    # phminposuw xmm8, xmmword ptr [r13 + 0x10]
    (b"\x66\x45\x0F\x38\x41\x45\x10", "PHMINPOSUW XMM8, XMMWORD PTR [R13 + 0x10]"),
    # phminposuw xmm1, xmmword ptr [rip + 0x1234]
    (b"\x66\x0F\x38\x41\x0D\x34\x12\x00\x00", "PHMINPOSUW XMM1, XMMWORD PTR [RIP + 0x1234]"),
]
```

### PACKUSDW

This pull request adds the ability to disassemble ``PACKUSDW`` instruction and includes its semantic, the following tests were used to verify the disassembly :

```python

checks = [
    # packusdw xmm0, xmm1 
    (b"\x66\x0F\x38\x2B\xC1", "PACKUSDW XMM0, XMM1"),
    # packusdw xmm8, xmm1
    (b"\x66\x44\x0F\x38\x2B\xC1", "PACKUSDW XMM8, XMM1"),
    # packusdw xmm0, xmm8 
    (b"\x66\x41\x0F\x38\x2B\xC0", "PACKUSDW XMM0, XMM8"),
    # packusdw xmm0, xmmword ptr [r13 + 0x10]
    (b"\x66\x41\x0F\x38\x2B\x45\x10", "PACKUSDW XMM0, XMMWORD PTR [R13 + 0x10]"),
    # packusdw xmm8, xmmword ptr [r13 + 0x10] 
    (b"\x66\x45\x0F\x38\x2B\x45\x10", "PACKUSDW XMM8, XMMWORD PTR [R13 + 0x10]"),
]
```

### PCLMULQDQ

This pull request adds the ability to disassemble ``PCLMULQDQ`` instruction and includes its semantic, the following tests were used to verify the disassembly :

```python

checks = [
    # pclmulqdq xmm0, xmm1, 0x00
    (b"\x66\x0F\x3A\x44\xC1\x00", "PCLMULQDQ XMM0, XMM1, 0x0"),
    # pclmulqdq xmm0, xmm1, 0x01
    (b"\x66\x0F\x3A\x44\xC1\x01", "PCLMULQDQ XMM0, XMM1, 0x1"),
    # pclmulqdq xmm0, xmm1, 0x10
    (b"\x66\x0F\x3A\x44\xC1\x10", "PCLMULQDQ XMM0, XMM1, 0x10"),
    # pclmulqdq xmm0, xmm1, 0x11
    (b"\x66\x0F\x3A\x44\xC1\x11", "PCLMULQDQ XMM0, XMM1, 0x11"),
    # pclmulqdq xmm8, xmm1, 0x00
    (b"\x66\x44\x0F\x3A\x44\xC1\x00", "PCLMULQDQ XMM8, XMM1, 0x0"),
    # pclmulqdq xmm0, xmm8, 0x11
    (b"\x66\x41\x0F\x3A\x44\xC0\x11", "PCLMULQDQ XMM0, XMM8, 0x11"),
    # pclmulqdq xmm0, xmmword ptr [r13 + 0x10], 0x00
    (b"\x66\x41\x0F\x3A\x44\x45\x10\x00", "PCLMULQDQ XMM0, XMMWORD PTR [R13 + 0x10], 0x0"),
    # pclmulqdq xmm8, xmmword ptr [r13 + 0x10], 0x11
    (b"\x66\x45\x0F\x3A\x44\x45\x10\x11", "PCLMULQDQ XMM8, XMMWORD PTR [R13 + 0x10], 0x11"),
    # pclmulqdq xmm1, xmmword ptr [rip + 0x1234], 0x10
    (b"\x66\x0F\x3A\x44\x0D\x34\x12\x00\x00\x10", "PCLMULQDQ XMM1, XMMWORD PTR [RIP + 0x1234], 0x10"),
]
```

Let me know If I missed something.