### PR TITLE
arch/aarch64: fix operand order for RBIT/REV/REV16/REV32/CLZ/CLS

### DIFF
--- a/miasm/arch/aarch64/arch.py
+++ b/miasm/arch/aarch64/arch.py
@@ -2136,12 +2136,12 @@ datap0_name = {'RBIT': 0b000000, 'REV16': 0b000001,
               'REV': 0b000010,
               'CLZ': 0b000100, 'CLS': 0b000101}
 bs_datap0_name = bs_name(l=6, name=datap0_name)
-aarch64op("ldstp", [bs('0', fname='sf'), bs('1'), modf, bs('11010110'), bs('00000'), bs_datap0_name, rn, rd])
+aarch64op("ldstp", [bs('0', fname='sf'), bs('1'), modf, bs('11010110'), bs('00000'), bs_datap0_name, rn, rd], [rd, rn])
 datap1_name = {'RBIT': 0b000000, 'REV16': 0b000001,
                'REV32': 0b000010, 'REV': 0b000011,
               'CLZ': 0b000100, 'CLS': 0b000101}
 bs_datap1_name = bs_name(l=6, name=datap1_name)
-aarch64op("ldstp", [bs('1', fname='sf'), bs('1'), modf, bs('11010110'), bs('00000'), bs_datap1_name, rn, rd])
+aarch64op("ldstp", [bs('1', fname='sf'), bs('1'), modf, bs('11010110'), bs('00000'), bs_datap1_name, rn, rd], [rd, rn])
 
 
 # conditional branch p.132


### PR DESCRIPTION
The aarch64op definitions for the data-processing-1-source family at arch/aarch64/arch.py:2134,2145 omit the explicit operand-order list, so miasm falls back to encoding-field order (Rn, Rd) instead of canonical AArch64 syntax (Rd, Rn). This breaks both directions:

  >>> mn.dis(bytes.fromhex('0101c0da'), 'l')   # canonical: RBIT X1, X8
  RBIT X8, X1
  >>> mn.asm(mn.fromstring("RBIT X1, X8", LocationDB(), 'l'))[0].hex()
  '2800c0da'                                    # canonical: 0101c0da

Add `[rd, rn]` as the third arg to both aarch64op calls so disassembly and assembly match GAS / llvm-as / objdump / IDA, and so semantic engines receive the destination as instr.args[0].

Affects: RBIT, REV, REV16, REV32, CLZ, CLS — both 32-bit and 64-bit variants.

```py
"""Test cases for AArch64 data-processing-1-source mnemonics.

Run BEFORE the patch: every assertion fails — operands are swapped.
Run AFTER the patch ([rd, rn] added to aarch64op for these instructions):
all pass.

Each case is a (canonical-syntax, expected-LE-bytes) pair drawn from the
ARM Architecture Reference Manual encodings:
  RBIT  Xd, Xn         11011010 110 00000 000000 nnnnn ddddd
  REV   Xd, Xn         11011010 110 00000 000011 nnnnn ddddd
  REV16 Xd, Xn         11011010 110 00000 000001 nnnnn ddddd
  REV32 Xd, Xn         11011010 110 00000 000010 nnnnn ddddd
  CLZ   Xd, Xn         11011010 110 00000 000100 nnnnn ddddd
  CLS   Xd, Xn         11011010 110 00000 000101 nnnnn ddddd
"""
from miasm.analysis.machine import Machine
from miasm.core.locationdb import LocationDB

machine = Machine('aarch64l')
mn = machine.mn
loc_db = LocationDB()


CASES = [
    # (canonical syntax that GAS / llvm-as accepts, little-endian bytes)
    ("RBIT  X1, X8",  bytes.fromhex("0101c0da")),   # Rd=1 Rn=8
    ("REV   X3, X10", bytes.fromhex("430dc0da")),   # Rd=3 Rn=10  (datap1: opc=011)
    ("REV   X6, X7", bytes.fromhex("e60cc0da")),   # Rd=3 Rn=10  (datap1: opc=011)
    ("REV32 X5, X12", bytes.fromhex("8509c0da")),   # Rd=5 Rn=12  (datap1: opc=010)
    ("REV16 X7, X14", bytes.fromhex("c705c0da")),   # Rd=7 Rn=14
    ("CLZ   X9, X16", bytes.fromhex("0912c0da")),   # Rd=9 Rn=16
    ("CLS   X11, X18", bytes.fromhex("4b16c0da")),  # Rd=11 Rn=18
]


def report(case):
    text, raw = case
    instr = mn.dis(raw, 'l')
    miasm_text = str(instr).strip()
    miasm_args = [str(a) for a in instr.args]
    expected_dst, expected_src = [t.strip() for t in text.split(None, 1)[1].split(',')]
    actual_dst = miasm_args[0]
    ok = actual_dst == expected_dst
    return ok, text, miasm_text, miasm_args, raw.hex()


print(f"{'expected (canonical)':<22} {'miasm prints':<22} dst-OK")
print("-" * 60)
fail = 0
for c in CASES:
    ok, exp, got, args, raw = report(c)
    flag = "✓" if ok else "✗"
    print(f"{exp:<22} {got:<22} {flag}")
    if not ok:
        fail += 1

print()
if fail == 0:
    print("ALL PASS — bug appears to be fixed.")
else:
    print(f"{fail}/{len(CASES)} mnemonics print operands in wrong order.")
    print("Bug: arch.py:2142,2147 — `aarch64op(...)` is missing the `[rd, rn]`")
    print("operand-order list, so miasm falls back to encoding-field order")
    print("(rn, rd) which is opposite of canonical AArch64 (rd, rn).")
    
```